### PR TITLE
Hardened Fabric-X transaction status compatibility for async mempool processing

### DIFF
--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -117,7 +117,7 @@ func buildApp(cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorse
 	case "fabric":
 		gwSync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain)
 	case "fabric-x", "":
-		gwSync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain)
+		gwSync, err = core.NewFabricXSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain)
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %q", cfg.Network.Protocol)
 	}

--- a/gateway/core/fabricx_sync.go
+++ b/gateway/core/fabricx_sync.go
@@ -83,7 +83,9 @@ func (p *fabricXCompatParser) Parse(b *cb.Block) (blocks.Block, error) {
 func isFabricXCommittedStatus(status int) bool {
 	const legacyCommittedStatusV2 = 2
 	// Compatibility across committer status encodings:
-	// - legacy: COMMITTED=0
+	// - legacy: committed was encoded as numeric 0.
+	//   In newer protobuf enums, value 0 is named STATUS_UNSPECIFIED.
+	//   We intentionally treat 0 as committed for backward compatibility.
 	// - current: COMMITTED=1
 	// - some deployed test committers: COMMITTED=2
 	return status == int(committerpb.Status_STATUS_UNSPECIFIED) ||

--- a/gateway/core/fabricx_sync.go
+++ b/gateway/core/fabricx_sync.go
@@ -31,6 +31,15 @@ func NewFabricXSynchronizer(
 		return nil, err
 	}
 
+	return newFabricXSynchronizerWithPeer(db, peer, logger, handlers...)
+}
+
+func newFabricXSynchronizerWithPeer(
+	db network.BlockHeightReader,
+	peer network.SyncPeer,
+	logger sdk.Logger,
+	handlers ...blocks.BlockHandler,
+) (*network.Synchronizer, error) {
 	processor := blocks.NewProcessor(newFabricXCompatParser(logger), handlers)
 	return network.NewSynchronizer(db, peer, processor, logger)
 }

--- a/gateway/core/fabricx_sync.go
+++ b/gateway/core/fabricx_sync.go
@@ -1,0 +1,83 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	blocksfx "github.com/hyperledger/fabric-x-sdk/blocks/fabricx"
+	"github.com/hyperledger/fabric-x-sdk/network"
+	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
+)
+
+// NewFabricXSynchronizer creates a Fabric-X synchronizer using a parser that
+// preserves per-transaction status and handles legacy committed status values.
+func NewFabricXSynchronizer(
+	db network.BlockHeightReader,
+	channel string,
+	conf network.PeerConf,
+	signer sdk.Signer,
+	logger sdk.Logger,
+	handlers ...blocks.BlockHandler,
+) (*network.Synchronizer, error) {
+	peer, err := nfabx.NewPeer(conf, channel, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	processor := blocks.NewProcessor(newFabricXCompatParser(logger), handlers)
+	return network.NewSynchronizer(db, peer, processor, logger)
+}
+
+type fabricXCompatParser struct {
+	base blocksfx.BlockParser
+}
+
+func newFabricXCompatParser(log sdk.Logger) blocks.BlockParser {
+	return &fabricXCompatParser{
+		base: blocksfx.NewBlockParser(log),
+	}
+}
+
+func (p *fabricXCompatParser) Parse(b *cb.Block) (blocks.Block, error) {
+	parsed, err := p.base.Parse(b)
+	if err != nil {
+		return parsed, err
+	}
+
+	if b == nil || b.Metadata == nil {
+		return parsed, nil
+	}
+	if len(b.Metadata.Metadata) <= int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER) {
+		return parsed, nil
+	}
+
+	txFilter := b.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER]
+	for i := range parsed.Transactions {
+		txNum := int(parsed.Transactions[i].Number)
+		if txNum < 0 || txNum >= len(txFilter) {
+			continue
+		}
+		status := int(txFilter[txNum])
+		parsed.Transactions[i].Status = status
+		parsed.Transactions[i].Valid = isFabricXCommittedStatus(status)
+	}
+	return parsed, nil
+}
+
+func isFabricXCommittedStatus(status int) bool {
+	const legacyCommittedStatusV2 = 2
+	// Compatibility across committer status encodings:
+	// - legacy: COMMITTED=0
+	// - current: COMMITTED=1
+	// - some deployed test committers: COMMITTED=2
+	return status == int(committerpb.Status_STATUS_UNSPECIFIED) ||
+		status == int(committerpb.Status_COMMITTED) ||
+		status == legacyCommittedStatusV2
+}

