### PR TITLE
Factory execution + SnapshotDB RW-set coverage for CREATE/CREATE2

### DIFF
--- a/integration/contracts/proxyfactory.gen.go
+++ b/integration/contracts/proxyfactory.gen.go
@@ -1,0 +1,223 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// ProxyFactoryMetaData contains all meta data concerning the ProxyFactory contract.
+var ProxyFactoryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"code\",\"type\":\"bytes\"}],\"name\":\"createContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x608060405234801561000f575f80fd5b506102998061001d5f395ff3fe608060405234801561000f575f80fd5b5060043610610029575f3560e01c806390042baf1461002d575b5f80fd5b610047600480360381019061004291906101c4565b61005d565b604051610054919061024a565b60405180910390f35b5f8151602083015ff09050803b610072575f80fd5b919050565b5f604051905090565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b6100d682610090565b810181811067ffffffffffffffff821117156100f5576100f46100a0565b5b80604052505050565b5f610107610077565b905061011382826100cd565b919050565b5f67ffffffffffffffff821115610132576101316100a0565b5b61013b82610090565b9050602081019050919050565b828183375f83830152505050565b5f61016861016384610118565b6100fe565b9050828152602081018484840111156101845761018361008c565b5b61018f848285610148565b509392505050565b5f82601f8301126101ab576101aa610088565b5b81356101bb848260208601610156565b91505092915050565b5f602082840312156101d9576101d8610080565b5b5f82013567ffffffffffffffff8111156101f6576101f5610084565b5b61020284828501610197565b91505092915050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6102348261020b565b9050919050565b6102448161022a565b82525050565b5f60208201905061025d5f83018461023b565b9291505056fea2646970667358221220d9029d906fd7918ef36fd43ef7eed5c8c15986cb65530648f51c122c86c0228264736f6c63430008140033",
+}
+
+// ProxyFactoryABI is the input ABI used to generate the binding from.
+// Deprecated: Use ProxyFactoryMetaData.ABI instead.
+var ProxyFactoryABI = ProxyFactoryMetaData.ABI
+
+// ProxyFactoryBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use ProxyFactoryMetaData.Bin instead.
+var ProxyFactoryBin = ProxyFactoryMetaData.Bin
+
+// DeployProxyFactory deploys a new Ethereum contract, binding an instance of ProxyFactory to it.
+func DeployProxyFactory(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *ProxyFactory, error) {
+	parsed, err := ProxyFactoryMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(ProxyFactoryBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &ProxyFactory{ProxyFactoryCaller: ProxyFactoryCaller{contract: contract}, ProxyFactoryTransactor: ProxyFactoryTransactor{contract: contract}, ProxyFactoryFilterer: ProxyFactoryFilterer{contract: contract}}, nil
+}
+
+// ProxyFactory is an auto generated Go binding around an Ethereum contract.
+type ProxyFactory struct {
+	ProxyFactoryCaller     // Read-only binding to the contract
+	ProxyFactoryTransactor // Write-only binding to the contract
+	ProxyFactoryFilterer   // Log filterer for contract events
+}
+
+// ProxyFactoryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ProxyFactoryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProxyFactoryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ProxyFactoryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProxyFactoryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ProxyFactoryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProxyFactorySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ProxyFactorySession struct {
+	Contract     *ProxyFactory     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ProxyFactoryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ProxyFactoryCallerSession struct {
+	Contract *ProxyFactoryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// ProxyFactoryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ProxyFactoryTransactorSession struct {
+	Contract     *ProxyFactoryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// ProxyFactoryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ProxyFactoryRaw struct {
+	Contract *ProxyFactory // Generic contract binding to access the raw methods on
+}
+
+// ProxyFactoryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ProxyFactoryCallerRaw struct {
+	Contract *ProxyFactoryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ProxyFactoryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ProxyFactoryTransactorRaw struct {
+	Contract *ProxyFactoryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewProxyFactory creates a new instance of ProxyFactory, bound to a specific deployed contract.
+func NewProxyFactory(address common.Address, backend bind.ContractBackend) (*ProxyFactory, error) {
+	contract, err := bindProxyFactory(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ProxyFactory{ProxyFactoryCaller: ProxyFactoryCaller{contract: contract}, ProxyFactoryTransactor: ProxyFactoryTransactor{contract: contract}, ProxyFactoryFilterer: ProxyFactoryFilterer{contract: contract}}, nil
+}
+
+// NewProxyFactoryCaller creates a new read-only instance of ProxyFactory, bound to a specific deployed contract.
+func NewProxyFactoryCaller(address common.Address, caller bind.ContractCaller) (*ProxyFactoryCaller, error) {
+	contract, err := bindProxyFactory(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ProxyFactoryCaller{contract: contract}, nil
+}
+
+// NewProxyFactoryTransactor creates a new write-only instance of ProxyFactory, bound to a specific deployed contract.
+func NewProxyFactoryTransactor(address common.Address, transactor bind.ContractTransactor) (*ProxyFactoryTransactor, error) {
+	contract, err := bindProxyFactory(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ProxyFactoryTransactor{contract: contract}, nil
+}
+
+// NewProxyFactoryFilterer creates a new log filterer instance of ProxyFactory, bound to a specific deployed contract.
+func NewProxyFactoryFilterer(address common.Address, filterer bind.ContractFilterer) (*ProxyFactoryFilterer, error) {
+	contract, err := bindProxyFactory(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ProxyFactoryFilterer{contract: contract}, nil
+}
+
+// bindProxyFactory binds a generic wrapper to an already deployed contract.
+func bindProxyFactory(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(ProxyFactoryABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ProxyFactory *ProxyFactoryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ProxyFactory.Contract.ProxyFactoryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ProxyFactory *ProxyFactoryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.ProxyFactoryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ProxyFactory *ProxyFactoryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.ProxyFactoryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ProxyFactory *ProxyFactoryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ProxyFactory.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ProxyFactory *ProxyFactoryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ProxyFactory *ProxyFactoryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.contract.Transact(opts, method, params...)
+}
+
+// CreateContract is a paid mutator transaction binding the contract method 0x90042baf.
+//
+// Solidity: function createContract(bytes code) returns(address addr)
+func (_ProxyFactory *ProxyFactoryTransactor) CreateContract(opts *bind.TransactOpts, code []byte) (*types.Transaction, error) {
+	return _ProxyFactory.contract.Transact(opts, "createContract", code)
+}
+
+// CreateContract is a paid mutator transaction binding the contract method 0x90042baf.
+//
+// Solidity: function createContract(bytes code) returns(address addr)
+func (_ProxyFactory *ProxyFactorySession) CreateContract(code []byte) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.CreateContract(&_ProxyFactory.TransactOpts, code)
+}
+
+// CreateContract is a paid mutator transaction binding the contract method 0x90042baf.
+//
+// Solidity: function createContract(bytes code) returns(address addr)
+func (_ProxyFactory *ProxyFactoryTransactorSession) CreateContract(code []byte) (*types.Transaction, error) {
+	return _ProxyFactory.Contract.CreateContract(&_ProxyFactory.TransactOpts, code)
+}

--- a/integration/ethclient.go
+++ b/integration/ethclient.go
@@ -18,7 +18,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/hyperledger/fabric-x-evm/gateway/core"
 	"github.com/hyperledger/fabric-x-evm/utils"
+	sdk "github.com/hyperledger/fabric-x-sdk"
 )
 
 // NonceProvider is an interface for getting account nonces.
@@ -217,4 +219,32 @@ func (e *EthClient) TxForCall(ctx context.Context, nonceProvider NonceProvider, 
 // EIP-155 signer; otherwise the gateway rejects the tx as unprotected.
 func GetCtxForSigner() (blockNumber *big.Int, blockTime uint64) {
 	return big.NewInt(0), 0
+}
+
+// EndorseTransact creates and endorses a state-changing method call.
+func (e *EthClient) EndorseTransact(ctx context.Context, gw *core.Gateway, addr common.Address, method string, args ...any) (sdk.Endorsement, error) {
+	tx, err := e.TxForCall(ctx, gw, &addr, method, nil, args...)
+	if err != nil {
+		return sdk.Endorsement{}, err
+	}
+	return gw.ExecuteEthTx(ctx, tx, nil)
+}
+
+// Broadcast submits an endorsement and waits for the transaction to be committed.
+func (e *EthClient) Broadcast(ctx context.Context, gw *core.Gateway, env sdk.Endorsement) error {
+	if err := gw.SubmitFabricTx(ctx, env); err != nil {
+		return err
+	}
+
+	tx, err := extractEthTxFromProposal(env.Proposal)
+	if err != nil {
+		return err
+	}
+
+	ec, err := NewNativeEthClient(gw)
+	if err != nil {
+		return err
+	}
+
+	return waitForCommit(ctx, ec, tx)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -645,7 +645,7 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 	if pairAddr == (common.Address{}) {
 		t.Fatal("pair address is zero")
 	}
-	if strings.ToLower(pairAddr.Hex()) != strings.ToLower(pairAddrStr) {
+	if !strings.EqualFold(pairAddr.Hex(), pairAddrStr) {
 		t.Fatalf("pair address mismatch between RWS and query: rws=%s query=%s", pairAddrStr, pairAddr.Hex())
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -586,8 +586,8 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 
 	var pairAddrStr string
 	for _, w := range rws.Writes {
-		if strings.HasPrefix(w.Key, "acc:") && strings.HasSuffix(w.Key, ":code") && !strings.Contains(strings.ToLower(w.Key), strings.ToLower(factoryAddr.Hex())) {
-			parts := strings.Split(w.Key, ":")
+		parts := strings.SplitN(w.Key, ":", 3)
+		if len(parts) == 3 && parts[0] == "acc" && parts[2] == "code" && !strings.EqualFold(parts[1], factoryAddr.Hex()) {
 			pairAddrStr = parts[1]
 			break
 		}
@@ -1064,8 +1064,8 @@ func testProxyFactory(t *testing.T, th *TestHarness) {
 
 	var childAddrHex string
 	for _, w := range rws.Writes {
-		if strings.HasPrefix(w.Key, "acc:") && strings.HasSuffix(w.Key, ":code") && !strings.Contains(strings.ToLower(w.Key), strings.ToLower(factoryAddr.Hex())) {
-			parts := strings.Split(w.Key, ":")
+		parts := strings.SplitN(w.Key, ":", 3)
+		if len(parts) == 3 && parts[0] == "acc" && parts[2] == "code" && !strings.EqualFold(parts[1], factoryAddr.Hex()) {
 			childAddrHex = parts[1]
 			break
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -597,7 +597,7 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 		for _, w := range rws.Writes {
 			t.Logf("RWS Write: %s", w.Key)
 		}
-		if strings.Contains(t.Name(), "TestLocalX") {
+		if th.Protocol == "fabric-x" {
 			t.Skip("skipping missing code write in RWS for fabric-x mode")
 		} else {
 			t.Fatal("expected child contract code write in RWS for UniswapV2Pair")
@@ -1077,7 +1077,7 @@ func testProxyFactory(t *testing.T, th *TestHarness) {
 		}
 		t.Logf("RWS writes: %+v", rws.Writes)
 		// skip the assertion if fabric-x mode because we know it doesn't give us standard read-set keys.
-		if strings.Contains(t.Name(), "TestLocalX") {
+		if th.Protocol == "fabric-x" {
 			t.Skip("skipping missing code write in RWS for fabric-x mode")
 		} else {
 			t.Fatal("expected child contract code write in RWS")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1046,7 +1046,7 @@ func testProxyFactory(t *testing.T, th *TestHarness) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bytecode := counterClient.bytecode
+	bytecode := common.FromHex(contracts.CounterMetaData.Bin)
 
 	env, err := factoryClient.EndorseTransact(t.Context(), node, factoryAddr, "createContract", bytecode)
 	if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -67,6 +68,11 @@ var cases = []testCase{
 		fork:        "Byzantium",                                 // replaying against the latest forks causes out of gas error
 		overrides:   map[string]any{"Network.ChainID": int64(1)}, // mainnet chain ID which was used in the signature
 		primeDbPath: "../testdata/alloc_tether_replay.json",
+	},
+	{
+		name:  "proxy_factory",
+		fn:    testProxyFactory,
+		nodes: 2,
 	},
 	{
 		name:  "uniswap_factory",
@@ -504,6 +510,10 @@ func testTetherTokenParallel(t *testing.T, th *TestHarness) {
 
 func testUniswapFactory(t *testing.T, th *TestHarness) {
 	node := th.Gateways[0]
+	ec, err := NewNativeEthClient(node)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// -------------------- clients --------------------
 	erc20A, err := NewEthClient(contracts.GenericERC20MetaData, th.ethChainConfig)
@@ -560,16 +570,60 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 	)
 
 	// -------------------- create pair --------------------
-	callSmartContract(
-		t,
-		factoryClient,
-		factoryAddr,
-		node,
-		"createPair",
-		nil,
-		tokenAAddr,
-		tokenBAddr,
-	)
+	env, err := factoryClient.EndorseTransact(t.Context(), node, factoryAddr, "createPair", tokenAAddr, tokenBAddr)
+	if err != nil {
+		t.Fatalf("failed to endorse createPair: %v", err)
+	}
+	createPairTx, err := extractEthTxFromProposal(env.Proposal)
+	if err != nil {
+		t.Fatalf("failed to extract createPair tx from proposal: %v", err)
+	}
+
+	rws, err := endorsementToRWS(env)
+	if err != nil {
+		t.Fatalf("failed to unmarshal rws: %v", err)
+	}
+
+	var pairAddrStr string
+	for _, w := range rws.Writes {
+		if strings.HasPrefix(w.Key, "acc:") && strings.HasSuffix(w.Key, ":code") && !strings.Contains(strings.ToLower(w.Key), strings.ToLower(factoryAddr.Hex())) {
+			parts := strings.Split(w.Key, ":")
+			pairAddrStr = parts[1]
+			break
+		}
+	}
+	if pairAddrStr == "" {
+		t.Logf("RWS Write length in %s: %d", t.Name(), len(rws.Writes))
+		for _, w := range rws.Writes {
+			t.Logf("RWS Write: %s", w.Key)
+		}
+		if strings.Contains(t.Name(), "TestLocalX") {
+			t.Skip("skipping missing code write in RWS for fabric-x mode")
+		} else {
+			t.Fatal("expected child contract code write in RWS for UniswapV2Pair")
+		}
+	}
+
+	if err := factoryClient.Broadcast(t.Context(), node, env); err != nil {
+		t.Fatalf("failed to commit factory createPair: %v", err)
+	}
+
+	var storageWriteCount int
+	var pairNonceWrite bool
+	for _, w := range rws.Writes {
+		if strings.HasPrefix(strings.ToLower(w.Key), "acc:"+strings.ToLower(pairAddrStr)+":nonce") && !w.IsDelete {
+			pairNonceWrite = true
+		}
+		if strings.HasPrefix(strings.ToLower(w.Key), "str:"+strings.ToLower(pairAddrStr)) && !w.IsDelete {
+			storageWriteCount++
+		}
+	}
+	if !pairNonceWrite {
+		t.Fatal("expected nonce write to child address in RWS")
+	}
+	if storageWriteCount < 1 {
+		t.Fatalf("expected storage writes to child address in RWS, got %d", storageWriteCount)
+	}
 
 	// -------------------- fetch pair address --------------------
 	res := querySmartContract(
@@ -591,6 +645,25 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 	if pairAddr == (common.Address{}) {
 		t.Fatal("pair address is zero")
 	}
+	if strings.ToLower(pairAddr.Hex()) != strings.ToLower(pairAddrStr) {
+		t.Fatalf("pair address mismatch between RWS and query: rws=%s query=%s", pairAddrStr, pairAddr.Hex())
+	}
+
+	receipt, err := ec.TransactionReceipt(t.Context(), createPairTx.Hash())
+	if err != nil {
+		t.Fatalf("failed to retrieve createPair receipt: %v", err)
+	}
+	if receipt.ContractAddress != (common.Address{}) {
+		t.Fatalf("factory call must not set receipt.ContractAddress, got %s", receipt.ContractAddress.Hex())
+	}
+
+	gotTx, _, err := ec.TransactionByHash(t.Context(), createPairTx.Hash())
+	if err != nil {
+		t.Fatalf("failed to retrieve createPair tx by hash: %v", err)
+	}
+	if gotTx == nil || gotTx.To() == nil || *gotTx.To() != factoryAddr {
+		t.Fatalf("expected createPair tx recipient to be factory address %s", factoryAddr.Hex())
+	}
 
 	// Verify symmetric lookup
 	querySmartContractExpect(
@@ -603,6 +676,21 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 		tokenBAddr,
 		tokenAAddr,
 	)
+
+	// -------------------- failed duplicate CREATE2 --------------------
+	failedEnv, failedErr := factoryClient.EndorseTransact(t.Context(), node, factoryAddr, "createPair", tokenAAddr, tokenBAddr)
+	if failedErr != nil {
+		t.Fatalf("duplicate CREATE2 should fail during execution, not pre-validation: %v", failedErr)
+	}
+	if len(failedEnv.Responses) == 0 || failedEnv.Responses[0] == nil || failedEnv.Responses[0].Response == nil {
+		t.Fatal("duplicate CREATE2 endorsement did not include a proposal response")
+	}
+	if failedEnv.Responses[0].Response.Status != 500 {
+		t.Fatalf("duplicate CREATE2 must surface execution failure status, got %d", failedEnv.Responses[0].Response.Status)
+	}
+	if !strings.Contains(strings.ToLower(failedEnv.Responses[0].Response.Message), "revert") {
+		t.Fatalf("duplicate CREATE2 should include revert error, got message: %q", failedEnv.Responses[0].Response.Message)
+	}
 
 	// -------------------- validate pair state --------------------
 	token0 := querySmartContract(
@@ -643,6 +731,50 @@ func testUniswapFactory(t *testing.T, th *TestHarness) {
 
 	if allPairsLength.Cmp(big.NewInt(1)) != 0 {
 		t.Fatalf("expected 1 pair, got %s", allPairsLength.String())
+	}
+
+	pairCreatedTopic := crypto.Keccak256Hash([]byte("PairCreated(address,address,address,uint256)"))
+	filteredLogs, err := ec.FilterLogs(t.Context(), ethereum.FilterQuery{
+		FromBlock: receipt.BlockNumber,
+		ToBlock:   receipt.BlockNumber,
+		Addresses: []common.Address{factoryAddr},
+		Topics:    [][]common.Hash{{pairCreatedTopic}},
+	})
+	if err != nil {
+		t.Fatalf("eth_getLogs for PairCreated failed: %v", err)
+	}
+	if len(filteredLogs) == 0 {
+		t.Fatal("expected PairCreated log in gateway index")
+	}
+	factoryFilterer, err := contracts.NewUniswapV2FactoryFilterer(factoryAddr, ec)
+	if err != nil {
+		t.Fatalf("failed to create factory filterer: %v", err)
+	}
+	var sawPairCreated bool
+	for _, l := range filteredLogs {
+		if l.TxHash != createPairTx.Hash() {
+			continue
+		}
+		evt, err := factoryFilterer.ParsePairCreated(l)
+		if err != nil {
+			t.Fatalf("failed to parse PairCreated log: %v", err)
+		}
+		if evt.Pair != pairAddr {
+			t.Fatalf("PairCreated event pair mismatch: got %s want %s", evt.Pair.Hex(), pairAddr.Hex())
+		}
+		sawPairCreated = true
+		break
+	}
+	if !sawPairCreated {
+		t.Fatalf("expected PairCreated log for tx %s", createPairTx.Hash().Hex())
+	}
+
+	pairCode, err := ec.CodeAt(t.Context(), pairAddr, nil)
+	if err != nil {
+		t.Fatalf("failed to query pair code: %v", err)
+	}
+	if len(pairCode) == 0 {
+		t.Fatal("expected deployed pair code to be indexed and queryable")
 	}
 
 	// -------------------- approve tokens for pair --------------------
@@ -889,5 +1021,134 @@ func testQueryValidation(t *testing.T, th *TestHarness) {
 	}
 	if isPending {
 		t.Error("expected isPending=false for unknown hash")
+	}
+}
+
+func testProxyFactory(t *testing.T, th *TestHarness) {
+	node := th.Gateways[0]
+	ec, err := NewNativeEthClient(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	factoryClient, err := NewEthClient(contracts.ProxyFactoryMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	factoryAddr := deploySmartContract(
+		t,
+		node,
+		factoryClient,
+	)
+
+	counterClient, err := NewEthClient(contracts.CounterMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytecode := counterClient.bytecode
+
+	env, err := factoryClient.EndorseTransact(t.Context(), node, factoryAddr, "createContract", bytecode)
+	if err != nil {
+		t.Fatalf("failed to endorse createContract: %v", err)
+	}
+	createContractTx, err := extractEthTxFromProposal(env.Proposal)
+	if err != nil {
+		t.Fatalf("failed to extract createContract tx from proposal: %v", err)
+	}
+
+	rws, err := endorsementToRWS(env)
+	if err != nil {
+		t.Fatalf("failed to unmarshal rws: %v", err)
+	}
+
+	var childAddrHex string
+	for _, w := range rws.Writes {
+		if strings.HasPrefix(w.Key, "acc:") && strings.HasSuffix(w.Key, ":code") && !strings.Contains(strings.ToLower(w.Key), strings.ToLower(factoryAddr.Hex())) {
+			parts := strings.Split(w.Key, ":")
+			childAddrHex = parts[1]
+			break
+		}
+	}
+	if childAddrHex == "" {
+		t.Logf("RWS Write length in %s: %d", t.Name(), len(rws.Writes))
+		for _, w := range rws.Writes {
+			t.Logf("RWS Write in %s: %s", t.Name(), w.Key)
+		}
+		t.Logf("RWS writes: %+v", rws.Writes)
+		// skip the assertion if fabric-x mode because we know it doesn't give us standard read-set keys.
+		if strings.Contains(t.Name(), "TestLocalX") {
+			t.Skip("skipping missing code write in RWS for fabric-x mode")
+		} else {
+			t.Fatal("expected child contract code write in RWS")
+		}
+	}
+
+	if err := factoryClient.Broadcast(t.Context(), node, env); err != nil {
+		t.Fatalf("failed to commit ProxyFactory: %v", err)
+	}
+
+	var writeCount int
+	childAddr := common.HexToAddress(childAddrHex)
+	var sawCodeWrite bool
+	var sawNonceWrite bool
+	for _, w := range rws.Writes {
+		if strings.HasPrefix(strings.ToLower(w.Key), "acc:"+strings.ToLower(childAddrHex)) && !w.IsDelete {
+			writeCount++
+		}
+		if strings.EqualFold(w.Key, "acc:"+childAddrHex+":code") && !w.IsDelete {
+			sawCodeWrite = true
+		}
+		if strings.EqualFold(w.Key, "acc:"+childAddrHex+":nonce") && !w.IsDelete {
+			sawNonceWrite = true
+		}
+	}
+	if writeCount < 2 {
+		t.Fatalf("expected writes to child address in RWS, got %d", writeCount)
+	}
+	if !sawCodeWrite || !sawNonceWrite {
+		t.Fatalf("expected code+nonce writes for child contract, saw code=%t nonce=%t", sawCodeWrite, sawNonceWrite)
+	}
+
+	receipt, err := ec.TransactionReceipt(t.Context(), createContractTx.Hash())
+	if err != nil {
+		t.Fatalf("failed to retrieve createContract receipt: %v", err)
+	}
+	if receipt.ContractAddress != (common.Address{}) {
+		t.Fatalf("factory call must not set receipt.ContractAddress, got %s", receipt.ContractAddress.Hex())
+	}
+
+	gotTx, _, err := ec.TransactionByHash(t.Context(), createContractTx.Hash())
+	if err != nil {
+		t.Fatalf("failed to retrieve createContract tx by hash: %v", err)
+	}
+	if gotTx == nil || gotTx.To() == nil || *gotTx.To() != factoryAddr {
+		t.Fatalf("expected createContract tx recipient to be factory address %s", factoryAddr.Hex())
+	}
+
+	childCode, err := ec.CodeAt(t.Context(), childAddr, nil)
+	if err != nil {
+		t.Fatalf("failed to query child code: %v", err)
+	}
+	if len(childCode) == 0 {
+		t.Fatal("expected child contract code to be queryable after factory deployment")
+	}
+
+	callSmartContract(t, counterClient, childAddr, node, "increment", nil)
+	querySmartContractExpect(t, counterClient, childAddr, th, big.NewInt(1), "count")
+
+	// CREATE failure path should be an execution error (revert), not txpool-style pre-validation rejection.
+	failedEnv, failedErr := factoryClient.EndorseTransact(t.Context(), node, factoryAddr, "createContract", []byte{})
+	if failedErr != nil {
+		t.Fatalf("empty bytecode CREATE should fail during execution, not pre-validation: %v", failedErr)
+	}
+	if len(failedEnv.Responses) == 0 || failedEnv.Responses[0] == nil || failedEnv.Responses[0].Response == nil {
+		t.Fatal("empty bytecode CREATE endorsement did not include a proposal response")
+	}
+	if failedEnv.Responses[0].Response.Status != 500 {
+		t.Fatalf("empty bytecode CREATE must surface execution failure status, got %d", failedEnv.Responses[0].Response.Status)
+	}
+	if !strings.Contains(strings.ToLower(failedEnv.Responses[0].Response.Message), "revert") {
+		t.Fatalf("empty bytecode CREATE should include revert error, got message: %q", failedEnv.Responses[0].Response.Message)
 	}
 }

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -298,6 +298,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 		endorsers:      ends,
 		ethChainConfig: evmConfig.ChainConfig,
 		Primer:         primer,
+		Protocol:       cfg.Network.Protocol,
 	}
 
 	if err := th.PrimeStateFromJSON(t.Context(), primeDBPath, !bypass); err != nil {
@@ -515,6 +516,7 @@ type TestHarness struct {
 	endorsers      []*endorser.Endorser
 	ethChainConfig *params.ChainConfig
 	Primer         *StatePrimer
+	Protocol       string
 }
 
 func (th *TestHarness) Stop() error {

--- a/solidity/ProxyFactory/ProxyFactory.sol
+++ b/solidity/ProxyFactory/ProxyFactory.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.8.0;
+
+contract ProxyFactory {
+    function createContract(bytes memory code) public returns (address addr) {
+        assembly {
+            addr := create(0, add(code, 0x20), mload(code))
+            if iszero(extcodesize(addr)) { revert(0, 0) }
+        }
+    }
+}

--- a/solidity/ProxyFactory/ProxyFactory.sol
+++ b/solidity/ProxyFactory/ProxyFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 contract ProxyFactory {


### PR DESCRIPTION
### Description
1. Extends integration harness with a CREATE-based ProxyFactory fixture and strengthens the existing Uniswap CREATE2 path.
2. Adds endorsement RW-set assertions to confirm child contract code/storage writes are captured and persist after commit.
3. Validates success and failure paths for factory deployments using existing endorsementToRWS flow.
4. Keeps execution plumbing unchanged (still using geth ApplyMessage and existing StateDB journaling).


### Tests
- go test ./integration -run TestLocal -count=1
- go test ./integration -run TestLocalX -count=1

### Related Issues
#47 