### PR TITLE
integration: replace time.Sleep with WaitGroup in tether_token_parallel

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -11,8 +11,8 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/tests"
@@ -479,11 +479,11 @@ func testTetherTokenParallel(t *testing.T, th *TestHarness) {
 	//   User B: 130,000 USDT (-20,000)
 	//   User C:  30,000 USDT (+30,000)
 	//   User D:  20,000 USDT (+20,000)
-	go submit(t, node1, env1)
-	submit(t, node2, env2)
-
-	// ensure some slack for the background tx to be committed.
-	time.Sleep(200 * time.Millisecond)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); submit(t, node1, env1) }()
+	go func() { defer wg.Done(); submit(t, node2, env2) }()
+	wg.Wait()
 
 	toB = toB.Sub(toB, toBD)
 	toA = toA.Sub(toA, toAC)


### PR DESCRIPTION
Closes #77

## What's the problem?
`testTetherTokenParallel` used a `time.Sleep(200ms)` at the end to wait
for two fire-and-forget `go submit(...)` goroutines to finish. This is a
wall-clock guess  it can flake on slow machines or pass on fast ones
even if something is wrong.

## What's the fix?
Replaced the `go submit / submit / time.Sleep` block with a
`sync.WaitGroup`. Both submits now run as goroutines and the test blocks
on `wg.Wait()` until both are done. Since `submit` already polls
`TransactionByHash` via `waitForCommit`, the test ends deterministically
when both transactions are confirmed committed.

This removes the last remaining wall-clock wait in the integration tests,
finishing the cleanup started in PR #97 (which removed `SubmitWaitTime`).

## What changed?
- Dropped `time.Sleep(200 * time.Millisecond)` from `testTetherTokenParallel`
- Wrapped both `submit` calls in a `sync.WaitGroup`
- Imports: removed `"time"`, added `"sync"`
- No production code touched

## Test plan
- [x] `make checks`
- [x] `make unit-tests`
- [x] `make test-local`  all 7 subtests pass, including `tether_token_parallel`