### PR TITLE
gateway/api/rpcerr: add typed JSON-RPC error package

### DIFF
--- a/gateway/api/rpcerr/rpcerr.go
+++ b/gateway/api/rpcerr/rpcerr.go
@@ -1,0 +1,89 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+// Package rpcerr provides typed JSON-RPC errors that implement
+// go-ethereum's rpc.Error and rpc.DataError interfaces, so the
+// gateway can return Ethereum-compatible error codes instead of
+// the default -32603 Internal Error fallback.
+//
+// Standard JSON-RPC codes used here:
+//
+//	-32602 Invalid params         (malformed inputs from the caller)
+//	-32603 Internal error         (unexpected backend failures)
+//	-32003 Transaction rejected   (txpool rules: nonce, gas, funds, etc.)
+//	-32000 Generic server error   (used for execution reverted; carries data)
+package rpcerr
+
+import "fmt"
+
+// Standard error codes. The -32000 range is server-defined; geth uses
+// -32003 for "transaction rejected" and -32000 for execution reverted.
+const (
+	CodeInvalidParams     = -32602
+	CodeInternal          = -32603
+	CodeTxRejected        = -32003
+	CodeExecutionReverted = -32000
+)
+
+// Error is a JSON-RPC error with a code, satisfying rpc.Error.
+type Error struct {
+	Code    int
+	Message string
+}
+
+func (e *Error) Error() string  { return e.Message }
+func (e *Error) ErrorCode() int { return e.Code }
+
+// DataError carries a code, message, and a payload (e.g. EVM revert
+// data). It satisfies both rpc.Error and rpc.DataError.
+type DataError struct {
+	Code    int
+	Message string
+	Data    any
+}
+
+func (e *DataError) Error() string  { return e.Message }
+func (e *DataError) ErrorCode() int { return e.Code }
+func (e *DataError) ErrorData() any { return e.Data }
+
+// InvalidParams returns -32602 for malformed caller input
+// (bad hex, unparseable args, invalid raw tx, etc.).
+func InvalidParams(format string, args ...any) error {
+	return &Error{Code: CodeInvalidParams, Message: fmt.Sprintf(format, args...)}
+}
+
+// Internal returns -32603 for unexpected backend failures.
+// Use only when no more specific code applies.
+func Internal(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{Code: CodeInternal, Message: err.Error()}
+}
+
+// TxRejected returns -32003 for transactions rejected by validation
+// rules (nonce too low, intrinsic gas, insufficient funds,
+// unsupported tx type, init code too large, invalid sender,
+// unprotected tx, etc.).
+func TxRejected(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{Code: CodeTxRejected, Message: err.Error()}
+}
+
+// ExecutionReverted returns -32000 with the EVM revert data attached
+// as ErrorData(). reason is the decoded human-readable message (or
+// "execution reverted" if the data does not match the Error(string)
+// selector). data is the raw 0x-prefixed revert payload — callers
+// should match what eth_call clients expect to read back.
+func ExecutionReverted(reason string, data string) error {
+	return &DataError{
+		Code:    CodeExecutionReverted,
+		Message: reason,
+		Data:    data,
+	}
+}

