### PR TITLE
add option to zero out gas fees

### DIFF
--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -48,6 +48,7 @@ func NewEndorser(
 
 	evmConfig := &endorser.EVMConfig{
 		ChainConfig: common.BuildChainConfig(network.ChainID),
+		FreeGas:     true,
 	}
 
 	var builder endorsement.Builder

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -33,6 +33,8 @@ type EVMConfig struct {
 	BlockContext *vm.BlockContext
 	ChainConfig  *params.ChainConfig
 	VMConfig     *vm.Config
+	// FreeGas disables gas-fee balance enforcement.
+	FreeGas bool
 }
 
 // EVMEngine manages EVM execution and state reads for an endorser.
@@ -169,6 +171,7 @@ type executor struct {
 	chainCfg *params.ChainConfig
 	blockCtx vm.BlockContext
 	vmConfig vm.Config
+	freeGas  bool
 }
 
 // newExecutor creates an executor with the provided StateDB.
@@ -235,6 +238,7 @@ func newExecutor(stateDB *StateDB, blockInfo *utils.BlockInfo, evmConfig *EVMCon
 		chainCfg: ethChainConfig,
 		blockCtx: blockCtx,
 		vmConfig: vmConfig,
+		freeGas:  evmConfig != nil && evmConfig.FreeGas,
 	}
 }
 
@@ -364,6 +368,15 @@ func (h *executor) execute(msg *core.Message) ([]byte, error) {
 	// Default gas limit to 5_000_000 if not set
 	if msg.GasLimit == 0 {
 		msg.GasLimit = 5_000_000
+	}
+
+	// When FreeGas is enabled, zero out gas prices so buyGas never requires
+	// ETH balance from the sender. At the moment this is the default; we only
+	// charge gas in ethereum compatibility tests.
+	if h.freeGas {
+		msg.GasPrice = new(big.Int)
+		msg.GasFeeCap = new(big.Int)
+		msg.GasTipCap = new(big.Int)
 	}
 
 	// Create EVM instance with configured VMConfig

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -225,12 +225,12 @@ func (api *EthAPI) EstimateGas(ctx context.Context, args map[string]any, block *
 
 // eth_gasPrice
 func (api *EthAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
-	return (*hexutil.Big)(big.NewInt(1)), nil
+	return (*hexutil.Big)(big.NewInt(0)), nil
 }
 
 // eth_maxPriorityFeePerGas
 func (api *EthAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
-	return (*hexutil.Big)(big.NewInt(1)), nil
+	return (*hexutil.Big)(big.NewInt(0)), nil
 }
 
 // eth_feeHistory


### PR DESCRIPTION
Before this, the following command:

```
cast send --rpc-url http://localhost:8545 --chain-id 31337 --private-key $PRIVATE_KEY \
  --create "$(cat bin/GLDToken/GLDToken.bin)$(cast abi-encode 'constructor(uint256)' 1000000000000000000000  | sed 's/^0x//')"
```

Failed with:

```
Error: server returned an error response: error code -32000: process proposal: insufficient funds for gas * price + value: address 0xaFE0ef8c1c986b2dE97da30c1F4DA0E09733Cf5C have 0 want 5000000
```