### PR TITLE
Verify pre-execution errors when running ethereum tests

### DIFF
--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -128,7 +128,7 @@ func (g *Gateway) processTx(ctx context.Context, tx *types.Transaction) error {
 // SendTransaction runs geth-style pre-flight validation, then enqueues the tx
 // for async endorse/submit. Mirrors eth_sendRawTransaction's failure model.
 func (g *Gateway) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	if err := validateTx(ctx, tx, g.chainConfig, g.signer, g); err != nil {
+	if err := ValidateTx(ctx, tx, g.chainConfig, g.signer, g); err != nil {
 		return err
 	}
 	g.txQueue.Enqueue(tx)

--- a/gateway/core/validate.go
+++ b/gateway/core/validate.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,15 +29,15 @@ var errUnprotectedTx = errors.New("only replay-protected (EIP-155) transactions 
 // txMaxSize redeclares the unexported core/txpool/legacypool constant (4 * 32 KiB).
 const txMaxSize = 4 * 32 * 1024
 
-const blockGasLimit uint64 = 30_000_000
+const blockGasLimit uint64 = math.MaxUint64
 
 const acceptedTxTypes = (1 << types.LegacyTxType) | (1 << types.AccessListTxType) | (1 << types.DynamicFeeTxType)
 
-// validateTx delegates stateless checks to geth's txpool.ValidateTransaction so
+// ValidateTx delegates stateless checks to geth's txpool.ValidateTransaction so
 // the failure model tracks upstream. The only stateful check is nonce-too-low,
 // inlined from txpool.ValidateTransactionWithState to avoid building a per-tx
 // StateDB. Deviations are documented in docs/COMPATIBILITY.md.
-func validateTx(
+func ValidateTx(
 	ctx context.Context,
 	tx *types.Transaction,
 	chainConfig *params.ChainConfig,

--- a/gateway/core/validate_test.go
+++ b/gateway/core/validate_test.go
@@ -81,7 +81,7 @@ func TestValidateTx_Valid(t *testing.T) {
 	tx := newValidTx(t, key, validTxOpts{nonce: 5})
 	state := &fakeState{nonce: 5}
 
-	require.NoError(t, validateTx(context.Background(), tx, cfg, signer, state))
+	require.NoError(t, ValidateTx(context.Background(), tx, cfg, signer, state))
 }
 
 func TestValidateTx_UnprotectedRejected(t *testing.T) {
@@ -93,7 +93,7 @@ func TestValidateTx_UnprotectedRejected(t *testing.T) {
 	tx, err := types.SignTx(raw, types.HomesteadSigner{}, key) // pre-EIP-155 → unprotected
 	require.NoError(t, err)
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, errUnprotectedTx)
 }
 
@@ -106,7 +106,7 @@ func TestValidateTx_ChainIDMismatch(t *testing.T) {
 	tx, err := types.SignTx(raw, types.NewEIP155Signer(big.NewInt(testChainID+1)), key)
 	require.NoError(t, err)
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, txpool.ErrInvalidSender)
 }
 
@@ -127,7 +127,7 @@ func TestValidateTx_TipAboveFeeCap(t *testing.T) {
 	tx, err := types.SignTx(raw, signer, key)
 	require.NoError(t, err)
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, ethcore.ErrTipAboveFeeCap)
 }
 
@@ -136,7 +136,7 @@ func TestValidateTx_IntrinsicGasTooLow(t *testing.T) {
 	cfg, signer := chainCtx(t)
 
 	tx := newValidTx(t, key, validTxOpts{gas: 20_000}) // below 21_000
-	err := validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err := ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, ethcore.ErrIntrinsicGas)
 }
 
@@ -147,7 +147,7 @@ func TestValidateTx_NonceTooLow(t *testing.T) {
 	tx := newValidTx(t, key, validTxOpts{nonce: 3})
 	state := &fakeState{nonce: 7}
 
-	err := validateTx(context.Background(), tx, cfg, signer, state)
+	err := ValidateTx(context.Background(), tx, cfg, signer, state)
 	require.ErrorIs(t, err, ethcore.ErrNonceTooLow)
 }
 
@@ -160,7 +160,7 @@ func TestValidateTx_InitCodeTooLarge(t *testing.T) {
 	tx, err := types.SignTx(raw, types.NewEIP155Signer(big.NewInt(testChainID)), key)
 	require.NoError(t, err)
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{nonce: 0})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{nonce: 0})
 	require.ErrorIs(t, err, ethcore.ErrMaxInitCodeSizeExceeded)
 }
 