--- a/gateway/api/rpcerr/rpcerr_test.go
+++ b/gateway/api/rpcerr/rpcerr_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package rpcerr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func TestInvalidParamsCodeAndMessage(t *testing.T) {
+	err := InvalidParams("bad hex %q", "0xnope")
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("InvalidParams must satisfy rpc.Error, got %T", err)
+	}
+	if rpcErr.ErrorCode() != CodeInvalidParams {
+		t.Errorf("code = %d, want %d", rpcErr.ErrorCode(), CodeInvalidParams)
+	}
+	if rpcErr.Error() != `bad hex "0xnope"` {
+		t.Errorf("message = %q, want %q", rpcErr.Error(), `bad hex "0xnope"`)
+	}
+}
+
+func TestInternalCodeAndMessage(t *testing.T) {
+	err := Internal(errors.New("db connection lost"))
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("Internal must satisfy rpc.Error")
+	}
+	if rpcErr.ErrorCode() != CodeInternal {
+		t.Errorf("code = %d, want %d", rpcErr.ErrorCode(), CodeInternal)
+	}
+	if rpcErr.Error() != "db connection lost" {
+		t.Errorf("message = %q, want %q", rpcErr.Error(), "db connection lost")
+	}
+}
+
+func TestInternalNilReturnsNil(t *testing.T) {
+	if err := Internal(nil); err != nil {
+		t.Errorf("Internal(nil) = %v, want nil", err)
+	}
+}
+
+func TestTxRejectedCodeAndMessage(t *testing.T) {
+	err := TxRejected(errors.New("nonce too low"))
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("TxRejected must satisfy rpc.Error")
+	}
+	if rpcErr.ErrorCode() != CodeTxRejected {
+		t.Errorf("code = %d, want %d", rpcErr.ErrorCode(), CodeTxRejected)
+	}
+	if rpcErr.Error() != "nonce too low" {
+		t.Errorf("message = %q, want %q", rpcErr.Error(), "nonce too low")
+	}
+}
+
+func TestTxRejectedNilReturnsNil(t *testing.T) {
+	if err := TxRejected(nil); err != nil {
+		t.Errorf("TxRejected(nil) = %v, want nil", err)
+	}
+}
+
+func TestExecutionRevertedSatisfiesDataError(t *testing.T) {
+	const data = "0x08c379a0deadbeef"
+	err := ExecutionReverted("execution reverted: out of stock", data)
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("ExecutionReverted must satisfy rpc.Error")
+	}
+	if rpcErr.ErrorCode() != CodeExecutionReverted {
+		t.Errorf("code = %d, want %d", rpcErr.ErrorCode(), CodeExecutionReverted)
+	}
+
+	var dataErr rpc.DataError
+	if !errors.As(err, &dataErr) {
+		t.Fatalf("ExecutionReverted must satisfy rpc.DataError")
+	}
+	if dataErr.ErrorData() != data {
+		t.Errorf("ErrorData() = %v, want %s", dataErr.ErrorData(), data)
+	}
+	if dataErr.Error() != "execution reverted: out of stock" {
+		t.Errorf("message = %q", dataErr.Error())
+	}
+}
+
+func TestStandardCodesMatchSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"InvalidParams", CodeInvalidParams, -32602},
+		{"Internal", CodeInternal, -32603},
+		{"TxRejected", CodeTxRejected, -32003},
+		{"ExecutionReverted", CodeExecutionReverted, -32000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
First PR of a four-part plan to bring the gateway's JSON-RPC error responses to parity with geth, tracked in #46.

Adds a new leaf package `gateway/api/rpcerr` that exposes typed errors implementing go-ethereum's `rpc.Error` and `rpc.DataError` interfaces. This enables later PRs to return Ethereum-compatible JSON-RPC error codes from handlers and validation paths.

This PR is **purely additive** no existing call sites are modified and no behavior changes.

Refs #46.

## Background
Currently, all RPC handlers (`gateway/api/eth.go`) return plain Go `error`. The go-ethereum RPC server maps non-`rpc.Error` values to:

```json
{ "code": -32603, "message": "<msg>" }
```

This makes all failures appear as "Internal error", breaking compatibility with Ethereum clients that rely on error codes (ethers.js, Hardhat, MetaMask, Blockscout, etc.).

## Design

### Package structure
A separate `rpcerr` package is introduced to avoid dependency cycles:
- No internal dependencies
- Can be used by both `gateway/api` and `gateway/core`

### Types
- `Error` → implements `rpc.Error`
- `DataError` → implements `rpc.Error` + `rpc.DataError`

### Constructors
- `InvalidParams(...)` → -32602
- `Internal(err)` → -32603 (nil-safe)
- `TxRejected(err)` → -32003 (nil-safe)
- `ExecutionReverted(reason, data)` → -32000

### Notes
- `Internal` and `TxRejected` return `nil` if input is `nil`
- `InvalidParams` and `ExecutionReverted` always return non-nil
- Minimal API: 4 constants, 2 types, 4 functions

## Files

- `gateway/api/rpcerr/rpcerr.go`
- `gateway/api/rpcerr/rpcerr_test.go`

## Test Plan

- `go vet ./...` clean  
- `gofmt -l gateway/api/rpcerr/` clean  
- `go test -race -count=1 ./gateway/api/rpcerr/...` all 7 tests passing  


All tests passing.

## Follow-ups

Planned as separate PRs:

1. Wire validation errors in `SendRawTransaction`
2. Add `eth_call` revert handling
3. Add read-side coverage, integration tests, and docs (Closes #46)