### PR TITLE
gateway/api: resolving `BlockNumberOrHash` correctly and reject unknown block hashes. Closes #125

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ make unit-tests
 
 ## Integration tests
 
+Some integration tests rely on the `ethereum/tests` corpus vendored as a git
+submodule under `testdata/ethereum-tests`. Initialize it once before running
+those tests:
+
+```shell
+git submodule update --init --recursive
+```
+
 ### Local
 
 The simplest integration tests don't require a Fabric network, but still

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -128,7 +128,11 @@ func (api *EthAPI) GetBlockTransactionCountByNumber(ctx context.Context, num rpc
 
 // eth_getBalance
 func (api *EthAPI) GetBalance(ctx context.Context, address common.Address, block rpc.BlockNumberOrHash) (*hexutil.Big, error) {
-	b, err := api.b.BalanceAt(ctx, address, blockNumberOrHashToBlockNumber(block))
+	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, block)
+	if err != nil {
+		return nil, err
+	}
+	b, err := api.b.BalanceAt(ctx, address, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +141,11 @@ func (api *EthAPI) GetBalance(ctx context.Context, address common.Address, block
 
 // eth_getCode
 func (api *EthAPI) GetCode(ctx context.Context, addr common.Address, block rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	code, err := api.b.CodeAt(ctx, addr, blockNumberOrHashToBlockNumber(block))
+	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, block)
+	if err != nil {
+		return nil, err
+	}
+	code, err := api.b.CodeAt(ctx, addr, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +154,11 @@ func (api *EthAPI) GetCode(ctx context.Context, addr common.Address, block rpc.B
 
 // eth_getStorageAt
 func (api *EthAPI) GetStorageAt(ctx context.Context, addr common.Address, slot common.Hash, block rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	data, err := api.b.StorageAt(ctx, addr, slot, blockNumberOrHashToBlockNumber(block))
+	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, block)
+	if err != nil {
+		return nil, err
+	}
+	data, err := api.b.StorageAt(ctx, addr, slot, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +167,11 @@ func (api *EthAPI) GetStorageAt(ctx context.Context, addr common.Address, slot c
 
 // eth_getTransactionCount
 func (api *EthAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
-	nonce, err := api.b.NonceAt(ctx, address, blockNumberOrHashToBlockNumber(blockNrOrHash))
+	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := api.b.NonceAt(ctx, address, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +235,10 @@ func (api *EthAPI) Call(ctx context.Context, args map[string]any, block rpc.Bloc
 	if err != nil {
 		return nil, err
 	}
-	blockNum := blockNumberOrHashToBlockNumber(block)
+	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, block)
+	if err != nil {
+		return nil, err
+	}
 	return api.b.CallContract(ctx, callMsg, blockNum)
 }
 
@@ -413,13 +432,26 @@ func argsToCallMsg(args map[string]any) (ethereum.CallMsg, error) {
 	return msg, nil
 }
 
-// blockNumberOrHashToBlockNumber converts rpc.BlockNumberOrHash to *big.Int
-func blockNumberOrHashToBlockNumber(numOrHash rpc.BlockNumberOrHash) *big.Int {
+// blockNumberOrHashToBlockNumber converts rpc.BlockNumberOrHash to *big.Int.
+// If a block hash is provided, it resolves the hash to a block number.
+func (api *EthAPI) blockNumberOrHashToBlockNumber(ctx context.Context, numOrHash rpc.BlockNumberOrHash) (*big.Int, error) {
 	if num, ok := numOrHash.Number(); ok {
-		return rpcBlockNumberToBigInt(num)
+		return rpcBlockNumberToBigInt(num), nil
 	}
-	// TODO: For block hash, we now return nil (latest).
-	return nil
+
+	hash, ok := numOrHash.Hash()
+	if !ok {
+		return nil, nil
+	}
+
+	blk, err := api.b.GetBlockByHash(ctx, hash, false)
+	if err != nil {
+		return nil, err
+	}
+	if blk == nil {
+		return nil, nil
+	}
+	return new(big.Int).SetUint64(blk.BlockNumber), nil
 }
 
 // rpcBlockNumberToBigInt converts rpc.BlockNumber to *big.Int

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -29,6 +29,7 @@ type Backend interface {
 	// Blocks
 	GetBlockByNumber(ctx context.Context, num uint64, full bool) (*domain.Block, error)
 	GetBlockByHash(ctx context.Context, hash common.Hash, full bool) (*domain.Block, error)
+	BlockNumberByHash(ctx context.Context, hash common.Hash) (*uint64, error)
 	GetBlockTxCountByHash(ctx context.Context, hash common.Hash) (int64, error)
 	GetBlockTxCountByNumber(ctx context.Context, num uint64) (int64, error)
 
@@ -444,14 +445,14 @@ func (api *EthAPI) blockNumberOrHashToBlockNumber(ctx context.Context, numOrHash
 		return nil, nil
 	}
 
-	blk, err := api.b.GetBlockByHash(ctx, hash, false)
+	num, err := api.b.BlockNumberByHash(ctx, hash)
 	if err != nil {
 		return nil, err
 	}
-	if blk == nil {
+	if num == nil {
 		return nil, ethereum.NotFound
 	}
-	return new(big.Int).SetUint64(blk.BlockNumber), nil
+	return new(big.Int).SetUint64(*num), nil
 }
 
 // rpcBlockNumberToBigInt converts rpc.BlockNumber to *big.Int

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -449,7 +449,7 @@ func (api *EthAPI) blockNumberOrHashToBlockNumber(ctx context.Context, numOrHash
 		return nil, err
 	}
 	if blk == nil {
-		return nil, nil
+		return nil, ethereum.NotFound
 	}
 	return new(big.Int).SetUint64(blk.BlockNumber), nil
 }

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -243,6 +243,20 @@ func (s *stubBackend) GetBlockByHash(ctx context.Context, hash common.Hash, full
 	}
 	return s.blockByHash[hash], nil
 }
+func (s *stubBackend) BlockNumberByHash(ctx context.Context, hash common.Hash) (*uint64, error) {
+	if s.getBlockErr != nil {
+		return nil, s.getBlockErr
+	}
+	if s.blockByHash == nil {
+		return nil, nil
+	}
+	blk := s.blockByHash[hash]
+	if blk == nil {
+		return nil, nil
+	}
+	num := blk.BlockNumber
+	return &num, nil
+}
 func (s *stubBackend) GetBlockTxCountByHash(ctx context.Context, hash common.Hash) (int64, error) {
 	return 0, nil
 }
@@ -274,7 +288,9 @@ func (s *stubBackend) GetTransactionByBlockHashAndIndex(ctx context.Context, has
 func (s *stubBackend) GetTransactionByBlockNumberAndIndex(ctx context.Context, num uint64, idx int64) (*domain.Transaction, error) {
 	return nil, nil
 }
-func (s *stubBackend) GetLogs(ctx context.Context, query domain.LogFilter) ([]domain.Log, error) { return nil, nil }
+func (s *stubBackend) GetLogs(ctx context.Context, query domain.LogFilter) ([]domain.Log, error) {
+	return nil, nil
+}
 
 var (
 	_ Backend = (*stubBackend)(nil)

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -7,14 +7,18 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
 func TestRpcBlockNumberToBigInt(t *testing.T) {
@@ -70,6 +74,8 @@ func TestBlockNumberToUint64(t *testing.T) {
 }
 
 func TestBlockNumberOrHashToBlockNumber(t *testing.T) {
+	api := NewEthAPI(&stubBackend{})
+
 	tests := []struct {
 		name      string
 		numOrHash rpc.BlockNumberOrHash
@@ -84,7 +90,10 @@ func TestBlockNumberOrHashToBlockNumber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := blockNumberOrHashToBlockNumber(tt.numOrHash)
+			got, err := api.blockNumberOrHashToBlockNumber(context.Background(), tt.numOrHash)
+			if err != nil {
+				t.Fatalf("blockNumberOrHashToBlockNumber() error = %v", err)
+			}
 			if (got == nil) != (tt.want == nil) {
 				t.Errorf("blockNumberOrHashToBlockNumber() = %v, want %v", got, tt.want)
 				return
@@ -93,6 +102,48 @@ func TestBlockNumberOrHashToBlockNumber(t *testing.T) {
 				t.Errorf("blockNumberOrHashToBlockNumber() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBlockNumberOrHashToBlockNumber_Hash(t *testing.T) {
+	hash := common.HexToHash("0x1234")
+	api := NewEthAPI(&stubBackend{
+		blockByHash: map[common.Hash]*domain.Block{
+			hash: {BlockNumber: 42},
+		},
+	})
+
+	got, err := api.blockNumberOrHashToBlockNumber(context.Background(), rpc.BlockNumberOrHashWithHash(hash, false))
+	if err != nil {
+		t.Fatalf("blockNumberOrHashToBlockNumber() error = %v", err)
+	}
+	if got == nil || got.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("blockNumberOrHashToBlockNumber() = %v, want 42", got)
+	}
+}
+
+func TestBlockNumberOrHashToBlockNumber_HashNotFound(t *testing.T) {
+	hash := common.HexToHash("0xabcd")
+	api := NewEthAPI(&stubBackend{})
+
+	got, err := api.blockNumberOrHashToBlockNumber(context.Background(), rpc.BlockNumberOrHashWithHash(hash, false))
+	if err != nil {
+		t.Fatalf("blockNumberOrHashToBlockNumber() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("blockNumberOrHashToBlockNumber() = %v, want nil", got)
+	}
+}
+
+func TestBlockNumberOrHashToBlockNumber_HashError(t *testing.T) {
+	hash := common.HexToHash("0x9999")
+	api := NewEthAPI(&stubBackend{
+		getBlockErr: errors.New("boom"),
+	})
+
+	_, err := api.blockNumberOrHashToBlockNumber(context.Background(), rpc.BlockNumberOrHashWithHash(hash, false))
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 
@@ -173,3 +224,61 @@ func TestRPCReceiptMarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+type stubBackend struct {
+	blockByHash map[common.Hash]*domain.Block
+	getBlockErr error
+}
+
+func (s *stubBackend) ChainID(ctx context.Context) (*big.Int, error) { return big.NewInt(1), nil }
+func (s *stubBackend) BlockNumber(ctx context.Context) (uint64, error) {
+	return 0, nil
+}
+func (s *stubBackend) GetBlockByNumber(ctx context.Context, num uint64, full bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubBackend) GetBlockByHash(ctx context.Context, hash common.Hash, full bool) (*domain.Block, error) {
+	if s.getBlockErr != nil {
+		return nil, s.getBlockErr
+	}
+	if s.blockByHash == nil {
+		return nil, nil
+	}
+	return s.blockByHash[hash], nil
+}
+func (s *stubBackend) GetBlockTxCountByHash(ctx context.Context, hash common.Hash) (int64, error) {
+	return 0, nil
+}
+func (s *stubBackend) GetBlockTxCountByNumber(ctx context.Context, num uint64) (int64, error) {
+	return 0, nil
+}
+func (s *stubBackend) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+func (s *stubBackend) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubBackend) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubBackend) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
+func (s *stubBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error { return nil }
+func (s *stubBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubBackend) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, bool, error) {
+	return nil, false, nil
+}
+func (s *stubBackend) GetTransactionByBlockHashAndIndex(ctx context.Context, hash common.Hash, idx int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubBackend) GetTransactionByBlockNumberAndIndex(ctx context.Context, num uint64, idx int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubBackend) GetLogs(ctx context.Context, query domain.LogFilter) ([]domain.Log, error) { return nil, nil }
+
+var (
+	_ Backend = (*stubBackend)(nil)
+)

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -126,12 +126,9 @@ func TestBlockNumberOrHashToBlockNumber_HashNotFound(t *testing.T) {
 	hash := common.HexToHash("0xabcd")
 	api := NewEthAPI(&stubBackend{})
 
-	got, err := api.blockNumberOrHashToBlockNumber(context.Background(), rpc.BlockNumberOrHashWithHash(hash, false))
-	if err != nil {
-		t.Fatalf("blockNumberOrHashToBlockNumber() error = %v", err)
-	}
-	if got != nil {
-		t.Fatalf("blockNumberOrHashToBlockNumber() = %v, want nil", got)
+	_, err := api.blockNumberOrHashToBlockNumber(context.Background(), rpc.BlockNumberOrHashWithHash(hash, false))
+	if !errors.Is(err, ethereum.NotFound) {
+		t.Fatalf("blockNumberOrHashToBlockNumber() error = %v, want %v", err, ethereum.NotFound)
 	}
 }
 

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -53,6 +53,7 @@ type Gateway struct {
 
 type Store interface {
 	BlockNumber(ctx context.Context) (uint64, error)
+	BlockNumberByHash(ctx context.Context, hash []byte) (*uint64, error)
 	LatestBlock(ctx context.Context, full bool) (*domain.Block, error)
 	GetBlockByNumber(ctx context.Context, num uint64, full bool) (*domain.Block, error)
 	GetBlockByHash(ctx context.Context, hash []byte, full bool) (*domain.Block, error)
@@ -163,6 +164,11 @@ func (g *Gateway) ChainID(ctx context.Context) (*big.Int, error) {
 // BlockNumber is the current blockheight as observed by this gateway.
 func (g *Gateway) BlockNumber(ctx context.Context) (uint64, error) {
 	return g.store.BlockNumber(ctx)
+}
+
+// BlockNumberByHash resolves a block hash to a block number.
+func (g *Gateway) BlockNumberByHash(ctx context.Context, hash common.Hash) (*uint64, error) {
+	return g.store.BlockNumberByHash(ctx, hash.Bytes())
 }
 
 // GetBlockByNumber returns the block at the specified number.

--- a/gateway/storage/store.go
+++ b/gateway/storage/store.go
@@ -168,6 +168,19 @@ func (s *Store) BlockNumber(ctx context.Context) (uint64, error) {
 	return uint64(num), err
 }
 
+// BlockNumberByHash resolves a block hash to its block number.
+func (s *Store) BlockNumberByHash(ctx context.Context, blockHash []byte) (*uint64, error) {
+	num, err := s.queries.BlockNumberByHash(ctx, blockHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	res := uint64(num)
+	return &res, nil
+}
+
 // GetBlockByNumber retrieves a block by its number.
 // Always loads transactions so the API layer can return either hashes or full objects.
 func (s *Store) GetBlockByNumber(ctx context.Context, blockNumber uint64, full bool) (*domain.Block, error) {

--- a/gateway/storage/store_test.go
+++ b/gateway/storage/store_test.go
@@ -406,6 +406,32 @@ func TestBlockNumber(t *testing.T) {
 	}
 }
 
+func TestBlockNumberByHash(t *testing.T) {
+	store := setupTestDB(t)
+
+	blockHash := makeHash(0xBC)
+	insertTestBlock(t, store, 77, blockHash)
+
+	num, err := store.BlockNumberByHash(t.Context(), blockHash)
+	if err != nil {
+		t.Fatalf("BlockNumberByHash error: %v", err)
+	}
+	if num == nil {
+		t.Fatal("expected block number, got nil")
+	}
+	if *num != 77 {
+		t.Errorf("expected block number 77, got %d", *num)
+	}
+
+	missing, err := store.BlockNumberByHash(t.Context(), makeHash(0xFF))
+	if err != nil {
+		t.Fatalf("BlockNumberByHash (missing) error: %v", err)
+	}
+	if missing != nil {
+		t.Errorf("expected nil for missing hash, got %d", *missing)
+	}
+}
+
 func TestGetBlockByNumber(t *testing.T) {
 	store := setupTestDB(t)
 

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -119,10 +119,6 @@ func filterSlowTests(files []string, slow map[string]struct{}, want_very_slow bo
 //
 // This follows the same approach as Besu, Geth, and other Ethereum clients.
 func TestEthereumTests(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping ethereum/tests corpus in short mode")
-	}
-
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr)) // disable grpc logging
 
 	// Load slow
@@ -137,7 +133,7 @@ func TestEthereumTests(t *testing.T) {
 	// 1) GeneralStateTests
 	testsDir := filepath.Join("..", "testdata", "ethereum-tests", "GeneralStateTests")
 	if _, err := os.Stat(testsDir); os.IsNotExist(err) {
-		t.Skipf("ethereum/tests corpus not found at %s; run `git submodule update --init --recursive`", testsDir)
+		t.Fatalf("ethereum/tests corpus not found at %s; run `git submodule update --init --recursive`", testsDir)
 	}
 	allFiles, err := findJSONFiles(testsDir)
 	if err != nil {

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -119,6 +119,10 @@ func filterSlowTests(files []string, slow map[string]struct{}, want_very_slow bo
 //
 // This follows the same approach as Besu, Geth, and other Ethereum clients.
 func TestEthereumTests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ethereum/tests corpus in short mode")
+	}
+
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr)) // disable grpc logging
 
 	// Load slow
@@ -132,6 +136,9 @@ func TestEthereumTests(t *testing.T) {
 
 	// 1) GeneralStateTests
 	testsDir := filepath.Join("..", "testdata", "ethereum-tests", "GeneralStateTests")
+	if _, err := os.Stat(testsDir); os.IsNotExist(err) {
+		t.Skipf("ethereum/tests corpus not found at %s; run `git submodule update --init --recursive`", testsDir)
+	}
 	allFiles, err := findJSONFiles(testsDir)
 	if err != nil {
 		t.Fatalf("Failed to find test files: %v", err)

--- a/integration/state_test.go
+++ b/integration/state_test.go
@@ -21,6 +21,10 @@ import (
 // TestSingleAdd11 runs only the add11.json test from LegacyTests/Constantinople/GeneralStateTests/stExample
 // This test is ported from go-ethereum's tests/state_test.go
 func TestSingleAdd11(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ethereum state test in short mode")
+	}
+
 	// Adjust the path to point to the ethereum-tests directory in this repo
 	// Original path in go-ethereum: ./testdata/LegacyTests/Constantinople/GeneralStateTests/stExample/add11.json
 	// Path in this repo: ../testdata/ethereum-tests/LegacyTests/Constantinople/GeneralStateTests/stExample/add11.json
@@ -29,6 +33,9 @@ func TestSingleAdd11(t *testing.T) {
 	// Load the test file
 	file, err := os.Open(testPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("ethereum test file not found at %s; run `git submodule update --init --recursive`", testPath)
+		}
 		t.Fatal(err)
 	}
 	defer file.Close()

--- a/integration/state_test.go
+++ b/integration/state_test.go
@@ -21,10 +21,6 @@ import (
 // TestSingleAdd11 runs only the add11.json test from LegacyTests/Constantinople/GeneralStateTests/stExample
 // This test is ported from go-ethereum's tests/state_test.go
 func TestSingleAdd11(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping ethereum state test in short mode")
-	}
-
 	// Adjust the path to point to the ethereum-tests directory in this repo
 	// Original path in go-ethereum: ./testdata/LegacyTests/Constantinople/GeneralStateTests/stExample/add11.json
 	// Path in this repo: ../testdata/ethereum-tests/LegacyTests/Constantinople/GeneralStateTests/stExample/add11.json
@@ -34,7 +30,7 @@ func TestSingleAdd11(t *testing.T) {
 	file, err := os.Open(testPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			t.Skipf("ethereum test file not found at %s; run `git submodule update --init --recursive`", testPath)
+			t.Fatalf("ethereum test file not found at %s; run `git submodule update --init --recursive`", testPath)
 		}
 		t.Fatal(err)
 	}


### PR DESCRIPTION

## Summary
This PR fixes state-query block selection in the Ethereum RPC API. Closes #125 
Previously, when callers provided a `blockHash` (via `BlockNumberOrHash`), the API could silently fall back to latest state.  
Now, hash-based queries are resolved through `GetBlockByHash`, and unknown hashes return `NotFound` instead of reading latest state.

## Testing
- Ran with local Go 1.26.2 toolchain:
  - `toolchains/go1.26.2/bin/go test ./gateway/api`
- Result: `ok github.com/hyperledger/fabric-x-evm/gateway/api`