--- a/gateway/core/fabricx_sync_test.go
+++ b/gateway/core/fabricx_sync_test.go
@@ -70,12 +70,30 @@ func TestNewFabricXSynchronizerWithPeerUsesCompatParser(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, handler.blocksSeen())
-	got := handler.last()
+	got, ok := handler.last()
+	require.True(t, ok)
 	require.Len(t, got.Transactions, 2)
 	require.Equal(t, 2, got.Transactions[0].Status)
 	require.True(t, got.Transactions[0].Valid)
 	require.Equal(t, 3, got.Transactions[1].Status)
 	require.False(t, got.Transactions[1].Valid)
+}
+
+func TestNewFabricXSynchronizerWithPeerCancellationWithoutBlocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler := &captureBlockHandler{}
+	peer := &fakeSyncPeer{cancel: cancel}
+	db := fakeBlockHeightReader(0)
+
+	syncer, err := newFabricXSynchronizerWithPeer(db, peer, sdk.NoOpLogger{}, handler)
+	require.NoError(t, err)
+	require.NotNil(t, syncer)
+
+	err = syncer.Start(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, handler.blocksSeen())
 }
 
 func buildFabricXTestEnvelope(t *testing.T, txID string) *cb.Envelope {
@@ -175,8 +193,11 @@ func (c *captureBlockHandler) blocksSeen() int {
 	return len(c.blocks)
 }
 
-func (c *captureBlockHandler) last() blocks.Block {
+func (c *captureBlockHandler) last() (blocks.Block, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.blocks[len(c.blocks)-1]
+	if len(c.blocks) == 0 {
+		return blocks.Block{}, false
+	}
+	return c.blocks[len(c.blocks)-1], true
 }

--- a/gateway/core/fabricx_sync_test.go
+++ b/gateway/core/fabricx_sync_test.go
@@ -13,9 +13,9 @@ import (
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/hyperledger/fabric-x-sdk/network"
-	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )

--- a/gateway/core/fabricx_sync_test.go
+++ b/gateway/core/fabricx_sync_test.go
@@ -7,10 +7,14 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package core
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/network"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -39,6 +43,37 @@ func TestFabricXCompatParserSetsStatusAndValidity(t *testing.T) {
 	require.Equal(t, 2, got.Transactions[0].Status)
 	require.True(t, got.Transactions[0].Valid)
 
+	require.Equal(t, 3, got.Transactions[1].Status)
+	require.False(t, got.Transactions[1].Valid)
+}
+
+func TestNewFabricXSynchronizerWithPeerUsesCompatParser(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler := &captureBlockHandler{}
+	peer := &fakeSyncPeer{
+		cancel: cancel,
+		block: buildFabricXTestBlock(t,
+			[]byte{2, 3},
+			buildFabricXTestEnvelope(t, "tx-0"),
+			buildFabricXTestEnvelope(t, "tx-1"),
+		),
+	}
+	db := fakeBlockHeightReader(0)
+
+	syncer, err := newFabricXSynchronizerWithPeer(db, peer, sdk.NoOpLogger{}, handler)
+	require.NoError(t, err)
+	require.NotNil(t, syncer)
+
+	err = syncer.Start(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, handler.blocksSeen())
+	got := handler.last()
+	require.Len(t, got.Transactions, 2)
+	require.Equal(t, 2, got.Transactions[0].Status)
+	require.True(t, got.Transactions[0].Valid)
 	require.Equal(t, 3, got.Transactions[1].Status)
 	require.False(t, got.Transactions[1].Valid)
 }
@@ -96,3 +131,52 @@ func buildFabricXTestBlock(t *testing.T, txFilter []byte, envelopes ...*cb.Envel
 	}
 }
 
