### PR TITLE
gateway/api: encode logsBloom and extraData as hexutil.Bytes (compliant block JSON)

### DIFF
--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -219,6 +220,44 @@ func TestRPCReceiptMarshalJSON(t *testing.T) {
 			tt.checkTo(t, m)
 			tt.checkFields(t, m)
 		})
+	}
+}
+
+func TestRPCBlockMarshalJSON(t *testing.T) {
+	b := &domain.Block{
+		BlockNumber: 7,
+		BlockHash:   common.HexToHash("0xaa").Bytes(),
+		ParentHash:  common.HexToHash("0xbb").Bytes(),
+		StateRoot:   common.HexToHash("0xcc").Bytes(),
+		Timestamp:   1700000000,
+	}
+
+	data, err := json.Marshal(rpcBlock(b, false))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	bloom, ok := m["logsBloom"].(string)
+	if !ok {
+		t.Fatalf("logsBloom missing or not a string: %v", m["logsBloom"])
+	}
+	// Empty bloom is 256 bytes of zeros, hex-encoded as 0x + 512 zero chars.
+	wantBloom := "0x" + strings.Repeat("0", 512)
+	if bloom != wantBloom {
+		t.Errorf("logsBloom = %q, want %q", bloom, wantBloom)
+	}
+
+	extra, ok := m["extraData"].(string)
+	if !ok {
+		t.Fatalf("extraData missing or not a string: %v", m["extraData"])
+	}
+	if extra != "0x" {
+		t.Errorf("extraData = %q, want %q", extra, "0x")
 	}
 }
 

--- a/gateway/api/models.go
+++ b/gateway/api/models.go
@@ -9,7 +9,6 @@ package api
 import (
 	"encoding/json"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -131,14 +130,14 @@ type RPCBlock struct {
 	Hash             common.Hash    `json:"hash"`
 	ParentHash       common.Hash    `json:"parentHash"`
 	Sha3Uncles       common.Hash    `json:"sha3Uncles"`
-	LogsBloom        string         `json:"logsBloom"`
+	LogsBloom        hexutil.Bytes  `json:"logsBloom"`
 	TransactionsRoot common.Hash    `json:"transactionsRoot"`
 	StateRoot        common.Hash    `json:"stateRoot"`
 	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
 	Miner            common.Address `json:"miner"`
 	Difficulty       hexutil.Big    `json:"difficulty"`
 	TotalDifficulty  hexutil.Big    `json:"totalDifficulty"`
-	ExtraData        string         `json:"extraData"`
+	ExtraData        hexutil.Bytes  `json:"extraData"`
 	Size             hexutil.Uint64 `json:"size"`
 	GasLimit         hexutil.Uint64 `json:"gasLimit"`
 	GasUsed          hexutil.Uint64 `json:"gasUsed"`
@@ -220,14 +219,14 @@ func rpcBlock(b *domain.Block, full bool) *RPCBlock {
 		Hash:             (common.Hash)(b.BlockHash),
 		ParentHash:       (common.Hash)(b.ParentHash),
 		Sha3Uncles:       common.Hash{},
-		LogsBloom:        "" + strings.Repeat("0", 512),
+		LogsBloom:        make(hexutil.Bytes, types.BloomByteLength),
 		TransactionsRoot: common.Hash{},
 		StateRoot:        common.BytesToHash(b.StateRoot),
 		ReceiptsRoot:     common.Hash{},
 		Miner:            common.Address{}, // b.Miner
 		Difficulty:       hexutil.Big(*big.NewInt(0)),
 		TotalDifficulty:  hexutil.Big(*big.NewInt(0)),
-		ExtraData:        "",
+		ExtraData:        hexutil.Bytes{},
 		Size:             0,
 		GasLimit:         hexutil.Uint64(0),
 		GasUsed:          hexutil.Uint64(0),


### PR DESCRIPTION
## Summary
Fix `eth_getBlockByHash` / `eth_getBlockByNumber` JSON encoding so responses can be decoded by standard Ethereum clients (`ethclient`, `ethers.js`, `web3.py`, MetaMask, Blockscout, etc.).

Closes #138.

## Background
While validating query APIs in #122, `ethclient.BlockByHash` failed with:

```
hex string without 0x prefix
```

Root cause: `RPCBlock` (`gateway/api/models.go`) serialized:
- `LogsBloom` as `"000...000"` (no `0x`)
- `ExtraData` as `""`

go-ethereum requires `0x`-prefixed hex for all fields, so header decoding failed.

## Changes

### gateway/api/models.go
- Switched:
  - `LogsBloom` → `hexutil.Bytes`
  - `ExtraData` → `hexutil.Bytes`

- Updated constructor:
```go
LogsBloom: make(hexutil.Bytes, types.BloomByteLength),
ExtraData: hexutil.Bytes{},
```

- Removed `strings` import

Result:
- `logsBloom`: `"0x00...00"` (256 bytes)
- `extraData`: `"0x"`

Uses `types.BloomByteLength` to stay aligned with geth.

## Tests

### New
- `TestRPCBlockMarshalJSON`
  - asserts:
    - `logsBloom == "0x" + 512*"0"`
    - `extraData == "0x"`

### Validation
- `go vet ./...`
- `gofmt -l ./...`
- `go test ./gateway/api/...`
- `go test ./gateway/core/...`
- `go test -run '^TestLocalX$' ./integration/...`

Manual check:
- `ec.TransactionReceipt(...)`
- `ec.BlockByHash(...)` → now decodes successfully

## Compatibility / Risk

- Fix aligns with Ethereum JSON-RPC spec
- Previously failing clients now work
- No internal logic depends on these fields
- Encoding-only change; values unchanged

## Follow-up

Will enable block assertions in `testQueryValidation` (from #122):
- `ec.BlockByHash`
- `ec.BlockByNumber`
- validate hash, number, tx index

