### PR TITLE
change default chain id to 4011 (0xF4B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ cast wallet new
 
 Follow instructions
 [here](https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc)
-to add a custom network with RPC URL http://localhost:8545 and chain id 31337.
+to add a custom network with RPC URL http://localhost:8545 and chain id 4011.
 
 > [!IMPORTANT]
 > If you have used the wallet before and start with a clean network, reset the
@@ -168,7 +168,7 @@ export METAMASK=0x123
 Deploy the smart contract and remember the address:
 
 ```shell
-export CONTRACT_ADDRESS=$(cast send --rpc-url http://localhost:8545 --chain-id 31337 --private-key $PRIVATE_KEY \
+export CONTRACT_ADDRESS=$(cast send --rpc-url http://localhost:8545 --chain-id 4011 --private-key $PRIVATE_KEY \
   --create "$(cat bin/GLDToken/GLDToken.bin)$(cast abi-encode 'constructor(uint256)' 1000000000000000000000 | sed 's/^0x//')" \
   | awk '/contractAddress/ {print $2}')
 ```
@@ -176,7 +176,7 @@ export CONTRACT_ADDRESS=$(cast send --rpc-url http://localhost:8545 --chain-id 3
 Transfer 100 tokens to the metamask wallet:
 
 ```shell
-cast send --rpc-url http://localhost:8545 --chain-id 31337 --private-key $PRIVATE_KEY $CONTRACT_ADDRESS "transfer(address,uint256)" $METAMASK "100000000000000000000"
+cast send --rpc-url http://localhost:8545 --chain-id 4011 --private-key $PRIVATE_KEY $CONTRACT_ADDRESS "transfer(address,uint256)" $METAMASK "100000000000000000000"
 ```
 
 Go to your browser and verify that you can see the tokens. Copy the address of

--- a/gateway/core/chain_test.go
+++ b/gateway/core/chain_test.go
@@ -24,7 +24,7 @@ import (
 func createTestEthTx(t *testing.T, key *ecdsa.PrivateKey, to common.Address, value *big.Int) *types.Transaction {
 	t.Helper()
 	tx := types.NewTransaction(0, to, value, 21000, big.NewInt(1000), []byte("test data"))
-	signer := types.NewEIP155Signer(big.NewInt(31337))
+	signer := types.NewEIP155Signer(big.NewInt(4011))
 	signed, err := types.SignTx(tx, signer, key)
 	require.NoError(t, err)
 	return signed
@@ -165,7 +165,7 @@ func TestConvertTransaction_ContractCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	ethTx := types.NewContractCreation(0, big.NewInt(0), 1000000, big.NewInt(1000), []byte("contract code"))
-	signer := types.NewEIP155Signer(big.NewInt(31337))
+	signer := types.NewEIP155Signer(big.NewInt(4011))
 	signed, err := types.SignTx(ethTx, signer, key)
 	require.NoError(t, err)
 	ethb, _ := signed.MarshalBinary()

--- a/gateway/testimpl/test_eth_api_test.go
+++ b/gateway/testimpl/test_eth_api_test.go
@@ -163,7 +163,7 @@ func (m *mockBackend) SendTransaction(_ context.Context, tx *types.Transaction) 
 }
 
 func (m *mockBackend) ChainID(_ context.Context) (*big.Int, error) {
-	return big.NewInt(31337), nil
+	return big.NewInt(4011), nil
 }
 
 func (m *mockBackend) NonceAt(_ context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {

--- a/integration/config.go
+++ b/integration/config.go
@@ -77,7 +77,7 @@ func FabricSamplesConfig(testdataDir string) config.Config {
 			Channel:   "mychannel",
 			Namespace: "basic",
 			NsVersion: "1.0",
-			ChainID:   31337,
+			ChainID:   4011,
 		},
 		Gateway: config.Gateway{
 			Orderers: []common.ClientConfig{{
@@ -161,7 +161,7 @@ func XTestCommitterConfig() config.Config {
 			Channel:   "mychannel",
 			Namespace: "basic",
 			NsVersion: "1.0",
-			ChainID:   31337,
+			ChainID:   4011,
 		},
 		Gateway: config.Gateway{
 			Orderers: []common.ClientConfig{{

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -362,7 +362,7 @@ func newLocalTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EVM
 			Channel:   "mychannel",
 			Namespace: "basic",
 			NsVersion: "1.0",
-			ChainID:   31337,
+			ChainID:   4011,
 		},
 		Gateway: config.Gateway{
 			DbConnStr:   filepath.Join(dir, tname+"gateway.db"),


### PR DESCRIPTION
This will be the Chain ID for local dev networks. The previous one was the Hardhat ChainID, which could clash with exisiting configurations in developer tooling.

Real deployments should choose and configure their own chain id.