+type fakeSyncPeer struct {
+	cancel func()
+	block  *cb.Block
+}
+
+func (f *fakeSyncPeer) SubscribeBlocks(ctx context.Context, _ uint64, p network.BlockProcessor) error {
+	if f.block != nil {
+		if err := p.ProcessBlock(ctx, f.block); err != nil {
+			return err
+		}
+	}
+	if f.cancel != nil {
+		f.cancel()
+	}
+	return nil
+}
+
+func (f *fakeSyncPeer) BlockHeight(context.Context) (uint64, error) { return 1, nil }
+func (f *fakeSyncPeer) Close() error                                { return nil }
+
+type fakeBlockHeightReader uint64
+
+func (f fakeBlockHeightReader) BlockNumber(context.Context) (uint64, error) {
+	return uint64(f), nil
+}
+
+type captureBlockHandler struct {
+	mu     sync.Mutex
+	blocks []blocks.Block
+}
+
+func (c *captureBlockHandler) Handle(_ context.Context, b blocks.Block) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.blocks = append(c.blocks, b)
+	return nil
+}
+
+func (c *captureBlockHandler) blocksSeen() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.blocks)
+}
+
+func (c *captureBlockHandler) last() blocks.Block {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.blocks[len(c.blocks)-1]
+}

--- a/gateway/core/fabricx_sync_test.go
+++ b/gateway/core/fabricx_sync_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFabricXCompatCommittedStatusMapping(t *testing.T) {
+	require.True(t, isFabricXCommittedStatus(0))
+	require.True(t, isFabricXCommittedStatus(1))
+	require.True(t, isFabricXCommittedStatus(2))
+	require.False(t, isFabricXCommittedStatus(3))
+}
+
+func TestFabricXCompatParserSetsStatusAndValidity(t *testing.T) {
+	parser := newFabricXCompatParser(sdk.NoOpLogger{})
+
+	block := buildFabricXTestBlock(t,
+		[]byte{2, 3},
+		buildFabricXTestEnvelope(t, "tx-0"),
+		buildFabricXTestEnvelope(t, "tx-1"),
+	)
+
+	got, err := parser.Parse(block)
+	require.NoError(t, err)
+	require.Len(t, got.Transactions, 2)
+
+	require.Equal(t, 2, got.Transactions[0].Status)
+	require.True(t, got.Transactions[0].Valid)
+
+	require.Equal(t, 3, got.Transactions[1].Status)
+	require.False(t, got.Transactions[1].Valid)
+}
+
+func buildFabricXTestEnvelope(t *testing.T, txID string) *cb.Envelope {
+	t.Helper()
+
+	tx := &applicationpb.Tx{
+		Namespaces: []*applicationpb.TxNamespace{
+			{
+				NsId: "basic",
+				BlindWrites: []*applicationpb.Write{
+					{Key: []byte("k"), Value: []byte("v")},
+				},
+			},
+		},
+	}
+	txBytes, err := proto.Marshal(tx)
+	require.NoError(t, err)
+
+	chdrBytes, err := proto.Marshal(&cb.ChannelHeader{
+		TxId: txID,
+		Type: int32(cb.HeaderType_MESSAGE),
+	})
+	require.NoError(t, err)
+
+	payloadBytes, err := proto.Marshal(&cb.Payload{
+		Header: &cb.Header{ChannelHeader: chdrBytes},
+		Data:   txBytes,
+	})
+	require.NoError(t, err)
+
+	return &cb.Envelope{Payload: payloadBytes}
+}
+
+func buildFabricXTestBlock(t *testing.T, txFilter []byte, envelopes ...*cb.Envelope) *cb.Block {
+	t.Helper()
+
+	data := make([][]byte, len(envelopes))
+	for i, env := range envelopes {
+		var err error
+		data[i], err = proto.Marshal(env)
+		require.NoError(t, err)
+	}
+
+	metadata := make([][]byte, int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+	metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = txFilter
+
+	return &cb.Block{
+		Header: &cb.BlockHeader{Number: 1},
+		Data:   &cb.BlockData{Data: data},
+		Metadata: &cb.BlockMetadata{
+			Metadata: metadata,
+		},
+	}
+}
+

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -265,7 +265,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 			sync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 			submitter, err1 = nfab.NewSubmitter(orderers, gwSigner, 0, logger)
 		case "fabric-x", "":
-			sync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+			sync, err = core.NewFabricXSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 			submitter, err1 = nfabx.NewSubmitter(orderers, gwSigner, 0, logger)
 		default:
 			return nil, nil, fmt.Errorf("unsupported protocol: %q", cfg.Network.Protocol)
@@ -282,6 +282,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 
 	if !bypass {
 		go func() error { return sync.Start(t.Context()) }()
+		waitUntilSynced(t, sync, 10*time.Second)
 	}
 
 	// Start gateway worker pool for tests

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -198,8 +198,8 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 //   - cfg.Gateway.SignerMSPDir set → MSP-based signer; empty → local mock
 //   - cfg.Endorsers[0].MspDir set → FabricDeserializer; empty → local mock
 //
-// Sync goroutines are started in the background using ctx. The returned synchronizers
-// can be used by callers that need to wait for the initial sync to complete.
+// For non-bypass runs, this function starts the synchronizer and waits until it
+// is ready before returning.
 func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig endorser.EVMConfig, primeDBPath string, bypass bool) (*TestHarness, *network.Synchronizer, error) {
 	t.Helper()
 
@@ -281,8 +281,11 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 	}
 
 	if !bypass {
-		go func() error { return sync.Start(t.Context()) }()
-		waitUntilSynced(t, sync, 10*time.Second)
+		startErr := make(chan error, 1)
+		go func() {
+			startErr <- sync.Start(t.Context())
+		}()
+		waitUntilSynced(t, sync, 10*time.Second, startErr)
 	}
 
 	// Start gateway worker pool for tests
