### PR TITLE
integration: add query_validation subtest

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math/big"
@@ -15,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/hyperledger/fabric-x-evm/endorser"
 	"github.com/hyperledger/fabric-x-evm/integration/contracts"
@@ -72,6 +75,11 @@ var cases = []testCase{
 	{
 		name:  "nonce_validation",
 		fn:    testNonceValidation,
+		nodes: 2,
+	},
+	{
+		name:  "query_validation",
+		fn:    testQueryValidation,
 		nodes: 2,
 	},
 }
@@ -767,5 +775,167 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 
 	if reserve0After.Cmp(reserve0) == 0 && reserve1After.Cmp(reserve1) == 0 {
 		t.Fatal("expected reserves to change after swap")
+	}
+}
+
+// testQueryValidation asserts every read endpoint returns coherent data after a deploy + call.
+func testQueryValidation(t *testing.T, th *TestHarness) {
+	node := th.Gateways[0]
+	ec, err := NewNativeEthClient(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counter, err := NewEthClient(contracts.CounterMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deployTx, contractAddr, err := counter.txForDeploy(t.Context(), node, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.SendTransaction(t.Context(), deployTx); err != nil {
+		t.Fatal(err)
+	}
+	waitForCommitT(t, ec, deployTx)
+
+	callTx, err := counter.TxForCall(t.Context(), node, &contractAddr, "increment", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ec.SendTransaction(t.Context(), callTx); err != nil {
+		t.Fatal(err)
+	}
+	waitForCommitT(t, ec, callTx)
+
+	sender := counter.Address()
+
+	cases := []struct {
+		name   string
+		tx     *types.Transaction
+		isCall bool
+	}{
+		{name: "deploy", tx: deployTx, isCall: false},
+		{name: "call", tx: callTx, isCall: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			domTx, isPending, err := node.TransactionByHash(t.Context(), c.tx.Hash())
+			if err != nil {
+				t.Fatalf("TransactionByHash: %v", err)
+			}
+			if domTx == nil {
+				t.Fatal("TransactionByHash returned nil for a committed tx")
+			}
+			// TODO: flip once #116 is fixed.
+			if isPending {
+				t.Errorf("expected isPending=false, got true")
+			}
+
+			if !bytes.Equal(domTx.TxHash, c.tx.Hash().Bytes()) {
+				t.Errorf("TxHash mismatch: got %x, want %x", domTx.TxHash, c.tx.Hash())
+			}
+			if !bytes.Equal(domTx.FromAddress, sender.Bytes()) {
+				t.Errorf("FromAddress mismatch: got %x, want %x", domTx.FromAddress, sender)
+			}
+			if domTx.Status != 1 {
+				t.Errorf("expected Status=1, got %d", domTx.Status)
+			}
+			if len(domTx.BlockHash) == 0 {
+				t.Error("BlockHash is empty")
+			}
+			if domTx.BlockNumber == 0 {
+				t.Error("BlockNumber is zero")
+			}
+			if len(domTx.RawTx) == 0 {
+				t.Fatal("RawTx is empty")
+			}
+
+			recovered := new(types.Transaction)
+			if err := recovered.UnmarshalBinary(domTx.RawTx); err != nil {
+				t.Fatalf("decode RawTx: %v", err)
+			}
+			if recovered.Hash() != c.tx.Hash() {
+				t.Errorf("recovered hash mismatch: got %s, want %s", recovered.Hash(), c.tx.Hash())
+			}
+			if recovered.Nonce() != c.tx.Nonce() {
+				t.Errorf("nonce mismatch: got %d, want %d", recovered.Nonce(), c.tx.Nonce())
+			}
+			if recovered.Gas() != c.tx.Gas() {
+				t.Errorf("gas mismatch: got %d, want %d", recovered.Gas(), c.tx.Gas())
+			}
+			if recovered.ChainId().Cmp(c.tx.ChainId()) != 0 {
+				t.Errorf("chainId mismatch: got %s, want %s", recovered.ChainId(), c.tx.ChainId())
+			}
+
+			if c.isCall {
+				if !bytes.Equal(domTx.ToAddress, contractAddr.Bytes()) {
+					t.Errorf("ToAddress mismatch: got %x, want %x", domTx.ToAddress, contractAddr)
+				}
+			} else {
+				expected := crypto.CreateAddress(sender, c.tx.Nonce())
+				if !bytes.Equal(domTx.ContractAddress, expected.Bytes()) {
+					t.Errorf("ContractAddress mismatch: got %x, want %x", domTx.ContractAddress, expected)
+				}
+				if expected != contractAddr {
+					t.Errorf("computed contract addr drifted from txForDeploy: got %s, want %s", expected, contractAddr)
+				}
+			}
+
+			byHashIdx, err := node.GetTransactionByBlockHashAndIndex(t.Context(), common.BytesToHash(domTx.BlockHash), domTx.TxIndex)
+			if err != nil {
+				t.Fatalf("GetTransactionByBlockHashAndIndex: %v", err)
+			}
+			if byHashIdx == nil || !bytes.Equal(byHashIdx.TxHash, domTx.TxHash) {
+				t.Errorf("by-(blockHash,index) lookup did not return the same tx")
+			}
+
+			byNumIdx, err := node.GetTransactionByBlockNumberAndIndex(t.Context(), domTx.BlockNumber, domTx.TxIndex)
+			if err != nil {
+				t.Fatalf("GetTransactionByBlockNumberAndIndex: %v", err)
+			}
+			if byNumIdx == nil || !bytes.Equal(byNumIdx.TxHash, domTx.TxHash) {
+				t.Errorf("by-(blockNumber,index) lookup did not return the same tx")
+			}
+
+			block, err := node.GetBlockByNumber(t.Context(), domTx.BlockNumber, true)
+			if err != nil {
+				t.Fatalf("GetBlockByNumber: %v", err)
+			}
+			if block == nil {
+				t.Fatal("GetBlockByNumber returned nil for a committed block")
+			}
+			if !bytes.Equal(block.BlockHash, domTx.BlockHash) {
+				t.Errorf("block hash mismatch: got %x, want %x", block.BlockHash, domTx.BlockHash)
+			}
+			if block.BlockNumber != domTx.BlockNumber {
+				t.Errorf("block number mismatch: got %d, want %d", block.BlockNumber, domTx.BlockNumber)
+			}
+			found := false
+			for _, btx := range block.Transactions {
+				if bytes.Equal(btx.TxHash, domTx.TxHash) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("tx %x not found in block.Transactions", domTx.TxHash)
+			}
+		})
+	}
+
+	var unknown common.Hash
+	unknown[0] = 0xde
+	domTx, isPending, err := node.TransactionByHash(t.Context(), unknown)
+	if err != nil {
+		t.Fatalf("TransactionByHash(unknown): %v", err)
+	}
+	if domTx != nil {
+		t.Errorf("expected nil for unknown hash, got %+v", domTx)
+	}
+	if isPending {
+		t.Error("expected isPending=false for unknown hash")
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -822,11 +823,11 @@ func testQueryValidation(t *testing.T, th *TestHarness) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			domTx, isPending, err := node.TransactionByHash(t.Context(), c.tx.Hash())
+			gotTx, isPending, err := ec.TransactionByHash(t.Context(), c.tx.Hash())
 			if err != nil {
 				t.Fatalf("TransactionByHash: %v", err)
 			}
-			if domTx == nil {
+			if gotTx == nil {
 				t.Fatal("TransactionByHash returned nil for a committed tx")
 			}
 			// TODO: flip once #116 is fixed.
@@ -834,106 +835,57 @@ func testQueryValidation(t *testing.T, th *TestHarness) {
 				t.Errorf("expected isPending=false, got true")
 			}
 
-			if !bytes.Equal(domTx.TxHash, c.tx.Hash().Bytes()) {
-				t.Errorf("TxHash mismatch: got %x, want %x", domTx.TxHash, c.tx.Hash())
+			gotJSON, err := gotTx.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON(got): %v", err)
 			}
-			if !bytes.Equal(domTx.FromAddress, sender.Bytes()) {
-				t.Errorf("FromAddress mismatch: got %x, want %x", domTx.FromAddress, sender)
+			wantJSON, err := c.tx.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON(want): %v", err)
 			}
-			if domTx.Status != 1 {
-				t.Errorf("expected Status=1, got %d", domTx.Status)
-			}
-			if len(domTx.BlockHash) == 0 {
-				t.Error("BlockHash is empty")
-			}
-			if domTx.BlockNumber == 0 {
-				t.Error("BlockNumber is zero")
-			}
-			if len(domTx.RawTx) == 0 {
-				t.Fatal("RawTx is empty")
+			if !bytes.Equal(gotJSON, wantJSON) {
+				t.Errorf("tx JSON mismatch:\n got:  %s\n want: %s", gotJSON, wantJSON)
 			}
 
-			recovered := new(types.Transaction)
-			if err := recovered.UnmarshalBinary(domTx.RawTx); err != nil {
-				t.Fatalf("decode RawTx: %v", err)
+			receipt, err := ec.TransactionReceipt(t.Context(), c.tx.Hash())
+			if err != nil {
+				t.Fatalf("TransactionReceipt: %v", err)
 			}
-			if recovered.Hash() != c.tx.Hash() {
-				t.Errorf("recovered hash mismatch: got %s, want %s", recovered.Hash(), c.tx.Hash())
-			}
-			if recovered.Nonce() != c.tx.Nonce() {
-				t.Errorf("nonce mismatch: got %d, want %d", recovered.Nonce(), c.tx.Nonce())
-			}
-			if recovered.Gas() != c.tx.Gas() {
-				t.Errorf("gas mismatch: got %d, want %d", recovered.Gas(), c.tx.Gas())
-			}
-			if recovered.ChainId().Cmp(c.tx.ChainId()) != 0 {
-				t.Errorf("chainId mismatch: got %s, want %s", recovered.ChainId(), c.tx.ChainId())
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				t.Errorf("expected receipt.Status=%d, got %d", types.ReceiptStatusSuccessful, receipt.Status)
 			}
 
-			if c.isCall {
-				if !bytes.Equal(domTx.ToAddress, contractAddr.Bytes()) {
-					t.Errorf("ToAddress mismatch: got %x, want %x", domTx.ToAddress, contractAddr)
-				}
-			} else {
+			if !c.isCall {
 				expected := crypto.CreateAddress(sender, c.tx.Nonce())
-				if !bytes.Equal(domTx.ContractAddress, expected.Bytes()) {
-					t.Errorf("ContractAddress mismatch: got %x, want %x", domTx.ContractAddress, expected)
+				if receipt.ContractAddress != expected {
+					t.Errorf("receipt.ContractAddress mismatch: got %s, want %s", receipt.ContractAddress, expected)
 				}
 				if expected != contractAddr {
 					t.Errorf("computed contract addr drifted from txForDeploy: got %s, want %s", expected, contractAddr)
 				}
 			}
 
-			byHashIdx, err := node.GetTransactionByBlockHashAndIndex(t.Context(), common.BytesToHash(domTx.BlockHash), domTx.TxIndex)
+			byHashIdx, err := ec.TransactionInBlock(t.Context(), receipt.BlockHash, receipt.TransactionIndex)
 			if err != nil {
-				t.Fatalf("GetTransactionByBlockHashAndIndex: %v", err)
+				t.Fatalf("TransactionInBlock: %v", err)
 			}
-			if byHashIdx == nil || !bytes.Equal(byHashIdx.TxHash, domTx.TxHash) {
+			if byHashIdx == nil || byHashIdx.Hash() != c.tx.Hash() {
 				t.Errorf("by-(blockHash,index) lookup did not return the same tx")
 			}
-
-			byNumIdx, err := node.GetTransactionByBlockNumberAndIndex(t.Context(), domTx.BlockNumber, domTx.TxIndex)
-			if err != nil {
-				t.Fatalf("GetTransactionByBlockNumberAndIndex: %v", err)
-			}
-			if byNumIdx == nil || !bytes.Equal(byNumIdx.TxHash, domTx.TxHash) {
-				t.Errorf("by-(blockNumber,index) lookup did not return the same tx")
-			}
-
-			block, err := node.GetBlockByNumber(t.Context(), domTx.BlockNumber, true)
-			if err != nil {
-				t.Fatalf("GetBlockByNumber: %v", err)
-			}
-			if block == nil {
-				t.Fatal("GetBlockByNumber returned nil for a committed block")
-			}
-			if !bytes.Equal(block.BlockHash, domTx.BlockHash) {
-				t.Errorf("block hash mismatch: got %x, want %x", block.BlockHash, domTx.BlockHash)
-			}
-			if block.BlockNumber != domTx.BlockNumber {
-				t.Errorf("block number mismatch: got %d, want %d", block.BlockNumber, domTx.BlockNumber)
-			}
-			found := false
-			for _, btx := range block.Transactions {
-				if bytes.Equal(btx.TxHash, domTx.TxHash) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("tx %x not found in block.Transactions", domTx.TxHash)
-			}
+			// TODO: add ec.BlockByHash / ec.BlockByNumber assertions once the gateway
+			// returns header fields (logsBloom, extraData) as 0x-prefixed hex — today
+			// they are bare strings and go-ethereum's RPC decoder rejects them.
 		})
 	}
 
 	var unknown common.Hash
 	unknown[0] = 0xde
-	domTx, isPending, err := node.TransactionByHash(t.Context(), unknown)
-	if err != nil {
+	gotTx, isPending, err := ec.TransactionByHash(t.Context(), unknown)
+	if err != nil && err != ethereum.NotFound {
 		t.Fatalf("TransactionByHash(unknown): %v", err)
 	}
-	if domTx != nil {
-		t.Errorf("expected nil for unknown hash, got %+v", domTx)
+	if gotTx != nil {
+		t.Errorf("expected nil for unknown hash, got %+v", gotTx)
 	}
 	if isPending {
 		t.Error("expected isPending=false for unknown hash")


### PR DESCRIPTION
 ## Summary
Add systematic test coverage for the gateway's JSON-RPC query surface via a dedicated integration subtest using the native go-ethereum `ethclient.Client`.

## Background
Issue #41 highlights missing direct coverage for read-side APIs. Current tests focus on submit-side behavior, while APIs like:
- `eth_getTransactionByHash`
- `eth_getTransactionReceipt`
- `eth_getTransactionByBlockHashAndIndex`
are only exercised indirectly and not explicitly validated.

## Changes

### integration/integration_test.go
- Added `testQueryValidation(t, th)` registered as `query_validation`
- Runs under `TestLocal`, `TestLocalX`, `TestFabric`, `TestFabricX`
- Uses native `*ethclient.Client` (`ec`) instead of internal APIs

## Test Coverage

Deploy + call (`Counter.increment`) validated after commit:

### TransactionByHash
- Returns tx with `isPending == false`
- Full equality via `MarshalJSON()` comparison

### TransactionReceipt
- `receipt.Status == types.ReceiptStatusSuccessful`
- Deploy: `receipt.ContractAddress == crypto.CreateAddress(from, nonce)`

### TransactionInBlock
- Matches original tx hash via `(blockHash, index)`

### Negative case
- Unknown hash → `(nil, false, ethereum.NotFound)`

## Note on #116

The behavior around `isPending` is intentionally unchanged in this PR.

A follow-up PR (#127) was opened to address #116, but it was closed based on maintainer guidance since it represents a later stage in a broader workflow requiring earlier phases to land first. The implementation will be revisited once those dependencies are in place.

This PR focuses only on adding test coverage and documents the current behavior (`isPending == false`) without modifying it.

## Known Limitations

- `ec.BlockByHash` / `ec.BlockByNumber` not asserted due to invalid hex encoding in gateway (`LogsBloom`, `ExtraData` not `0x`-prefixed). Tracked for a separate fix.
- Block validation is indirectly covered via receipt + `TransactionInBlock`.

## Test Plan
- [x] `make checks`
- [x] `make unit-tests`
- [x] `go test -run '^TestLocalX$/^query_validation$' ./integration -v`
- [x] `go test -run '^TestLocalX$' ./integration`

All passing.

Closes #41