### PR TITLE
gateway: track pending txs so TransactionByHash returns isPending correctly

### DIFF
--- a/gateway/api/models.go
+++ b/gateway/api/models.go
@@ -160,17 +160,21 @@ func rpcTransaction(tx *domain.Transaction) *RPCTransaction {
 		return nil
 	}
 
-	blockHash := common.Hash(tx.BlockHash)
-	blockNumber := hexutil.Big(*big.NewInt(int64(tx.BlockNumber)))
-	txIndex := hexutil.Uint64(tx.TxIndex)
-
-	return &RPCTransaction{
-		tx:               ethTx,
-		From:             common.BytesToAddress(tx.FromAddress),
-		BlockHash:        &blockHash,
-		BlockNumber:      &blockNumber,
-		TransactionIndex: &txIndex,
+	out := &RPCTransaction{
+		tx:   ethTx,
+		From: common.BytesToAddress(tx.FromAddress),
 	}
+	// Pending txs (no committed block yet) leave block metadata nil so eth
+	// clients see isPending=true.
+	if len(tx.BlockHash) == common.HashLength {
+		blockHash := common.Hash(tx.BlockHash)
+		blockNumber := hexutil.Big(*big.NewInt(int64(tx.BlockNumber)))
+		txIndex := hexutil.Uint64(tx.TxIndex)
+		out.BlockHash = &blockHash
+		out.BlockNumber = &blockNumber
+		out.TransactionIndex = &txIndex
+	}
+	return out
 }
 
 // rpcBlock returns a block in the form the RPC API can return. Some values are mocked.

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	cmn "github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
@@ -46,9 +47,16 @@ type Gateway struct {
 	chainConfig *params.ChainConfig
 	signer      types.Signer
 	txQueue     *TxQueue
+	pendingTxs  sync.Map // common.Hash -> pendingTx
 	workerCount int
 	wg          sync.WaitGroup
 	stopOnce    sync.Once
+}
+
+// pendingTx is the data we keep about a tx accepted by SendTransaction but not yet committed.
+type pendingTx struct {
+	tx   *types.Transaction
+	from common.Address
 }
 
 type Store interface {
@@ -131,6 +139,11 @@ func (g *Gateway) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	if err := ValidateTx(ctx, tx, g.chainConfig, g.signer, g); err != nil {
 		return err
 	}
+	from, err := types.Sender(g.signer, tx)
+	if err != nil {
+		return err
+	}
+	g.pendingTxs.Store(tx.Hash(), pendingTx{tx: tx, from: from})
 	g.txQueue.Enqueue(tx)
 	return nil
 }