@@ -434,12 +437,10 @@ func newFabricTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EV
 		return nil, err
 	}
 
-	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false)
+	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false)
 	if err != nil {
 		return nil, err
 	}
-
-	waitUntilSynced(t, sync, 10*time.Second)
 
 	return th, nil
 }
@@ -816,18 +817,30 @@ func (tl TestLogger) Errorf(format string, v ...any) {
 	tl.T.Logf(tl.ID+" > [ERROR] "+format, v...)
 }
 
-func waitUntilSynced(t *testing.T, sync *network.Synchronizer, timeout time.Duration) {
+func waitUntilSynced(t *testing.T, sync *network.Synchronizer, timeout time.Duration, startErr <-chan error) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	for {
+		select {
+		case err := <-startErr:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("synchronizer failed to start: %v", err)
+			}
+		default:
+		}
+
 		if err := sync.Ready(); err == nil {
 			break
 		}
 		select {
 		case <-ctx.Done():
 			t.Fatal("timeout waiting for sync")
+		case err := <-startErr:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("synchronizer failed before ready: %v", err)
+			}
 		case <-time.After(100 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
This PR fixes a runtime [compatibility issue](https://github.com/hyperledger/fabric-x-evm/issues/145) I hit in the Fabric-X path while validating async mempool behavior. 

In some committer environments, the transaction status values in block metadata did not line up with the status semantics the gateway was assuming. That mismatch caused transactions that Ire effectively committed to be interpreted as invalid, which then led to incorrect retry behavior and missing state updates in integration runs.

To address this, I introduced a Fabric-X compatibility synchronizer/parser in the gateway core and moved Fabric-X sync wiring to use it in both app runtime and integration harness setup. The parser now preserves per-transaction status from `TRANSACTIONS_FILTER` and applies a compatibility mapping that supports legacy and current committer encodings observed in our environments. This keeps transaction validity decisions stable across those versions and removes the runtime failure mode I Ire seeing.

I also made integration startup behavior safer by waiting for synchronizer readiness before worker processing begins in the harness, reducing race-related noise during startup. Alongside this, I added focused unit tests for status mapping and parser behavior so this compatibility path is locked in and regressions are easier to catch.

Validation was done with gateway/core tests plus full Fabric-X integration (`make test-x`) on fresh committer state. With this patch, the async mempool flow remains intact and the Fabric-X status handling is now robust for the currently supported committer variants.
