### PR TITLE
add sleep to ensure endorsers are caught up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,13 @@ stop-fablo:
 
 .PHONY: test-fablo
 test-fablo:
-	@go test -timeout 360s -run ^TestFablo$$ ./integration
+	@go test -timeout 30s -run ^TestFablo$$ ./integration
 
 .PHONY: clean-fablo
 clean-fablo:
 	cd testdata/fablo && ./fablo prune || true
 	rm -rf testdata/fablo/snapshot.fablo.tar.gz
+
 .PHONY: test-local
 test-local:
 	@go test -timeout 30s -v -run ^TestLocal$$ ./integration

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -775,6 +775,12 @@ func waitForCommit(ctx context.Context, ec *ethclient.Client, tx *types.Transact
 		}
 	}
 
+	// Give the endorser synchronizers a moment to process the same block that the
+	// gateway sync just confirmed. The gateway sync and endorser syncs run
+	// independently; without this pause the next NonceAt or state query can read
+	// stale state from an endorser that hasn't applied the block yet.
+	time.Sleep(100 * time.Millisecond)
+
 	return nil
 }
 


### PR DESCRIPTION
As spotted by @Daniel-1600 , there is a flakiness issue in the tests. This PR gives the endorsers enough time to catch up.

https://github.com/hyperledger/fabric-x-evm/pull/109#issuecomment-4320625527