### PR TITLE
change protoutil dependency from fabric to fabric-x-common

### DIFF
--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -16,12 +16,12 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	fabCommon "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser"
 	"github.com/hyperledger/fabric-x-evm/utils"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
-	"github.com/hyperledger/fabric/protoutil"
 )
 
 // Endorser interface defines the contract for endorsement providers.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-x-evm
 
-go 1.26
+go 1.26.2
 
 tool (
 	github.com/ethereum/go-ethereum/cmd/abigen
@@ -14,9 +14,9 @@ tool (
 require (
 	github.com/ethereum/go-ethereum v1.16.7
 	github.com/holiman/uint256 v1.3.2
-	github.com/hyperledger/fabric v1.4.0-rc1.0.20240918034325-94590aa4332b
 	github.com/hyperledger/fabric-lib-go v1.1.3
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
+	github.com/hyperledger/fabric-x-common v0.1.1-0.20260219094834-26c5a49ed548
 	github.com/hyperledger/fabric-x-sdk v0.0.0-20260415085836-ee298db39297
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
@@ -96,10 +96,10 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/hyperledger-labs/SmartBFT v0.0.0-20250503203013-eb005eef8866 // indirect
 	github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc // indirect
+	github.com/hyperledger/fabric v1.4.0-rc1.0.20240918034325-94590aa4332b // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 // indirect
 	github.com/hyperledger/fabric-x v0.0.14 // indirect
 	github.com/hyperledger/fabric-x-committer v0.1.9 // indirect
-	github.com/hyperledger/fabric-x-common v0.1.1-0.20260219094834-26c5a49ed548 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/influxdata/influxdb-client-go/v2 v2.4.0 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c // indirect

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/endorser"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage/trie"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
-	"github.com/hyperledger/fabric/protoutil"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/protobuf/proto"
 )

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser"
 	econf "github.com/hyperledger/fabric-x-evm/endorser/config"
@@ -50,7 +51,6 @@ import (
 	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
 	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
 	"github.com/hyperledger/fabric-x-sdk/state"
-	"github.com/hyperledger/fabric/protoutil"
 )
 
 type localSigner struct{}


### PR DESCRIPTION
The fabric dependency was old (v1.4.0) and unnecessary, because the code has been moved to fabric-x-common. It at least gets rid of some false positives in vulnerability scanners.