@@ -183,7 +183,7 @@ func TestValidateTx_BlobTxTypeRejected(t *testing.T) {
 	tx, err := types.SignTx(raw, signer, key)
 	require.NoError(t, err)
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, ethcore.ErrTxTypeNotSupported)
 }
 
@@ -206,7 +206,7 @@ func TestValidateTx_NegativeValue(t *testing.T) {
 		t.Skip("signer rejects negative value at sign time:", err)
 	}
 
-	err = validateTx(context.Background(), tx, cfg, signer, &fakeState{})
+	err = ValidateTx(context.Background(), tx, cfg, signer, &fakeState{})
 	require.ErrorIs(t, err, txpool.ErrNegativeValue)
 }
 
@@ -218,6 +218,6 @@ func TestValidateTx_StateLookupErrorPropagates(t *testing.T) {
 	boom := errors.New("ledger unavailable")
 	state := &fakeState{nonceErr: boom}
 
-	err := validateTx(context.Background(), tx, cfg, signer, state)
+	err := ValidateTx(context.Background(), tx, cfg, signer, state)
 	require.ErrorIs(t, err, boom)
 }

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -8,9 +8,11 @@ package integration
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"io"
+	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -19,12 +21,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/endorser"
+	"github.com/hyperledger/fabric-x-evm/gateway/core"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage/trie"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
@@ -192,6 +196,15 @@ func runSingleEthereumTest(t *testing.T, stateTest *StateTest) {
 	}
 }
 
+type nonceReader struct {
+	db *state.StateDB
+}
+
+func (n *nonceReader) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	nonce := n.db.GetNonce(account)
+	return nonce, nil
+}
+
 // runEthereumTestConfig executes a specific test configuration
 func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubtest, snapshotter bool, scheme string) {
 	// Build block info from test environment
@@ -254,6 +267,9 @@ func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubt
 	}
 	defer th.Stop()
 
+	// run the tx through the pre-execution validation steps
+	preExecErr := core.ValidateTx(t.Context(), tx, config, signerForTx(tx), &nonceReader{th.endorsers[0].GetEthStateDB()})
+
 	// Execute transaction through gateway
 	env, execErr := th.Gateways[0].ExecuteEthTx(t.Context(), tx, blockInfo)
 
@@ -274,6 +290,15 @@ func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubt
 			}
 
 			actualRoot = root
+		}
+	}
+
+	if tx.Type() != types.BlobTxType && // our pre-execution validation doesn't support blob txes yet
+		tx.Protected() { // our pre-execution validation only support protected transactions
+
+		// err out if we got a pre-validation error which we wouldn't get again when endorsing
+		if preExecErr != nil && execErr == nil {
+			t.Fatalf("unexpected pre-validation error %q", preExecErr)
 		}
 	}
 


### PR DESCRIPTION
This PR asserts that pre-execution errors returned by the gateway are a subset of pre-execution errors returned by the endorser, for the types of transactions that the gateway validation logic accepts.

Whenever we run the ethereum tests, we first call the pre-execution validation in the gateway, and then submit the tx to the endorser. Both these steps can err out, but here we assert that

- if the gateway errs out, so will the endorser
   - there is an exception to this: the gateway currently only supports protected transactions and doesn't support blob transactions, and so in those cases it will err out, whereas the endorser will succeed
- if the endorser errs out, the gateway doesn't necessarily have to since it performs more checks (I verified in geth that `ApplyMessage` performs checks that the pre-mempool-enqueue doesn't