@@ -246,25 +259,48 @@ func (g *Gateway) NonceAt(ctx context.Context, account common.Address, blockNumb
 
 // Transactions
 
-// TransactionByHash retrieves a past transaction data from local storage, reconstructs a Transaction object and returns it.
-// We always return false for "is pending".
+// TransactionByHash returns isPending=true for a tx that was accepted by
+// SendTransaction but is not yet visible in a committed block, and
+// isPending=false once the local store has indexed it.
 func (g *Gateway) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, bool, error) {
 	tx, err := g.store.GetTransactionByHash(ctx, hash.Bytes())
 	if err != nil {
 		return nil, false, err
 	}
-	if tx == nil {
-		return nil, false, nil
+	if tx != nil {
+		// Lazy cleanup so the pending map doesn't grow forever.
+		g.pendingTxs.Delete(hash)
+
+		logs, err := g.store.GetLogsByTxHash(ctx, hash.Bytes())
+		if err != nil {
+			return nil, false, err
+		}
+		tx.Logs = logs
+		return tx, false, nil
 	}
 
-	// Fetch logs for the transaction (needed for receipts)
-	logs, err := g.store.GetLogsByTxHash(ctx, hash.Bytes())
-	if err != nil {
-		return nil, false, err
+	if v, ok := g.pendingTxs.Load(hash); ok {
+		p := v.(pendingTx)
+		return pendingDomainTx(p.tx, p.from), true, nil
 	}
-	tx.Logs = logs
+	return nil, false, nil
+}
 
-	return tx, false, nil
+// pendingDomainTx synthesises a domain.Transaction for a queued-but-uncommitted
+// tx. Block-context fields (BlockHash/Number, TxIndex, Status, Logs) are zero.
+func pendingDomainTx(tx *types.Transaction, from common.Address) *domain.Transaction {
+	raw, _ := tx.MarshalBinary()
+	d := &domain.Transaction{
+		TxHash:      tx.Hash().Bytes(),
+		RawTx:       raw,
+		FromAddress: from.Bytes(),
+	}
+	if to := tx.To(); to != nil {
+		d.ToAddress = to.Bytes()
+	} else {
+		d.ContractAddress = crypto.CreateAddress(from, tx.Nonce()).Bytes()
+	}
+	return d
 }
 
 // GetTransactionByBlockHashAndIndex retrieves a transaction based on block hash in the transaction index in that block.

--- a/gateway/core/api_test.go
+++ b/gateway/core/api_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+	"github.com/stretchr/testify/require"
+)
+
+// stubStore is a Store with overridable lookups; everything else is a no-op.
+type stubStore struct {
+	getTxFn   func(ctx context.Context, hash []byte) (*domain.Transaction, error)
+	getLogsFn func(ctx context.Context, txHash []byte) ([]domain.Log, error)
+}
+
+func (s *stubStore) BlockNumber(context.Context) (uint64, error)              { return 0, nil }
+func (s *stubStore) LatestBlock(context.Context, bool) (*domain.Block, error) { return nil, nil }
+func (s *stubStore) GetBlockByNumber(context.Context, uint64, bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubStore) GetBlockByHash(context.Context, []byte, bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubStore) GetBlockTxCountByHash(context.Context, []byte) (int64, error)   { return 0, nil }
+func (s *stubStore) GetBlockTxCountByNumber(context.Context, uint64) (int64, error) { return 0, nil }
+func (s *stubStore) GetTransactionByHash(ctx context.Context, hash []byte) (*domain.Transaction, error) {
+	if s.getTxFn != nil {
+		return s.getTxFn(ctx, hash)
+	}
+	return nil, nil
+}
+func (s *stubStore) GetTransactionByBlockHashAndIndex(context.Context, []byte, int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubStore) GetTransactionByBlockNumberAndIndex(context.Context, uint64, int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubStore) GetLogs(context.Context, domain.LogFilter) ([]domain.Log, error) { return nil, nil }
+func (s *stubStore) GetLogsByTxHash(ctx context.Context, txHash []byte) ([]domain.Log, error) {
+	if s.getLogsFn != nil {
+		return s.getLogsFn(ctx, txHash)
+	}
+	return nil, nil
+}
+
+func newTestGateway(t *testing.T, store Store) *Gateway {
+	t.Helper()
+	gw, err := New(nil, nil, store, testChainID, 1)
+	require.NoError(t, err)
+	return gw
+}
+
+func signedTx(t *testing.T, key *ecdsa.PrivateKey, to *common.Address) *types.Transaction {
+	t.Helper()
+	var inner *types.LegacyTx
+	if to != nil {
+		inner = &types.LegacyTx{Nonce: 7, To: to, Gas: 21_000, GasPrice: big.NewInt(1), Value: big.NewInt(0)}
+	} else {
+		inner = &types.LegacyTx{Nonce: 7, Gas: 60_000, GasPrice: big.NewInt(1), Data: []byte{0x60}}
+	}
+	signed, err := types.SignTx(types.NewTx(inner), types.NewEIP155Signer(big.NewInt(testChainID)), key)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestTransactionByHash_PendingThenCommitted(t *testing.T) {
+	store := &stubStore{}
+	gw := newTestGateway(t, store)
+
+	key := newKey(t)
+	to := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	tx := signedTx(t, key, &to)
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	gw.pendingTxs.Store(tx.Hash(), pendingTx{tx: tx, from: from})
+
+	domTx, isPending, err := gw.TransactionByHash(context.Background(), tx.Hash())
+	require.NoError(t, err)
+	require.True(t, isPending)
+	require.NotNil(t, domTx)
+	require.Equal(t, tx.Hash().Bytes(), domTx.TxHash)
+	require.Equal(t, from.Bytes(), domTx.FromAddress)
+	require.Equal(t, to.Bytes(), domTx.ToAddress)
+	require.NotEmpty(t, domTx.RawTx)
+
+	// Simulate commit: store now returns the tx → isPending must flip and the
+	// pending entry must be cleaned up.
+	committed := &domain.Transaction{
+		TxHash:      tx.Hash().Bytes(),
+		BlockNumber: 42,
+		BlockHash:   []byte("block-hash"),
+		Status:      1,
+		FromAddress: from.Bytes(),
+		ToAddress:   to.Bytes(),
+	}
+	store.getTxFn = func(_ context.Context, _ []byte) (*domain.Transaction, error) {
+		return committed, nil
+	}
+
+	domTx, isPending, err = gw.TransactionByHash(context.Background(), tx.Hash())
+	require.NoError(t, err)
+	require.False(t, isPending)
+	require.Equal(t, committed, domTx)
+
+	_, stillPending := gw.pendingTxs.Load(tx.Hash())
+	require.False(t, stillPending, "pending entry should be cleared once committed")
+}
+
+func TestTransactionByHash_DeployPending(t *testing.T) {
+	gw := newTestGateway(t, &stubStore{})
+
+	key := newKey(t)
+	tx := signedTx(t, key, nil) // deploy
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	gw.pendingTxs.Store(tx.Hash(), pendingTx{tx: tx, from: from})
+
+	domTx, isPending, err := gw.TransactionByHash(context.Background(), tx.Hash())
+	require.NoError(t, err)
+	require.True(t, isPending)
+	require.NotNil(t, domTx)
+	require.Empty(t, domTx.ToAddress)
+	require.Equal(t, crypto.CreateAddress(from, tx.Nonce()).Bytes(), domTx.ContractAddress)
+}
+
+func TestTransactionByHash_Unknown(t *testing.T) {
+	gw := newTestGateway(t, &stubStore{})
+
+	domTx, isPending, err := gw.TransactionByHash(context.Background(), common.Hash{0xde, 0xad})
+	require.NoError(t, err)
+	require.Nil(t, domTx)
+	require.False(t, isPending)
+}


### PR DESCRIPTION
## Summary

Fix `Gateway.TransactionByHash` to correctly report pending transactions via the `isPending` flag, aligning with geth’s API behavior.

---

## Background

`Gateway.TransactionByHash` always returned `false` for `isPending`, regardless of whether a transaction was:

- pending (submitted but not yet committed)
- committed
- unknown

This breaks geth compatibility and clients relying on:
- `isPending`
- or `BlockNumber == nil` (ethclient heuristic)

---

## Changes

### `gateway/core/api.go`

- Added `pendingTxs sync.Map` keyed by `common.Hash`
  - Stores `pendingTx{tx, from}` to avoid repeated sender recovery

- Updated `SendTransaction`:
  - Stores `(tx.Hash(), pendingTx{tx, from})` after validation and before enqueue

- Updated `TransactionByHash` logic:
  - If found in store:
    - delete pending entry (lazy cleanup)
    - return `(tx, false, nil)`
  - If not in store but in `pendingTxs`:
    - return synthesized tx via `pendingDomainTx`
    - return `(tx, true, nil)`
  - Otherwise:
    - return `(nil, false, nil)`

- Added `pendingDomainTx`:
  - Populates:
    - `TxHash`, `FromAddress`, `RawTx`
    - `ToAddress` (calls)
    - or `ContractAddress = crypto.CreateAddress(from, nonce)` (deploys)
  - Leaves block fields empty → signals pending state

---

### `gateway/api/models.go`

- Fixed panic in `rpcTransaction`:
  - `common.Hash(tx.BlockHash)` could panic for empty hash (pending tx)
- Now guarded:
  - `BlockHash`, `BlockNumber`, `TransactionIndex` remain `nil` for pending txs
- Aligns with geth behavior (`BlockNumber == nil` → `isPending=true`)

---

### `gateway/core/api_test.go` (new)

Added unit tests using a stub store:

- `TestTransactionByHash_PendingThenCommitted`
  - Validates transition from pending → committed
  - Ensures pending entry cleanup

- `TestTransactionByHash_DeployPending`
  - Verifies deploy tx returns correct `ContractAddress`

- `TestTransactionByHash_Unknown`
  - Returns `(nil, false, nil)` for unknown hash

---

## Cleanup Behavior

- Pending entries are removed lazily when:
  - transaction is found in store via `TransactionByHash`
- Unqueried txs remain in memory

This matches typical client behavior (they query shortly after submission).  
More aggressive cleanup (TTL or block hook) can be added later if needed.

---

## Test Plan

- [x] `make checks`
- [x] `make unit-tests`
- [x] `go test -run '^TestLocalX$' ./integration -v`
- [x] `go test -run TestTransactionByHash ./gateway/core -v`

All tests passing.

---

Closes #116