### PR TITLE
Use lightweight in-memory key-value store

### DIFF
--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -20,7 +20,6 @@ import (
 	sdknet "github.com/hyperledger/fabric-x-sdk/network"
 	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
 	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
-	"github.com/hyperledger/fabric-x-sdk/state"
 )
 
 // NewEndorser creates a single endorser instance with its synchronizer.
@@ -37,14 +36,9 @@ func NewEndorser(
 		return nil, nil, fmt.Errorf("failed to create signer: %w", err)
 	}
 
-	writeDB, err := state.NewWriteDB(network.Channel, cfg.DbConnStr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize store: %w", err)
-	}
-	readDB, err := state.NewReadDB(network.Channel, cfg.DbConnStr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize store: %w", err)
-	}
+	// Create LightKVS for in-memory versioned state
+	// TODO: when we have it with persistence, instantiate from config
+	kvs := endorser.NewLightKVS()
 
 	evmConfig := endorser.EVMConfig{
 		ChainConfig: common.BuildChainConfig(network.ChainID),
@@ -56,10 +50,10 @@ func NewEndorser(
 	switch network.Protocol {
 	case "fabric-x":
 		builder = efabx.NewEndorsementBuilder(signer)
-		sync, err = nfabx.NewSynchronizer(readDB, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, writeDB)
+		sync, err = nfabx.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
 	default: // "fabric" or ""
 		builder = efab.NewEndorsementBuilder(signer)
-		sync, err = nfab.NewSynchronizer(readDB, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, writeDB)
+		sync, err = nfab.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create synchronizer: %w", err)
@@ -68,7 +62,7 @@ func NewEndorser(
 	// Executing transactions and signing the endorsement.
 	monotonicVersions := network.Protocol == "fabric-x"
 	end, err := endorser.New(
-		endorser.NewEVMEngine(network.Namespace, readDB, evmConfig, monotonicVersions),
+		endorser.NewEVMEngine(network.Namespace, kvs, evmConfig, monotonicVersions),
 		builder,
 		network.ChainID,
 	)

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -14,8 +14,8 @@ import (
 	"regexp"
 
 	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-evm/common"
@@ -35,9 +35,20 @@ type PeerConf struct {
 
 // Endorser implements the ProcessProposal API to simulate the execution of ethereum transaction
 type Endorser struct {
-	engine    *EVMEngine
+	Engine    EVMEngineInterface // Exported to allow injection of wrappers
 	builder   endorsement.Builder
 	ethSigner types.Signer
+}
+
+// EVMEngineInterface defines the interface for EVM execution engines.
+// This allows both *EVMEngine and *testimpl.EVMEngineWrapper to be used.
+type EVMEngineInterface interface {
+	Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (endorsement.ExecutionResult, error)
+	Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	BalanceAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) (*big.Int, error)
+	StorageAt(ctx context.Context, account ethcommon.Address, key ethcommon.Hash, blockNumber *big.Int) ([]byte, error)
+	CodeAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) ([]byte, error)
+	NonceAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) (uint64, error)
 }
 
 // New returns a new Endorser.
@@ -48,20 +59,10 @@ type Endorser struct {
 //   - `chainID`: Ethereum chain ID used to validate transaction signatures.
 func New(engine *EVMEngine, builder endorsement.Builder, chainID int64) (*Endorser, error) {
 	return &Endorser{
-		engine:    engine,
+		Engine:    engine,
 		builder:   builder,
 		ethSigner: types.LatestSignerForChainID(big.NewInt(chainID)),
 	}, nil
-}
-
-// SetEthStateDB sets the ethStateDB on the underlying EVMEngine.
-func (f *Endorser) SetEthStateDB(ethStateDB *state.StateDB) {
-	f.engine.SetEthStateDB(ethStateDB)
-}
-
-// GetEthStateDB returns the ethStateDB from the underlying EVMEngine.
-func (f *Endorser) GetEthStateDB() *state.StateDB {
-	return f.engine.GetEthStateDB()
 }
 
 // ProcessEVMTransaction processes an Ethereum transaction and returns a signed proposal response
@@ -72,7 +73,7 @@ func (f *Endorser) ProcessEVMTransaction(ctx context.Context, inv endorsement.In
 	}
 
 	// Execute the transaction
-	res, err := f.engine.Execute(blockInfo, ethTx)
+	res, err := f.Engine.Execute(blockInfo, ethTx)
 	if err != nil {
 		// Distinguish between pre-execution validation errors and execution errors.
 		// Pre-execution errors (from ApplyMessage) indicate the transaction is invalid
@@ -97,7 +98,7 @@ func (f *Endorser) ProcessCall(ctx context.Context, callMsg *ethereum.CallMsg, b
 	if blockInfo != nil {
 		blockNumber = blockInfo.BlockNumber
 	}
-	res, err := f.engine.Call(*callMsg, blockNumber)
+	res, err := f.Engine.Call(*callMsg, blockNumber)
 
 	return response(res, err), nil
 }
@@ -110,17 +111,17 @@ func (f *Endorser) ProcessStateQuery(ctx context.Context, query common.StateQuer
 
 	switch query.Type {
 	case common.QueryTypeBalance:
-		bal, balErr := f.engine.BalanceAt(ctx, query.Account, query.BlockNumber)
+		bal, balErr := f.Engine.BalanceAt(ctx, query.Account, query.BlockNumber)
 		if balErr != nil {
 			return response(nil, balErr), nil
 		}
 		res = bal.Bytes()
 	case common.QueryTypeCode:
-		res, err = f.engine.CodeAt(ctx, query.Account, query.BlockNumber)
+		res, err = f.Engine.CodeAt(ctx, query.Account, query.BlockNumber)
 	case common.QueryTypeStorage:
-		res, err = f.engine.StorageAt(ctx, query.Account, query.Key, query.BlockNumber)
+		res, err = f.Engine.StorageAt(ctx, query.Account, query.Key, query.BlockNumber)
 	case common.QueryTypeNonce:
-		nonce, nonceErr := f.engine.NonceAt(ctx, query.Account, query.BlockNumber)
+		nonce, nonceErr := f.Engine.NonceAt(ctx, query.Account, query.BlockNumber)
 		if nonceErr != nil {
 			return response(nil, nonceErr), nil
 		}

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
-	ethstate "github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
@@ -49,9 +48,8 @@ type EVMEngine struct {
 	monotonicVersions bool
 
 	// LightKVS provides versioned storage with snapshot isolation
-	kvs        KVSSnapshotter
-	ethStateDB *ethstate.StateDB
-	evmConfig  EVMConfig
+	kvs       KVSSnapshotter
+	evmConfig EVMConfig
 }
 
 // NewEVMEngine creates a new EVMEngine.
@@ -61,18 +59,7 @@ func NewEVMEngine(namespace string, kvs KVSSnapshotter, evmConfig EVMConfig, mon
 		kvs:               kvs,
 		monotonicVersions: monotonicVersions,
 		evmConfig:         evmConfig,
-		ethStateDB:        nil, // Will be set when priming state
 	}
-}
-
-// SetEthStateDB sets the ethStateDB for the EVMEngine.
-func (e *EVMEngine) SetEthStateDB(ethStateDB *ethstate.StateDB) {
-	e.ethStateDB = ethStateDB
-}
-
-// GetEthStateDB returns the ethStateDB from the EVMEngine.
-func (e *EVMEngine) GetEthStateDB() *ethstate.StateDB {
-	return e.ethStateDB
 }
 
 // Execute runs a state-changing transaction and returns the EVM result,
@@ -86,7 +73,7 @@ func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (
 	}
 	defer ex.Close()
 
-	ret, err := ex.send(tx)
+	ret, err := ex.Send(tx)
 	if err != nil {
 		return endorsement.ExecutionResult{}, err
 	}
@@ -115,7 +102,7 @@ func (e *EVMEngine) Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, er
 	}
 	defer ex.Close()
 
-	return ex.call(msg)
+	return ex.Call(msg)
 }
 
 func (e *EVMEngine) BalanceAt(_ context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
@@ -156,7 +143,7 @@ func (e *EVMEngine) NonceAt(_ context.Context, account common.Address, blockNumb
 
 // newExecutor creates a fresh executor with an isolated StateDB.
 // stateBlockNum selects the Fabric block height for the state snapshot (0 = latest).
-func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo, stateBlockNum uint64) (*executor, error) {
+func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo, stateBlockNum uint64) (*Executor, error) {
 	// Begin a new reader to get snapshot isolation
 	reader := e.kvs.NewSnapshot()
 
@@ -166,7 +153,7 @@ func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo, stateBlockNum uint64
 		reader.Close()
 		return nil, err
 	}
-	return newExecutor(stateDB, reader, blockInfo, e.evmConfig, e.ethStateDB)
+	return NewExecutor(stateDB, reader, blockInfo, e.evmConfig)
 }
 
 // newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height (0 = latest).
@@ -189,9 +176,8 @@ func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, ReadSt
 	return stateDB, reader, nil
 }
 
-// executor is a per-transaction EVM execution context. It is an internal type;
-// callers outside this package interact with EVMEngine instead.
-type executor struct {
+// Executor is a per-transaction EVM execution context.
+type Executor struct {
 	state    ExtendedStateDB
 	reader   ReadStore // reader that must be closed when done
 	chainCfg *params.ChainConfig
@@ -200,11 +186,12 @@ type executor struct {
 	freeGas  bool
 }
 
-// newExecutor creates an executor with the provided StateDB and reader.
+// NewExecutor creates an Executor with the provided StateDB and reader.
 // If blockInfo is not provided, the store's current version is used as the block number.
 // evmConfig.ChainConfig must be set.
-// The caller is responsible for closing the reader when done with the executor.
-func newExecutor(stateDB *StateDB, reader ReadStore, blockInfo *utils.BlockInfo, evmConfig EVMConfig, ethStateDB *ethstate.StateDB) (*executor, error) {
+// The caller is responsible for closing the reader when done with the Executor.
+// The stateDB parameter accepts ExtendedStateDB interface to allow DualStateDB for testing.
+func NewExecutor(stateDB ExtendedStateDB, reader ReadStore, blockInfo *utils.BlockInfo, evmConfig EVMConfig) (*Executor, error) {
 	if evmConfig.ChainConfig == nil {
 		return nil, fmt.Errorf("evmConfig.ChainConfig must be set")
 	}
@@ -251,19 +238,8 @@ func newExecutor(stateDB *StateDB, reader ReadStore, blockInfo *utils.BlockInfo,
 		vmConfig = *evmConfig.VMConfig
 	}
 
-	// if we have been given a non-nil ethStateDB instance, it means that we are meant
-	// to instantiate a dual state DB that uses the ethStateDB instance alongside the
-	// fabric state DB to handle state updates so that we can track eth root state evolution
-	var finalStateDB ExtendedStateDB
-	if ethStateDB == nil {
-		finalStateDB = stateDB
-	} else {
-		// NOTE: this is only meant to be used in testing
-		finalStateDB = NewDualStateDB(ethStateDB, stateDB)
-	}
-
-	return &executor{
-		state:    finalStateDB,
+	return &Executor{
+		state:    stateDB,
 		reader:   reader,
 		chainCfg: evmConfig.ChainConfig,
 		blockCtx: blockCtx,
@@ -273,8 +249,8 @@ func newExecutor(stateDB *StateDB, reader ReadStore, blockInfo *utils.BlockInfo,
 }
 
 // Close releases the reader's snapshot reference.
-// This should be called when the executor is done to allow garbage collection.
-func (h *executor) Close() error {
+// This should be called when the Executor is done to allow garbage collection.
+func (h *Executor) Close() error {
 	if h.reader != nil {
 		return h.reader.Close()
 	}
@@ -360,18 +336,18 @@ func CallMsgToMessage(msg ethereum.CallMsg, baseFee *big.Int, skipNonceCheck, sk
 	}
 }
 
-// call executes a read-only call (eth_call semantics).
+// Call executes a read-only call (eth_call semantics).
 // An empty revert is treated as a non-error: many Ethereum tools probe contracts this way.
-func (h *executor) call(msg ethereum.CallMsg) ([]byte, error) {
-	ret, err := h.execute(CallMsgToMessage(msg, h.blockCtx.BaseFee, true, true))
+func (h *Executor) Call(msg ethereum.CallMsg) ([]byte, error) {
+	ret, err := h.Execute(CallMsgToMessage(msg, h.blockCtx.BaseFee, true, true))
 	if errors.Is(err, vm.ErrExecutionReverted) && len(ret) == 0 {
 		return nil, nil // empty revert on a call is not an error
 	}
 	return ret, formatRevert(ret, err)
 }
 
-// send executes a state-changing transaction, increments the sender nonce and returns the result.
-func (h *executor) send(tx *types.Transaction) ([]byte, error) {
+// Send executes a state-changing transaction, increments the sender nonce and returns the result.
+func (h *Executor) Send(tx *types.Transaction) ([]byte, error) {
 	signer := types.MakeSigner(h.chainCfg, h.blockCtx.BlockNumber, h.blockCtx.Time)
 
 	from, err := types.Sender(signer, tx)
@@ -393,7 +369,7 @@ func (h *executor) send(tx *types.Transaction) ([]byte, error) {
 		return nil, err
 	}
 
-	ret, err := h.execute(msg)
+	ret, err := h.Execute(msg)
 	if err != nil {
 		return nil, formatRevert(ret, err)
 	}
@@ -401,9 +377,9 @@ func (h *executor) send(tx *types.Transaction) ([]byte, error) {
 	return ret, nil
 }
 
-// execute dispatches a call or deployment to the EVM using ApplyMessage.
+// Execute dispatches a call or deployment to the EVM using ApplyMessage.
 // A nil value defaults to 0; zero gas defaults to 5_000_000.
-func (h *executor) execute(msg *core.Message) ([]byte, error) {
+func (h *Executor) Execute(msg *core.Message) ([]byte, error) {
 	// Default gas limit to 5_000_000 if not set
 	if msg.GasLimit == 0 {
 		msg.GasLimit = 5_000_000

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -37,22 +37,29 @@ type EVMConfig struct {
 	FreeGas bool
 }
 
+type KVSSnapshotter interface {
+	NewSnapshot() ReadStore
+}
+
 // EVMEngine manages EVM execution and state reads for an endorser.
 // It creates isolated per-transaction snapshots for execution and reads state directly
 // for ChainStateReader calls.
 type EVMEngine struct {
 	namespace         string
 	monotonicVersions bool
-	db                ReadStore
-	ethStateDB        *ethstate.StateDB
-	evmConfig         EVMConfig
+
+	// LightKVS provides versioned storage with snapshot isolation
+	kvs        KVSSnapshotter
+	ethStateDB *ethstate.StateDB
+	evmConfig  EVMConfig
 }
 
 // NewEVMEngine creates a new EVMEngine.
-func NewEVMEngine(namespace string, db ReadStore, evmConfig EVMConfig, monotonicVersions bool) *EVMEngine {
+// The db parameter should be a KVSSnapshotter to provide snapshot isolation.
+func NewEVMEngine(namespace string, kvs KVSSnapshotter, evmConfig EVMConfig, monotonicVersions bool) *EVMEngine {
 	return &EVMEngine{
 		namespace:         namespace,
-		db:                db,
+		kvs:               kvs,
 		monotonicVersions: monotonicVersions,
 		evmConfig:         evmConfig,
 		ethStateDB:        nil, // Will be set when priming state
@@ -78,6 +85,8 @@ func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (
 	if err != nil {
 		return endorsement.ExecutionResult{}, err
 	}
+	defer ex.Close()
+
 	ret, err := ex.send(tx)
 	if err != nil {
 		return endorsement.ExecutionResult{}, err
@@ -105,87 +114,104 @@ func (e *EVMEngine) Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
+	defer ex.Close()
+
 	return ex.call(msg)
 }
 
 func (e *EVMEngine) BalanceAt(_ context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-	snap, err := e.newSnapshotAt(blockNumber)
+	snap, reader, err := e.newSnapshotAt(blockNumber)
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 	return snap.GetBalance(account).ToBig(), nil
 }
 
 func (e *EVMEngine) StorageAt(_ context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-	snap, err := e.newSnapshotAt(blockNumber)
+	snap, reader, err := e.newSnapshotAt(blockNumber)
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 	return snap.GetState(account, key).Bytes(), nil
 }
 
 func (e *EVMEngine) CodeAt(_ context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
-	snap, err := e.newSnapshotAt(blockNumber)
+	snap, reader, err := e.newSnapshotAt(blockNumber)
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 	return snap.GetCode(account), nil
 }
 
 func (e *EVMEngine) NonceAt(_ context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-	snap, err := e.newSnapshotAt(blockNumber)
+	snap, reader, err := e.newSnapshotAt(blockNumber)
 	if err != nil {
 		return 0, err
 	}
+	defer reader.Close()
 	return snap.GetNonce(account), nil
 }
 
 // newExecutor creates a fresh executor with an isolated StateDB.
 // stateBlockNum selects the Fabric block height for the state snapshot (0 = latest).
 func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo, stateBlockNum uint64) (*executor, error) {
-	stateDB, err := NewStateDB(context.TODO(), e.db, e.namespace, stateBlockNum, e.monotonicVersions)
+	// Begin a new reader to get snapshot isolation
+	reader := e.kvs.NewSnapshot()
+
+	// Create StateDB with the reader
+	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, stateBlockNum, e.monotonicVersions)
 	if err != nil {
+		reader.Close()
 		return nil, err
 	}
-	return newExecutor(stateDB, blockInfo, e.evmConfig, e.ethStateDB)
+	return newExecutor(stateDB, reader, blockInfo, e.evmConfig, e.ethStateDB)
 }
 
 // newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height (0 = latest).
-func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, error) {
+// The caller must close the returned reader when done.
+func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, ReadStore, error) {
 	blockNum := uint64(0)
 	if blockNumber != nil {
 		blockNum = blockNumber.Uint64()
 	}
-	stateDB, err := NewStateDB(context.TODO(), e.db, e.namespace, blockNum, e.monotonicVersions)
+
+	// Begin a new reader to get snapshot isolation
+	reader := e.kvs.NewSnapshot()
+
+	// Create StateDB with the reader
+	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, blockNum, e.monotonicVersions)
 	if err != nil {
-		return nil, err
+		reader.Close()
+		return nil, nil, err
 	}
-	return stateDB, nil
+	return stateDB, reader, nil
 }
 
 // executor is a per-transaction EVM execution context. It is an internal type;
 // callers outside this package interact with EVMEngine instead.
 type executor struct {
 	state    ExtendedStateDB
+	reader   ReadStore // reader that must be closed when done
 	chainCfg *params.ChainConfig
 	blockCtx vm.BlockContext
 	vmConfig vm.Config
 	freeGas  bool
 }
 
-// newExecutor creates an executor with the provided StateDB.
+// newExecutor creates an executor with the provided StateDB and reader.
 // If blockInfo is not provided, the store's current version is used as the block number.
 // evmConfig.ChainConfig must be set.
-func newExecutor(stateDB *StateDB, blockInfo *utils.BlockInfo, evmConfig EVMConfig, ethStateDB *ethstate.StateDB) (*executor, error) {
+// The caller is responsible for closing the reader when done with the executor.
+func newExecutor(stateDB *StateDB, reader ReadStore, blockInfo *utils.BlockInfo, evmConfig EVMConfig, ethStateDB *ethstate.StateDB) (*executor, error) {
 	if evmConfig.ChainConfig == nil {
 		return nil, fmt.Errorf("evmConfig.ChainConfig must be set")
 	}
 	if blockInfo == nil {
-		// Note: stateDB.Version() is a Fabric block number, not an Ethereum block number — these are
-		// separate namespaces. With all forks active from block 0 this is harmless,
-		// but callers executing real transactions should always supply blockInfo explicitly.
 		blockInfo = &utils.BlockInfo{
-			BlockNumber: new(big.Int).SetUint64(stateDB.Version()),
+			BlockNumber: new(big.Int),
 			BlockTime:   1_000_000,
 			GasLimit:    10_000_000,
 		}
@@ -239,11 +265,21 @@ func newExecutor(stateDB *StateDB, blockInfo *utils.BlockInfo, evmConfig EVMConf
 
 	return &executor{
 		state:    finalStateDB,
+		reader:   reader,
 		chainCfg: evmConfig.ChainConfig,
 		blockCtx: blockCtx,
 		vmConfig: vmConfig,
 		freeGas:  evmConfig.FreeGas,
 	}, nil
+}
+
+// Close releases the reader's snapshot reference.
+// This should be called when the executor is done to allow garbage collection.
+func (h *executor) Close() error {
+	if h.reader != nil {
+		return h.reader.Close()
+	}
+	return nil
 }
 
 // CallMsgToMessage converts an ethereum.CallMsg into a core.Message.

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -55,7 +55,6 @@ type EVMEngine struct {
 }
 
 // NewEVMEngine creates a new EVMEngine.
-// The db parameter should be a KVSSnapshotter to provide snapshot isolation.
 func NewEVMEngine(namespace string, kvs KVSSnapshotter, evmConfig EVMConfig, monotonicVersions bool) *EVMEngine {
 	return &EVMEngine{
 		namespace:         namespace,

--- a/endorser/lightkvs.go
+++ b/endorser/lightkvs.go
@@ -1,0 +1,359 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+// Package endorser implements a lightweight versioned key-value store (LightKVS)
+// with snapshot isolation for concurrent readers and a single writer.
+//
+// LightKVS uses structural sharing with atomic pointer swaps to provide:
+// - Lock-free reads with snapshot isolation
+// - Atomic batch updates
+// - Automatic garbage collection via Go's GC
+// - Space-efficient storage (only changed values are copied)
+//
+// Design:
+// - Each snapshot is a map[string]*ValueVersion
+// - Writer creates new snapshot by cloning the map and updating changed entries
+// - Readers hold references to their snapshot, preventing GC
+// - Go's GC automatically cleans up unreferenced snapshots and values
+package endorser
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sync/atomic"
+
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+)
+
+var (
+	// ErrKeyNotFound is returned when a key is not found in the store.
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+// LightKVS is a lightweight versioned key-value store with snapshot isolation.
+// It supports concurrent readers and a single writer.
+type LightKVS struct {
+	// Atomic pointer to current snapshot
+	// Readers get this atomically, writers swap it atomically
+	current atomic.Pointer[Snapshot]
+}
+
+// Snapshot represents an immutable point-in-time view of the key-value store.
+type Snapshot struct {
+	// blockNumber is the block number of this snapshot
+	blockNumber uint64
+
+	// Map from key to pointer to immutable value
+	// Multiple snapshots can share pointers to unchanged values
+	data map[string]*ValueVersion
+}
+
+// ValueVersion represents a versioned value in the store.
+type ValueVersion struct {
+	// Value is the binary blob stored for this key
+	Value []byte
+
+	// BlockNum is the block number where this write occurred
+	BlockNum uint64
+
+	// TxNum is the transaction number within the block
+	TxNum uint64
+
+	// Version is the monotonically increasing version number for this key
+	Version uint64
+
+	// TxID is the transaction ID
+	TxID string
+}
+
+// Reader provides a consistent view of the store at a specific point in time.
+// All Get operations see the state as it was when Begin() was called.
+// Reader implements the ReadStore interface for compatibility with StateDB.
+type Reader struct {
+	// snapshot holds a reference to the immutable snapshot
+	// This prevents the snapshot from being garbage collected
+	snapshot *Snapshot
+
+	// kvs reference for BlockNumber queries
+	kvs *LightKVS
+}
+
+// KeyValueVersion represents a key-value pair with version for batch updates.
+type KeyValueVersion struct {
+	Key      string
+	Value    []byte // Can be nil for storing nil values
+	BlockNum uint64
+	TxNum    uint64
+	TxID     string
+	IsDelete bool // True to delete the key, false to store Value (even if nil)
+}
+
+// truncateValue truncates a byte slice to maxLen bytes for logging
+func truncateValue(v []byte, maxLen int) string {
+	if v == nil {
+		return "<nil>"
+	}
+	if len(v) <= maxLen {
+		return fmt.Sprintf("%x", v)
+	}
+	return fmt.Sprintf("%x...", v[:maxLen])
+}
+
+// logUpdate is a helper type for JSON logging with truncated values
+type logUpdate struct {
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	BlockNum uint64 `json:"block_num"`
+	TxNum    uint64 `json:"tx_num"`
+	TxID     string `json:"tx_id"`
+	IsDelete bool   `json:"is_delete"`
+}
+
+func (u KeyValueVersion) toLogUpdate() logUpdate {
+	return logUpdate{
+		Key:      u.Key,
+		Value:    truncateValue(u.Value, 20),
+		BlockNum: u.BlockNum,
+		TxNum:    u.TxNum,
+		TxID:     u.TxID,
+		IsDelete: u.IsDelete,
+	}
+}
+
+// NewLightKVS creates a new empty versioned key-value store.
+func NewLightKVS() *LightKVS {
+	kvs := &LightKVS{}
+	initial := &Snapshot{
+		blockNumber: 0,
+		data:        make(map[string]*ValueVersion),
+	}
+	kvs.current.Store(initial)
+	return kvs
+}
+
+// NewSnapshot starts a new read transaction and returns a Reader.
+// The Reader will see a consistent snapshot of the store at this point in time,
+// regardless of subsequent writes.
+//
+// Readers must call Close() when done to allow garbage collection of old snapshots.
+func (kvs *LightKVS) NewSnapshot() ReadStore {
+	// Atomically load the current snapshot
+	snapshot := kvs.current.Load()
+
+	// Return a reader that holds a reference to this snapshot
+	return &Reader{
+		snapshot: snapshot,
+		kvs:      kvs,
+	}
+}
+
+func (kvs *LightKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error) {
+	r := kvs.NewSnapshot()
+	defer r.Close()
+
+	return r.Get(namespace, key)
+}
+
+// Get retrieves the value and version for a key from the reader's snapshot.
+// This implements the ReadStore interface with the signature:
+// Get(namespace, key string) (*blocks.WriteRecord, error)
+func (r *Reader) Get(namespace, key string) (*blocks.WriteRecord, error) {
+	if r.snapshot == nil {
+		return nil, errors.New("reader is closed")
+	}
+
+	// Prepend namespace to key
+	fullKey := namespace + ":" + key
+
+	if vv, ok := r.snapshot.data[fullKey]; ok {
+		record := &blocks.WriteRecord{
+			Namespace: namespace,
+			Key:       key,
+			BlockNum:  vv.BlockNum,
+			TxNum:     vv.TxNum,
+			Version:   vv.Version,
+			Value:     vv.Value,
+			IsDelete:  false,
+			TxID:      vv.TxID,
+		}
+
+		if false {
+			// Debug: JSON dump the record with truncated value
+			logRec := map[string]interface{}{
+				"namespace": namespace,
+				"key":       key,
+				"block_num": vv.BlockNum,
+				"tx_num":    vv.TxNum,
+				"version":   vv.Version,
+				"value":     truncateValue(vv.Value, 20),
+				"tx_id":     vv.TxID,
+			}
+			if jsonData, err := json.MarshalIndent(logRec, "", "  "); err == nil {
+				fmt.Printf("[LightKVS Get] %s\n", string(jsonData))
+			}
+		}
+
+		return record, nil
+	}
+
+	if false {
+		// Key not found - return nil record (not an error)
+		fmt.Printf("[LightKVS Get] key not found: %s\n", fullKey)
+	}
+	return nil, nil
+}
+
+// Close releases the reader's reference to its snapshot.
+// After Close(), the reader cannot be used for further Get operations.
+// This allows Go's GC to clean up the snapshot if no other readers reference it.
+func (r *Reader) Close() error {
+	r.snapshot = nil
+	return nil
+}
+
+// Update atomically applies a batch of updates to the store.
+// All updates are applied together in a single new snapshot.
+//
+// This operation:
+// 1. Clones the current snapshot's map (shallow copy - shares unchanged value pointers)
+// 2. Updates only the changed entries with new ValueVersion structs or deletes them
+// 3. Atomically swaps in the new snapshot
+//
+// The single writer assumption means no locking is needed for the update itself.
+func (kvs *LightKVS) Update(updates []KeyValueVersion) error {
+	// Load current snapshot
+	oldSnapshot := kvs.current.Load()
+
+	// Shallow clone the map - copies map structure, shares value pointers
+	// This is O(n) but highly optimized in Go's runtime
+	newData := maps.Clone(oldSnapshot.data)
+
+	// Update changed entries with new ValueVersion structs
+	// Only these allocations are new; unchanged entries share pointers
+	for _, update := range updates {
+		if update.IsDelete {
+			// Delete: remove the key from the map
+			delete(newData, update.Key)
+		} else {
+			// Compute next version for this key: existing version + 1, or 0 if new
+			nextVersion := uint64(0)
+			if existing, ok := oldSnapshot.data[update.Key]; ok {
+				nextVersion = existing.Version + 1
+			}
+
+			// Update: set new value (Value can be nil, which is a valid stored value)
+			newData[update.Key] = &ValueVersion{
+				Value:    update.Value,
+				BlockNum: update.BlockNum,
+				TxNum:    update.TxNum,
+				Version:  nextVersion,
+				TxID:     update.TxID,
+			}
+
+			if false {
+				// Debug: JSON dump the record with truncated value
+				logRec := map[string]interface{}{
+					"key":       update.Key,
+					"block_num": update.BlockNum,
+					"tx_num":    update.TxNum,
+					"version":   nextVersion,
+					"value":     truncateValue(update.Value, 20),
+					"tx_id":     update.TxID,
+				}
+				if jsonData, err := json.MarshalIndent(logRec, "", "  "); err == nil {
+					fmt.Printf("[LightKVS Put] %s\n", string(jsonData))
+				}
+			}
+
+		}
+	}
+
+	// Create new snapshot with the block number from updates
+	// All updates in a batch come from the same block
+	blockNum := uint64(0)
+	if len(updates) > 0 {
+		blockNum = updates[0].BlockNum
+	}
+	newSnapshot := &Snapshot{
+		blockNumber: blockNum,
+		data:        newData,
+	}
+
+	// Atomically swap in the new snapshot
+	// New readers will see this snapshot; existing readers keep their old snapshot
+	kvs.current.Store(newSnapshot)
+
+	return nil
+}
+
+// Handle implements the blocks.BlockHandler interface.
+// It processes a block by extracting all valid transaction writes and applying them atomically.
+// This is called by the synchronizer when a new block is committed to the ledger.
+func (kvs *LightKVS) Handle(ctx context.Context, b blocks.Block) error {
+	// Collect all writes from all valid transactions in the block
+	var updates []KeyValueVersion
+
+	for _, tx := range b.Transactions {
+		if !tx.Valid {
+			continue
+		}
+
+		// Process all namespace read-write sets
+		for _, nsrws := range tx.NsRWS {
+			// Process all writes in this namespace
+			for _, w := range nsrws.RWS.Writes {
+				// Create a key that includes the namespace
+				key := nsrws.Namespace + ":" + w.Key
+
+				updates = append(updates, KeyValueVersion{
+					Key:      key,
+					Value:    w.Value,
+					BlockNum: b.Number,
+					TxNum:    uint64(tx.Number),
+					TxID:     tx.ID,
+					IsDelete: w.IsDelete,
+				})
+			}
+		}
+	}
+
+	// Debug: JSON dump all updates with truncated values
+	if len(updates) > 0 {
+		logUpdates := make([]logUpdate, len(updates))
+		for i, u := range updates {
+			logUpdates[i] = u.toLogUpdate()
+		}
+
+		if false {
+			if jsonData, err := json.MarshalIndent(logUpdates, "", "  "); err == nil {
+				fmt.Printf("[LightKVS Handle] Block %d, %d updates:\n%s\n", b.Number, len(updates), string(jsonData))
+			}
+		}
+	}
+
+	// Apply all updates atomically
+	if len(updates) > 0 {
+		return kvs.Update(updates)
+	}
+
+	return nil
+}
+
+// BlockNumber returns the current snapshot block number.
+// This implements the BlockHeightReader interface for the synchronizer.
+func (kvs *LightKVS) BlockNumber(ctx context.Context) (uint64, error) {
+	snapshot := kvs.current.Load()
+	return snapshot.blockNumber, nil
+}
+
+// Close is a no-op for LightKVS since there are no resources to clean up.
+// It's provided for interface compatibility.
+func (kvs *LightKVS) Close() error {
+	return nil
+}

--- a/endorser/lightkvs.go
+++ b/endorser/lightkvs.go
@@ -4,20 +4,6 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: LGPL-3.0-or-later
 */
 
-// Package endorser implements a lightweight versioned key-value store (LightKVS)
-// with snapshot isolation for concurrent readers and a single writer.
-//
-// LightKVS uses structural sharing with atomic pointer swaps to provide:
-// - Lock-free reads with snapshot isolation
-// - Atomic batch updates
-// - Automatic garbage collection via Go's GC
-// - Space-efficient storage (only changed values are copied)
-//
-// Design:
-// - Each snapshot is a map[string]*ValueVersion
-// - Writer creates new snapshot by cloning the map and updating changed entries
-// - Readers hold references to their snapshot, preventing GC
-// - Go's GC automatically cleans up unreferenced snapshots and values
 package endorser
 
 import (

--- a/endorser/lightkvs_test.go
+++ b/endorser/lightkvs_test.go
@@ -1,0 +1,1145 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package endorser
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+)
+
+// TestNewLightKVS tests the creation of a new LightKVS instance
+func TestNewLightKVS(t *testing.T) {
+	kvs := NewLightKVS()
+	if kvs == nil {
+		t.Fatal("NewLightKVS returned nil")
+	}
+
+	// Verify initial snapshot exists and is empty
+	snapshot := kvs.current.Load()
+	if snapshot == nil {
+		t.Fatal("initial snapshot is nil")
+	}
+	if snapshot.blockNumber != 0 {
+		t.Errorf("expected initial block number 0, got %d", snapshot.blockNumber)
+	}
+	if len(snapshot.data) != 0 {
+		t.Errorf("expected empty initial data, got %d entries", len(snapshot.data))
+	}
+}
+
+// TestNewSnapshot tests creating a new snapshot reader
+func TestNewSnapshot(t *testing.T) {
+	kvs := NewLightKVS()
+	reader := kvs.NewSnapshot()
+	if reader == nil {
+		t.Fatal("NewSnapshot returned nil")
+	}
+
+	// Verify reader is of correct type
+	r, ok := reader.(*Reader)
+	if !ok {
+		t.Fatal("NewSnapshot did not return a *Reader")
+	}
+	if r.snapshot == nil {
+		t.Error("reader snapshot is nil")
+	}
+	if r.kvs != kvs {
+		t.Error("reader kvs reference is incorrect")
+	}
+}
+
+// TestReaderGet tests reading values from a snapshot
+func TestReaderGet(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add some data
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+		{
+			Key:      "ns1:key2",
+			Value:    []byte("value2"),
+			BlockNum: 1,
+			TxNum:    1,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Create reader and test Get
+	reader := kvs.NewSnapshot().(*Reader)
+	defer reader.Close()
+
+	// Test existing key
+	record, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected record, got nil")
+	}
+	if record.Namespace != "ns1" {
+		t.Errorf("expected namespace 'ns1', got '%s'", record.Namespace)
+	}
+	if record.Key != "key1" {
+		t.Errorf("expected key 'key1', got '%s'", record.Key)
+	}
+	if string(record.Value) != "value1" {
+		t.Errorf("expected value 'value1', got '%s'", string(record.Value))
+	}
+	if record.BlockNum != 1 {
+		t.Errorf("expected block num 1, got %d", record.BlockNum)
+	}
+	if record.TxNum != 0 {
+		t.Errorf("expected tx num 0, got %d", record.TxNum)
+	}
+	if record.TxID != "tx1" {
+		t.Errorf("expected tx id 'tx1', got '%s'", record.TxID)
+	}
+	if record.Version != 0 {
+		t.Errorf("expected version 0, got %d", record.Version)
+	}
+
+	// Test non-existent key
+	record, err = reader.Get("ns1", "nonexistent")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record != nil {
+		t.Errorf("expected nil record for non-existent key, got %v", record)
+	}
+}
+
+// TestReaderGetNilValue tests reading a nil value
+func TestReaderGetNilValue(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add a key with nil value
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    nil,
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	reader := kvs.NewSnapshot().(*Reader)
+	defer reader.Close()
+
+	record, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected record, got nil")
+	}
+	if record.Value != nil {
+		t.Errorf("expected nil value, got %v", record.Value)
+	}
+}
+
+// TestReaderClose tests closing a reader
+func TestReaderClose(t *testing.T) {
+	kvs := NewLightKVS()
+	reader := kvs.NewSnapshot().(*Reader)
+
+	// Close the reader
+	err := reader.Close()
+	if err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// Verify snapshot is nil after close
+	if reader.snapshot != nil {
+		t.Error("snapshot should be nil after Close")
+	}
+
+	// Verify Get returns error after close
+	_, err = reader.Get("ns1", "key1")
+	if err == nil {
+		t.Error("expected error when calling Get on closed reader")
+	}
+	if err.Error() != "reader is closed" {
+		t.Errorf("expected 'reader is closed' error, got '%v'", err)
+	}
+}
+
+// TestUpdate tests updating the store
+func TestUpdate(t *testing.T) {
+	kvs := NewLightKVS()
+
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+		{
+			Key:      "ns1:key2",
+			Value:    []byte("value2"),
+			BlockNum: 1,
+			TxNum:    1,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Verify data was updated
+	snapshot := kvs.current.Load()
+	if snapshot.blockNumber != 1 {
+		t.Errorf("expected block number 1, got %d", snapshot.blockNumber)
+	}
+	if len(snapshot.data) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(snapshot.data))
+	}
+
+	// Verify values
+	vv1 := snapshot.data["ns1:key1"]
+	if vv1 == nil {
+		t.Fatal("key1 not found")
+	}
+	if string(vv1.Value) != "value1" {
+		t.Errorf("expected 'value1', got '%s'", string(vv1.Value))
+	}
+	if vv1.Version != 0 {
+		t.Errorf("expected version 0, got %d", vv1.Version)
+	}
+
+	vv2 := snapshot.data["ns1:key2"]
+	if vv2 == nil {
+		t.Fatal("key2 not found")
+	}
+	if string(vv2.Value) != "value2" {
+		t.Errorf("expected 'value2', got '%s'", string(vv2.Value))
+	}
+}
+
+// TestUpdateVersionIncrement tests that versions increment correctly
+func TestUpdateVersionIncrement(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// First update
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	snapshot := kvs.current.Load()
+	if snapshot.data["ns1:key1"].Version != 0 {
+		t.Errorf("expected version 0, got %d", snapshot.data["ns1:key1"].Version)
+	}
+
+	// Second update to same key
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value2"),
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	snapshot = kvs.current.Load()
+	if snapshot.data["ns1:key1"].Version != 1 {
+		t.Errorf("expected version 1, got %d", snapshot.data["ns1:key1"].Version)
+	}
+
+	// Third update
+	updates3 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value3"),
+			BlockNum: 3,
+			TxNum:    0,
+			TxID:     "tx3",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates3)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	snapshot = kvs.current.Load()
+	if snapshot.data["ns1:key1"].Version != 2 {
+		t.Errorf("expected version 2, got %d", snapshot.data["ns1:key1"].Version)
+	}
+}
+
+// TestUpdateDelete tests deleting keys
+func TestUpdateDelete(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add a key
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Verify key exists
+	snapshot := kvs.current.Load()
+	if _, ok := snapshot.data["ns1:key1"]; !ok {
+		t.Fatal("key1 should exist")
+	}
+
+	// Delete the key
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			IsDelete: true,
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx2",
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Verify key is deleted
+	snapshot = kvs.current.Load()
+	if _, ok := snapshot.data["ns1:key1"]; ok {
+		t.Error("key1 should be deleted")
+	}
+}
+
+// TestUpdateEmptyBatch tests updating with an empty batch
+func TestUpdateEmptyBatch(t *testing.T) {
+	kvs := NewLightKVS()
+
+	err := kvs.Update([]KeyValueVersion{})
+	if err != nil {
+		t.Fatalf("Update with empty batch failed: %v", err)
+	}
+
+	snapshot := kvs.current.Load()
+	if snapshot.blockNumber != 0 {
+		t.Errorf("expected block number 0, got %d", snapshot.blockNumber)
+	}
+}
+
+// TestSnapshotIsolation tests that readers see a consistent snapshot
+func TestSnapshotIsolation(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Initial data
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Create reader before update
+	reader1 := kvs.NewSnapshot().(*Reader)
+	defer reader1.Close()
+
+	// Update the store
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value2"),
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Create reader after update
+	reader2 := kvs.NewSnapshot().(*Reader)
+	defer reader2.Close()
+
+	// Reader1 should see old value
+	record1, err := reader1.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record1.Value) != "value1" {
+		t.Errorf("reader1 expected 'value1', got '%s'", string(record1.Value))
+	}
+
+	// Reader2 should see new value
+	record2, err := reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record2.Value) != "value2" {
+		t.Errorf("reader2 expected 'value2', got '%s'", string(record2.Value))
+	}
+}
+
+// TestConcurrentReaders tests multiple concurrent readers
+func TestConcurrentReaders(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add initial data
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Create multiple readers concurrently
+	numReaders := 100
+	var wg sync.WaitGroup
+	wg.Add(numReaders)
+
+	for i := 0; i < numReaders; i++ {
+		go func() {
+			defer wg.Done()
+			reader := kvs.NewSnapshot().(*Reader)
+			defer reader.Close()
+
+			record, err := reader.Get("ns1", "key1")
+			if err != nil {
+				t.Errorf("Get failed: %v", err)
+				return
+			}
+			if record == nil {
+				t.Error("expected record, got nil")
+				return
+			}
+			if string(record.Value) != "value1" {
+				t.Errorf("expected 'value1', got '%s'", string(record.Value))
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestHandle tests the Handle method with blocks
+func TestHandle(t *testing.T) {
+	kvs := NewLightKVS()
+	ctx := context.Background()
+
+	// Create a block with transactions
+	block := blocks.Block{
+		Number: 1,
+		Transactions: []blocks.Transaction{
+			{
+				ID:     "tx1",
+				Number: 0,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns1",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key1",
+									Value:    []byte("value1"),
+									IsDelete: false,
+								},
+								{
+									Key:      "key2",
+									Value:    []byte("value2"),
+									IsDelete: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:     "tx2",
+				Number: 1,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns2",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key3",
+									Value:    []byte("value3"),
+									IsDelete: false,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := kvs.Handle(ctx, block)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	// Verify data was stored
+	reader := kvs.NewSnapshot().(*Reader)
+	defer reader.Close()
+
+	record1, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record1 == nil {
+		t.Fatal("expected record1, got nil")
+	}
+	if string(record1.Value) != "value1" {
+		t.Errorf("expected 'value1', got '%s'", string(record1.Value))
+	}
+	if record1.TxID != "tx1" {
+		t.Errorf("expected tx id 'tx1', got '%s'", record1.TxID)
+	}
+
+	record2, err := reader.Get("ns1", "key2")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record2 == nil {
+		t.Fatal("expected record2, got nil")
+	}
+	if string(record2.Value) != "value2" {
+		t.Errorf("expected 'value2', got '%s'", string(record2.Value))
+	}
+
+	record3, err := reader.Get("ns2", "key3")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record3 == nil {
+		t.Fatal("expected record3, got nil")
+	}
+	if string(record3.Value) != "value3" {
+		t.Errorf("expected 'value3', got '%s'", string(record3.Value))
+	}
+	if record3.TxID != "tx2" {
+		t.Errorf("expected tx id 'tx2', got '%s'", record3.TxID)
+	}
+}
+
+// TestHandleInvalidTransactions tests that invalid transactions are skipped
+func TestHandleInvalidTransactions(t *testing.T) {
+	kvs := NewLightKVS()
+	ctx := context.Background()
+
+	block := blocks.Block{
+		Number: 1,
+		Transactions: []blocks.Transaction{
+			{
+				ID:     "tx1",
+				Number: 0,
+				Valid:  false, // Invalid transaction
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns1",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key1",
+									Value:    []byte("value1"),
+									IsDelete: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:     "tx2",
+				Number: 1,
+				Valid:  true, // Valid transaction
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns1",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key2",
+									Value:    []byte("value2"),
+									IsDelete: false,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := kvs.Handle(ctx, block)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	reader := kvs.NewSnapshot().(*Reader)
+	defer reader.Close()
+
+	// key1 from invalid tx should not exist
+	record1, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record1 != nil {
+		t.Error("key1 from invalid transaction should not exist")
+	}
+
+	// key2 from valid tx should exist
+	record2, err := reader.Get("ns1", "key2")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record2 == nil {
+		t.Fatal("expected record2, got nil")
+	}
+	if string(record2.Value) != "value2" {
+		t.Errorf("expected 'value2', got '%s'", string(record2.Value))
+	}
+}
+
+// TestHandleDeletes tests handling delete operations
+func TestHandleDeletes(t *testing.T) {
+	kvs := NewLightKVS()
+	ctx := context.Background()
+
+	// First, add a key
+	block1 := blocks.Block{
+		Number: 1,
+		Transactions: []blocks.Transaction{
+			{
+				ID:     "tx1",
+				Number: 0,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns1",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key1",
+									Value:    []byte("value1"),
+									IsDelete: false,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := kvs.Handle(ctx, block1)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	// Verify key exists
+	reader1 := kvs.NewSnapshot().(*Reader)
+	record1, err := reader1.Get("ns1", "key1")
+	reader1.Close()
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record1 == nil {
+		t.Fatal("expected record1, got nil")
+	}
+
+	// Now delete the key
+	block2 := blocks.Block{
+		Number: 2,
+		Transactions: []blocks.Transaction{
+			{
+				ID:     "tx2",
+				Number: 0,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: "ns1",
+						RWS: blocks.ReadWriteSet{
+							Writes: []blocks.KVWrite{
+								{
+									Key:      "key1",
+									IsDelete: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = kvs.Handle(ctx, block2)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	// Verify key is deleted
+	reader2 := kvs.NewSnapshot().(*Reader)
+	defer reader2.Close()
+	record2, err := reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record2 != nil {
+		t.Error("key1 should be deleted")
+	}
+}
+
+// TestHandleEmptyBlock tests handling a block with no transactions
+func TestHandleEmptyBlock(t *testing.T) {
+	kvs := NewLightKVS()
+	ctx := context.Background()
+
+	block := blocks.Block{
+		Number:       1,
+		Transactions: []blocks.Transaction{},
+	}
+
+	err := kvs.Handle(ctx, block)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	// Block number should not change for empty blocks
+	snapshot := kvs.current.Load()
+	if snapshot.blockNumber != 0 {
+		t.Errorf("expected block number 0, got %d", snapshot.blockNumber)
+	}
+}
+
+// TestBlockNumber tests the BlockNumber method
+func TestBlockNumber(t *testing.T) {
+	kvs := NewLightKVS()
+	ctx := context.Background()
+
+	// Initial block number should be 0
+	blockNum, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber failed: %v", err)
+	}
+	if blockNum != 0 {
+		t.Errorf("expected block number 0, got %d", blockNum)
+	}
+
+	// Update with block 5
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 5,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Block number should be 5
+	blockNum, err = kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber failed: %v", err)
+	}
+	if blockNum != 5 {
+		t.Errorf("expected block number 5, got %d", blockNum)
+	}
+}
+
+// TestClose tests the Close method
+func TestClose(t *testing.T) {
+	kvs := NewLightKVS()
+
+	err := kvs.Close()
+	if err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+}
+
+// TestGetMethod tests the Get method on LightKVS
+func TestGetMethod(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add data
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Test Get method
+	record, err := kvs.Get("ns1", "key1", 0)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected record, got nil")
+	}
+	if string(record.Value) != "value1" {
+		t.Errorf("expected 'value1', got '%s'", string(record.Value))
+	}
+}
+
+// TestTruncateValue tests the truncateValue helper function
+func TestTruncateValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    []byte
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "nil value",
+			value:    nil,
+			maxLen:   10,
+			expected: "<nil>",
+		},
+		{
+			name:     "short value",
+			value:    []byte{0x01, 0x02, 0x03},
+			maxLen:   10,
+			expected: "010203",
+		},
+		{
+			name:     "long value",
+			value:    []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b},
+			maxLen:   5,
+			expected: "0102030405...",
+		},
+		{
+			name:     "exact length",
+			value:    []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			maxLen:   5,
+			expected: "0102030405",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateValue(tt.value, tt.maxLen)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestKeyValueVersionToLogUpdate tests the toLogUpdate method
+func TestKeyValueVersionToLogUpdate(t *testing.T) {
+	kvv := KeyValueVersion{
+		Key:      "test:key",
+		Value:    []byte{0x01, 0x02, 0x03},
+		BlockNum: 10,
+		TxNum:    5,
+		TxID:     "tx123",
+		IsDelete: false,
+	}
+
+	logUpdate := kvv.toLogUpdate()
+
+	if logUpdate.Key != "test:key" {
+		t.Errorf("expected key 'test:key', got '%s'", logUpdate.Key)
+	}
+	if logUpdate.Value != "010203" {
+		t.Errorf("expected value '010203', got '%s'", logUpdate.Value)
+	}
+	if logUpdate.BlockNum != 10 {
+		t.Errorf("expected block num 10, got %d", logUpdate.BlockNum)
+	}
+	if logUpdate.TxNum != 5 {
+		t.Errorf("expected tx num 5, got %d", logUpdate.TxNum)
+	}
+	if logUpdate.TxID != "tx123" {
+		t.Errorf("expected tx id 'tx123', got '%s'", logUpdate.TxID)
+	}
+	if logUpdate.IsDelete != false {
+		t.Errorf("expected is_delete false, got %v", logUpdate.IsDelete)
+	}
+}
+
+// TestMultipleNamespaces tests handling multiple namespaces
+func TestMultipleNamespaces(t *testing.T) {
+	kvs := NewLightKVS()
+
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+		{
+			Key:      "ns2:key1",
+			Value:    []byte("value2"),
+			BlockNum: 1,
+			TxNum:    1,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+		{
+			Key:      "ns1:key2",
+			Value:    []byte("value3"),
+			BlockNum: 1,
+			TxNum:    2,
+			TxID:     "tx3",
+			IsDelete: false,
+		},
+	}
+
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	reader := kvs.NewSnapshot().(*Reader)
+	defer reader.Close()
+
+	// Test ns1:key1
+	record1, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record1 == nil || string(record1.Value) != "value1" {
+		t.Error("ns1:key1 mismatch")
+	}
+
+	// Test ns2:key1
+	record2, err := reader.Get("ns2", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record2 == nil || string(record2.Value) != "value2" {
+		t.Error("ns2:key1 mismatch")
+	}
+
+	// Test ns1:key2
+	record3, err := reader.Get("ns1", "key2")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record3 == nil || string(record3.Value) != "value3" {
+		t.Error("ns1:key2 mismatch")
+	}
+}
+
+// TestStructuralSharing tests that unchanged values are shared between snapshots
+func TestStructuralSharing(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add initial data
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+		{
+			Key:      "ns1:key2",
+			Value:    []byte("value2"),
+			BlockNum: 1,
+			TxNum:    1,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	snapshot1 := kvs.current.Load()
+	ptr1 := snapshot1.data["ns1:key1"]
+
+	// Update only key2
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key2",
+			Value:    []byte("value2-updated"),
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx3",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	snapshot2 := kvs.current.Load()
+	ptr2 := snapshot2.data["ns1:key1"]
+
+	// key1 should share the same pointer (structural sharing)
+	if ptr1 != ptr2 {
+		t.Error("expected structural sharing for unchanged key1")
+	}
+
+	// key2 should have a different pointer
+	ptr1_key2 := snapshot1.data["ns1:key2"]
+	ptr2_key2 := snapshot2.data["ns1:key2"]
+	if ptr1_key2 == ptr2_key2 {
+		t.Error("expected different pointer for updated key2")
+	}
+}
+
+// TestConcurrentReadersWithUpdates tests readers during concurrent updates
+func TestConcurrentReadersWithUpdates(t *testing.T) {
+	kvs := NewLightKVS()
+
+	// Add initial data
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	numReaders := 50
+	numUpdates := 50
+
+	// Start readers
+	wg.Add(numReaders)
+	for i := 0; i < numReaders; i++ {
+		go func(id int) {
+			defer wg.Done()
+			reader := kvs.NewSnapshot().(*Reader)
+			defer reader.Close()
+
+			// Each reader should see a consistent snapshot
+			record, err := reader.Get("ns1", "key1")
+			if err != nil {
+				t.Errorf("Reader %d: Get failed: %v", id, err)
+				return
+			}
+			if record == nil {
+				t.Errorf("Reader %d: expected record, got nil", id)
+				return
+			}
+			// Value should be one of the valid values
+			val := string(record.Value)
+			if val != "value1" && val != "value2" && val != "value3" {
+				t.Errorf("Reader %d: unexpected value '%s'", id, val)
+			}
+		}(i)
+	}
+
+	// Perform updates concurrently (single writer, but testing atomicity)
+	for i := 0; i < numUpdates; i++ {
+		updates := []KeyValueVersion{
+			{
+				Key:      "ns1:key1",
+				Value:    []byte("value2"),
+				BlockNum: uint64(i + 2),
+				TxNum:    0,
+				TxID:     "tx" + string(rune(i+2)),
+				IsDelete: false,
+			},
+		}
+		err := kvs.Update(updates)
+		if err != nil {
+			t.Fatalf("Update %d failed: %v", i, err)
+		}
+	}
+
+	wg.Wait()
+}

--- a/endorser/state_test.go
+++ b/endorser/state_test.go
@@ -118,8 +118,11 @@ func assertEqual[T comparable](t *testing.T, label string, got1, got2, expected 
 	}
 }
 
-func snapshotDB(t *testing.T, backend ReadStore, blockNum uint64) *StateDB {
-	stateDB, err := NewStateDB(t.Context(), backend, Namespace, blockNum, false)
+func snapshotDB(t *testing.T, backend *state.VersionedDB, blockNum uint64) *StateDB {
+	wrapper := NewVersionedDBWrapper(backend)
+	snapshot := wrapper.NewSnapshot()
+	t.Cleanup(func() { snapshot.Close() })
+	stateDB, err := NewStateDB(t.Context(), snapshot, Namespace, blockNum, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/endorser/statedb.go
+++ b/endorser/statedb.go
@@ -63,8 +63,8 @@ type Log struct {
 
 // ReadStore is the read interface required to back a StateDB.
 type ReadStore interface {
-	Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error)
-	BlockNumber(ctx context.Context) (uint64, error)
+	Get(namespace, key string) (*blocks.WriteRecord, error)
+	Close() error
 }
 
 // revision represents a snapshot point in the journal.
@@ -197,7 +197,6 @@ type accessListAddSlotEntry struct {
 type StateDB struct {
 	namespace         string
 	store             ReadStore
-	blockNum          uint64
 	logs              []Log
 	monotonicVersions bool // if true, KVRead.Version is built from WriteRecord.Version (fabric-x MVCC semantics)
 
@@ -218,17 +217,9 @@ type StateDB struct {
 // monotonicVersions controls MVCC semantics: when true, KVRead versions use the per-key
 // monotonic version counter (Fabric-X); when false, they use (blockNum, txNum) (standard Fabric).
 func NewStateDB(ctx context.Context, store ReadStore, namespace string, blockNum uint64, monotonicVersions bool) (*StateDB, error) {
-	if blockNum == 0 {
-		var err error
-		blockNum, err = store.BlockNumber(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return &StateDB{
 		namespace:         namespace,
 		store:             store,
-		blockNum:          blockNum,
 		monotonicVersions: monotonicVersions,
 		selfDestructed:    make(map[common.Address]struct{}),
 		accessList:        newAccessList(),
@@ -294,7 +285,7 @@ func (s *StateDB) getStateFromJournal(key string) ([]byte, bool) {
 // getStateFromStore reads from the underlying ReadStore and journals the read.
 // This creates an MVCC read dependency.
 func (s *StateDB) getStateFromStore(key string) ([]byte, error) {
-	record, err := s.store.Get(s.namespace, key, s.blockNum)
+	record, err := s.store.Get(s.namespace, key)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +488,7 @@ func (s *StateDB) SetState(addr common.Address, slot common.Hash, value common.H
 		}
 	} else {
 		// Not in journal, read directly from store WITHOUT creating a read dependency
-		record, err := s.store.Get(s.namespace, key, s.blockNum)
+		record, err := s.store.Get(s.namespace, key)
 		if err != nil {
 			panic(fmt.Errorf("SetState failed to get previous value: %w", err))
 		}
@@ -705,11 +696,6 @@ func (s *StateDB) Result() blocks.ReadWriteSet {
 // Logs returns all non-reverted logs.
 func (s *StateDB) Logs() []Log {
 	return s.logs
-}
-
-// Version returns the block height of this snapshot.
-func (s *StateDB) Version() uint64 {
-	return s.blockNum
 }
 
 // -------------------- Stub implementations for unused methods --------------------

--- a/endorser/testimpl/endorser_wrapper.go
+++ b/endorser/testimpl/endorser_wrapper.go
@@ -1,0 +1,43 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/hyperledger/fabric-x-evm/endorser"
+)
+
+// EndorserWrapper wraps an Endorser and adds ethStateDB management for testing.
+// It injects an EVMEngineWrapper into the endorser to provide DualStateDB support.
+type EndorserWrapper struct {
+	*endorser.Endorser
+	engineWrapper *EVMEngineWrapper
+}
+
+// NewEndorserWrapper creates a new EndorserWrapper by injecting the engine wrapper into the endorser.
+func NewEndorserWrapper(
+	end *endorser.Endorser,
+	engineWrapper *EVMEngineWrapper,
+) *EndorserWrapper {
+	// Inject the engine wrapper into the endorser
+	end.Engine = engineWrapper
+
+	return &EndorserWrapper{
+		Endorser:      end,
+		engineWrapper: engineWrapper,
+	}
+}
+
+// SetEthStateDB sets the ethStateDB for testing purposes.
+func (w *EndorserWrapper) SetEthStateDB(ethStateDB *state.StateDB) {
+	w.engineWrapper.SetEthStateDB(ethStateDB)
+}
+
+// GetEthStateDB returns the ethStateDB used for testing.
+func (w *EndorserWrapper) GetEthStateDB() *state.StateDB {
+	return w.engineWrapper.GetEthStateDB()
+}

--- a/endorser/testimpl/evm_engine_wrapper.go
+++ b/endorser/testimpl/evm_engine_wrapper.go
@@ -1,0 +1,101 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	ethstate "github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-x-evm/endorser"
+	"github.com/hyperledger/fabric-x-evm/utils"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
+)
+
+// EVMEngineWrapper wraps an EVMEngine and adds ethStateDB management for testing.
+// This wrapper handles the machinery for tracking Ethereum state root evolution
+// alongside Fabric state, which is useful for testing and validation purposes.
+type EVMEngineWrapper struct {
+	*endorser.EVMEngine
+	ethStateDB        *ethstate.StateDB
+	namespace         string
+	kvs               endorser.KVSSnapshotter
+	evmConfig         endorser.EVMConfig
+	monotonicVersions bool
+}
+
+// NewEVMEngineWrapper creates a new EVMEngineWrapper that wraps the given EVMEngine.
+// The wrapper needs access to the engine's configuration to create executors with DualStateDB.
+func NewEVMEngineWrapper(
+	namespace string,
+	kvs endorser.KVSSnapshotter,
+	evmConfig endorser.EVMConfig,
+	monotonicVersions bool,
+	engine *endorser.EVMEngine,
+) *EVMEngineWrapper {
+	return &EVMEngineWrapper{
+		EVMEngine:         engine,
+		ethStateDB:        nil,
+		namespace:         namespace,
+		kvs:               kvs,
+		evmConfig:         evmConfig,
+		monotonicVersions: monotonicVersions,
+	}
+}
+
+// SetEthStateDB sets the ethStateDB for testing purposes.
+func (w *EVMEngineWrapper) SetEthStateDB(ethStateDB *ethstate.StateDB) {
+	w.ethStateDB = ethStateDB
+}
+
+// GetEthStateDB returns the ethStateDB used for testing.
+func (w *EVMEngineWrapper) GetEthStateDB() *ethstate.StateDB {
+	return w.ethStateDB
+}
+
+// Execute runs a state-changing transaction and returns the EVM result.
+// If ethStateDB is set, it creates an executor wrapper that uses DualStateDB.
+func (w *EVMEngineWrapper) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (endorsement.ExecutionResult, error) {
+	// Create an executor wrapper that will use DualStateDB
+	ex, err := w.newExecutorWrapper(blockInfo, 0)
+	if err != nil {
+		return endorsement.ExecutionResult{}, err
+	}
+	defer ex.Close()
+
+	return ex.Execute(tx)
+}
+
+// Call executes a read-only call against the state.
+func (w *EVMEngineWrapper) Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	// Create an executor wrapper that will use DualStateDB
+	stateBlock := uint64(0)
+	if blockNumber != nil {
+		stateBlock = blockNumber.Uint64()
+	}
+	ex, err := w.newExecutorWrapper(nil, stateBlock)
+	if err != nil {
+		return nil, err
+	}
+	defer ex.Close()
+
+	return ex.Call(msg)
+}
+
+// newExecutorWrapper creates an executor wrapper with DualStateDB support.
+func (w *EVMEngineWrapper) newExecutorWrapper(blockInfo *utils.BlockInfo, stateBlockNum uint64) (*ExecutorWrapper, error) {
+	return NewExecutorWrapper(
+		w.namespace,
+		w.kvs,
+		blockInfo,
+		stateBlockNum,
+		w.evmConfig,
+		w.monotonicVersions,
+		w.ethStateDB,
+	)
+}

--- a/endorser/testimpl/executor_wrapper.go
+++ b/endorser/testimpl/executor_wrapper.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	ethstate "github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-x-evm/endorser"
+	"github.com/hyperledger/fabric-x-evm/utils"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
+)
+
+// ExecutorWrapper wraps an Executor and adds DualStateDB support for testing.
+type ExecutorWrapper struct {
+	*endorser.Executor
+	state      *endorser.DualStateDB
+	ethStateDB *ethstate.StateDB
+}
+
+// NewExecutorWrapper creates a new executor wrapper with DualStateDB support.
+func NewExecutorWrapper(
+	namespace string,
+	kvs endorser.KVSSnapshotter,
+	blockInfo *utils.BlockInfo,
+	stateBlockNum uint64,
+	evmConfig endorser.EVMConfig,
+	monotonicVersions bool,
+	ethStateDB *ethstate.StateDB,
+) (*ExecutorWrapper, error) {
+	// Begin a new reader to get snapshot isolation
+	reader := kvs.NewSnapshot()
+
+	// Create StateDB with the reader
+	stateDB, err := endorser.NewStateDB(context.TODO(), reader, namespace, stateBlockNum, monotonicVersions)
+	if err != nil {
+		reader.Close()
+		return nil, err
+	}
+
+	// Create DualStateDB that wraps both the Fabric StateDB and the Ethereum StateDB
+	dualStateDB := endorser.NewDualStateDB(ethStateDB, stateDB)
+
+	// Create the executor using the public API with the DualStateDB
+	executor, err := endorser.NewExecutor(dualStateDB, reader, blockInfo, evmConfig)
+	if err != nil {
+		reader.Close()
+		return nil, err
+	}
+
+	return &ExecutorWrapper{
+		Executor:   executor,
+		state:      dualStateDB,
+		ethStateDB: ethStateDB,
+	}, nil
+}
+
+// Execute runs a state-changing transaction.
+func (w *ExecutorWrapper) Execute(tx *types.Transaction) (endorsement.ExecutionResult, error) {
+	ret, err := w.Executor.Send(tx)
+	if err != nil {
+		return endorsement.ExecutionResult{}, err
+	}
+
+	var logs []byte
+	if l := w.state.Logs(); len(l) > 0 {
+		logs, err = json.Marshal(l)
+		if err != nil {
+			return endorsement.ExecutionResult{}, errors.New("error marshaling logs")
+		}
+	}
+
+	return endorsement.Success(w.state.Result(), logs, ret), nil
+}

--- a/endorser/versioned_db_wrapper.go
+++ b/endorser/versioned_db_wrapper.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package endorser
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/state"
+)
+
+// VersionedDBWrapper wraps a VersionedDB to implement KVSSnapshotter.
+// It provides snapshot isolation by capturing the current block number
+// when NewSnapshot() is called, and using that block number for all
+// subsequent Get operations on the snapshot.
+type VersionedDBWrapper struct {
+	db *state.VersionedDB
+}
+
+// NewVersionedDBWrapper creates a new wrapper around a VersionedDB.
+func NewVersionedDBWrapper(db *state.VersionedDB) *VersionedDBWrapper {
+	return &VersionedDBWrapper{
+		db: db,
+	}
+}
+
+// NewSnapshot creates a new snapshot of the current state.
+// It queries the current block number and returns a VersionedDBSnapshot
+// that will use this block number for all Get operations, providing
+// snapshot isolation.
+func (w *VersionedDBWrapper) NewSnapshot() ReadStore {
+	// Query the current block number to establish the snapshot point
+	blockNum, err := w.db.BlockNumber(context.Background())
+	if err != nil {
+		// If we can't get the block number, default to 0 (latest)
+		blockNum = 0
+	}
+
+	return &VersionedDBSnapshot{
+		db:          w.db,
+		blockNumber: blockNum,
+	}
+}
+
+// VersionedDBSnapshot represents a point-in-time snapshot of the VersionedDB.
+// All Get operations will read state as of the snapshot's block number.
+// It implements the ReadStore interface required by StateDB.
+type VersionedDBSnapshot struct {
+	db          *state.VersionedDB
+	blockNumber uint64
+}
+
+// Get retrieves the value for a key as of the snapshot's block number.
+// This implements the ReadStore interface with the signature:
+// Get(namespace, key string) (*blocks.WriteRecord, error)
+//
+// The snapshot's block number is automatically appended as the lastBlock
+// parameter when calling the underlying VersionedDB.Get method.
+func (s *VersionedDBSnapshot) Get(namespace, key string) (*blocks.WriteRecord, error) {
+	// Use the VersionedDB's Get method with the snapshot's block number
+	return s.db.Get(namespace, key, s.blockNumber)
+}
+
+// Close is a no-op for VersionedDBSnapshot since VersionedDB doesn't
+// require explicit snapshot cleanup. It's provided for interface compatibility.
+func (s *VersionedDBSnapshot) Close() error {
+	return nil
+}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	_ "modernc.org/sqlite"
 
-	"github.com/hyperledger/fabric-x-evm/endorser"
 	eapp "github.com/hyperledger/fabric-x-evm/endorser/app"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/config"
@@ -62,7 +61,7 @@ func NewWithSigner(cfg config.Config, gwSigner sdk.Signer) (*App, error) {
 	logger := sdk.NewStdLogger("gateway")
 
 	// Create endorsers and their synchronizers.
-	endorsers := make([]*endorser.Endorser, 0, len(cfg.Endorsers))
+	endorsers := make([]core.Endorser, 0, len(cfg.Endorsers))
 	endorserSyncs := make([]*network.Synchronizer, 0, len(cfg.Endorsers))
 	for i, ecfg := range cfg.Endorsers {
 		end, sync, err := eapp.NewEndorser(ecfg, cfg.Network, logger, false)
@@ -78,7 +77,7 @@ func NewWithSigner(cfg config.Config, gwSigner sdk.Signer) (*App, error) {
 
 // buildApp wires up the gateway from pre-built endorsers. Used by NewWithSigner
 // and directly by integration tests that manage their own endorsers.
-func buildApp(cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []*endorser.Endorser, endorserSyncs []*network.Synchronizer) (*App, error) {
+func buildApp(cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []core.Endorser, endorserSyncs []*network.Synchronizer) (*App, error) {
 	ec, err := core.NewEndorsementClient(endorsers, gwSigner, cfg.Network.Channel, cfg.Network.Namespace, cfg.Network.NsVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endorsement client: %w", err)

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/common"
-	"github.com/hyperledger/fabric-x-evm/endorser"
 	"github.com/hyperledger/fabric-x-evm/utils"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
@@ -35,14 +34,16 @@ type Endorser interface {
 // EndorsementClient forwards ethereum-style transactions and calls
 // to the endorsers and returns their signed fabric-style responses.
 type EndorsementClient struct {
-	endorsers []*endorser.Endorser
+	endorsers []Endorser
 	signer    Signer
 	channel   string
 	namespace string
 	nsVersion string
 }
 
-func NewEndorsementClient(endorsers []*endorser.Endorser, signer Signer, channel, namespace, nsVersion string) (*EndorsementClient, error) {
+// NewEndorsementClient creates an EndorsementClient from Endorser interface instances.
+// This allows using concrete endorsers, wrapped endorsers (e.g., from testimpl package), or other implementations.
+func NewEndorsementClient(endorsers []Endorser, signer Signer, channel, namespace, nsVersion string) (*EndorsementClient, error) {
 	return &EndorsementClient{
 		endorsers: endorsers,
 		signer:    signer,
@@ -75,7 +76,7 @@ func (e EndorsementClient) ExecuteTransaction(ctx context.Context, tx *types.Tra
 
 	for i, end := range e.endorsers {
 		wg.Add(1)
-		go func(index int, endorser *endorser.Endorser) {
+		go func(index int, endorser Endorser) {
 			defer wg.Done()
 			pResp, err := endorser.ProcessEVMTransaction(ctx, inv, tx, blockInfo)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/hyperledger/fabric-lib-go v1.1.3
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
 	github.com/hyperledger/fabric-x-common v0.1.1-0.20260219094834-26c5a49ed548
-	github.com/hyperledger/fabric-x-sdk v0.0.0-20260422070946-52f2faebbaff
+	github.com/hyperledger/fabric-x-sdk v0.0.0-20260504131414-b5072a94e1c9
+	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
@@ -160,7 +161,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -982,8 +982,8 @@ github.com/hyperledger/fabric-x-committer v0.1.9 h1:3lgl1g3FkONogjJraRzhrD7gr89X
 github.com/hyperledger/fabric-x-committer v0.1.9/go.mod h1:MjD6yyRfnCk3QjmwbKySoApvQerfnR++f0exQyFcZNw=
 github.com/hyperledger/fabric-x-common v0.1.1-0.20260219094834-26c5a49ed548 h1:KTmH/ZtM43z39lcLxGm7G3I5iC7J7iZSVHqbCFcUUNo=
 github.com/hyperledger/fabric-x-common v0.1.1-0.20260219094834-26c5a49ed548/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
-github.com/hyperledger/fabric-x-sdk v0.0.0-20260422070946-52f2faebbaff h1:ZpG2bdMGl1Ews34rDbWDxf4sfVRuuznLwTCVRcG7B5o=
-github.com/hyperledger/fabric-x-sdk v0.0.0-20260422070946-52f2faebbaff/go.mod h1:fOMpy5+efegUsET0d7RMH+CENyTpjZOD5D1bpZBWzos=
+github.com/hyperledger/fabric-x-sdk v0.0.0-20260504131414-b5072a94e1c9 h1:ltUyAZRIoxTdpRwUF8zI87Fz1ZGpMahQQDe9CYdNSeQ=
+github.com/hyperledger/fabric-x-sdk v0.0.0-20260504131414-b5072a94e1c9/go.mod h1:fOMpy5+efegUsET0d7RMH+CENyTpjZOD5D1bpZBWzos=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -28,10 +30,13 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/endorser"
+	econf "github.com/hyperledger/fabric-x-evm/endorser/config"
+	"github.com/hyperledger/fabric-x-evm/endorser/testimpl"
 	"github.com/hyperledger/fabric-x-evm/gateway/core"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage/trie"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/protobuf/proto"
 )
@@ -271,7 +276,7 @@ func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubt
 	defer th.Stop()
 
 	// run the tx through the pre-execution validation steps
-	preExecErr := core.ValidateTx(t.Context(), tx, config, signerForTx(tx), &nonceReader{th.endorsers[0].GetEthStateDB()})
+	preExecErr := core.ValidateTx(t.Context(), tx, config, signerForTx(tx), &nonceReader{th.endorsers[0].(*testimpl.EndorserWrapper).GetEthStateDB()})
 
 	// Execute transaction through gateway
 	env, execErr := th.Gateways[0].ExecuteEthTx(t.Context(), tx, blockInfo)
@@ -282,7 +287,7 @@ func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubt
 	var actualRoot common.Hash
 	// After execution, extract the ethStateDB and commit the ethereum state
 	if len(th.endorsers) > 0 {
-		ethStateDB := th.endorsers[0].GetEthStateDB()
+		ethStateDB := th.endorsers[0].(*testimpl.EndorserWrapper).GetEthStateDB()
 		if ethStateDB != nil {
 			// Commit the ethereum state
 			root, err := ethStateDB.Commit(blockInfo.BlockNumber.Uint64(),
@@ -408,19 +413,117 @@ func verifyTrieRoot(t *testing.T, genesisRWS, txRWS blocks.ReadWriteSet, blockNu
 	t.Logf("trie root verified: %s", trieRoot.Hex())
 }
 
-// newEthereumTestHarness creates a test harness with pre-state primed from ethereum test format
-func newEthereumTestHarness(t *testing.T, evmConfig endorser.EVMConfig, pre types.GenesisAlloc) (*TestHarness, error) {
+// ethereumTestHarness wraps TestHarness with endorser wrappers for ethereum state tracking
+type ethereumTestHarness struct {
+	*TestHarness
+}
+
+// wrappedEndorserFactory creates endorsers wrapped with testimpl wrappers for ethStateDB tracking.
+func wrappedEndorserFactory(t *testing.T, ecfg econf.Endorser, channel, namespace string, evmConfig endorser.EVMConfig, protocol string) (*endorser.LightKVS, endorsement.Builder, core.Endorser) {
+	// Create the base endorser components
+	db, builder, end := newEndorser(t, ecfg, channel, namespace, evmConfig, protocol)
+
+	// Create engine wrapper with the same configuration
+	engine := endorser.NewEVMEngine(namespace, db, evmConfig, protocol == "fabric-x")
+	engineWrapper := testimpl.NewEVMEngineWrapper(namespace, db, evmConfig, protocol == "fabric-x", engine)
+
+	// Wrap the endorser
+	wrapper := testimpl.NewEndorserWrapper(end, engineWrapper)
+
+	return db, builder, wrapper
+}
+
+// newEthereumTestHarness creates a test harness with pre-state primed from ethereum test format.
+// This version creates endorser wrappers to support ethStateDB tracking for state root verification.
+func newEthereumTestHarness(t *testing.T, evmConfig endorser.EVMConfig, pre types.GenesisAlloc) (*ethereumTestHarness, error) {
 	t.Helper()
 
-	th, err := NewLocalTestHarness(t, TestLogger{T: t}, evmConfig, "", "bypass", nil)
+	// Create test harness with wrapped endorsers using custom factory
+	th, err := newLocalTestHarnessWithFactory(t, TestLogger{T: t}, evmConfig, "", "bypass", nil, wrappedEndorserFactory)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := th.PrimeGenesisAlloc(t.Context(), pre, false); err != nil {
+	eth := &ethereumTestHarness{th}
+
+	// Prime the state using our custom method that works with wrappers
+	if err := eth.primeGenesisAlloc(t.Context(), pre, false); err != nil {
 		th.Stop()
 		return nil, err
 	}
 
-	return th, nil
+	return eth, nil
+}
+
+// primeGenesisAlloc primes the state from ethereum genesis format and sets up ethStateDB for wrappers
+func (eth *ethereumTestHarness) primeGenesisAlloc(ctx context.Context, pre types.GenesisAlloc, wait bool) error {
+	if len(pre) == 0 {
+		return nil
+	}
+
+	primer, err := eth.NewStatePrimer()
+	if err != nil {
+		return err
+	}
+
+	// Sort addresses to ensure deterministic account creation order
+	var addresses []common.Address
+	for addr := range pre {
+		addresses = append(addresses, addr)
+	}
+	sort.Slice(addresses, func(i, j int) bool {
+		return bytes.Compare(addresses[i].Bytes(), addresses[j].Bytes()) < 0
+	})
+
+	// Convert each test account to StatePrimer operations in sorted order
+	for _, addr := range addresses {
+		account := pre[addr]
+		n := account.Nonce
+		nonce := &n
+
+		var balance *big.Int
+		if account.Balance != nil {
+			balance = account.Balance
+		}
+
+		var code []byte
+		if len(account.Code) > 0 {
+			code = account.Code
+		}
+
+		var storage map[common.Hash]common.Hash
+		if len(account.Storage) > 0 {
+			storage = account.Storage
+		}
+
+		primer.SetAccount(addr, nonce, code, balance, storage)
+	}
+
+	// Extract the ethStateDB before committing
+	ethStateDB := primer.GetEthStateDB()
+
+	// Commit the ethStateDB to finalize the primed state
+	root, err := ethStateDB.Commit(0, false, false)
+	if err != nil {
+		return fmt.Errorf("failed to commit primed ethStateDB: %w", err)
+	}
+
+	// Create a new ethStateDB from the committed root
+	stateDB := ethStateDB.Database()
+	ethStateDB, err = state.New(root, stateDB)
+	if err != nil {
+		return fmt.Errorf("failed to create new ethStateDB from committed root: %w", err)
+	}
+
+	// Commit all state changes to the Fabric ledger
+	if err := primer.Commit(ctx, wait); err != nil {
+		return err
+	}
+
+	// Set the ethStateDB on all wrappers
+	for _, end := range eth.endorsers {
+		end.(*testimpl.EndorserWrapper).SetEthStateDB(ethStateDB)
+	}
+
+	return nil
 }

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -31,12 +31,17 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/network"
 )
 
+type KVSSnapshotter interface {
+	NewSnapshot() endorser.ReadStore
+}
+
 // StatePrimer provides a builder pattern for priming ledger state.
 // It allows setting nonces, code, balances, and storage for addresses,
 // then commits all changes in a single transaction.
 type StatePrimer struct {
 	gw                *core.Gateway
-	db                endorser.ReadStore
+	kvs               KVSSnapshotter
+	reader            endorser.ReadStore
 	namespace         string
 	signer            sdk.Signer
 	builders          []endorsement.Builder
@@ -53,7 +58,7 @@ type StatePrimer struct {
 // NewStatePrimer creates a new state primer builder.
 func NewStatePrimer(
 	gw *core.Gateway,
-	db endorser.ReadStore,
+	db KVSSnapshotter,
 	namespace string,
 	signer sdk.Signer,
 	builders []endorsement.Builder,
@@ -62,7 +67,8 @@ func NewStatePrimer(
 	monotonicVersions bool,
 ) (*StatePrimer, error) {
 	// Create a DualStateDB with both Fabric and Ethereum state tracking
-	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), db, namespace, 0, monotonicVersions, nil)
+	store := db.NewSnapshot()
+	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), store, namespace, 0, monotonicVersions, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +80,8 @@ func NewStatePrimer(
 
 	return &StatePrimer{
 		gw:                gw,
-		db:                db,
+		reader:            store,
+		kvs:               db,
 		namespace:         namespace,
 		signer:            signer,
 		builders:          builders,
@@ -210,6 +217,8 @@ func (sp *StatePrimer) LoadFromJSON(jsonFilePath string) (*StatePrimer, error) {
 // Commit applies all state changes to the ledger by creating a proposal,
 // endorsing it, and submitting it through the normal Fabric commit flow.
 func (sp *StatePrimer) Commit(ctx context.Context, wait bool) error {
+	defer sp.reader.Close()
+
 	// create a fake ethereum tx so we can use it to track priming
 	tx, ethTxBytes, err := sp.fakeEthTx()
 	if err != nil {
@@ -257,7 +266,9 @@ func (sp *StatePrimer) Writes() blocks.ReadWriteSet {
 
 // Reset creates a new DualStateDB, discarding all uncommitted changes.
 func (sp *StatePrimer) Reset() (*StatePrimer, error) {
-	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), sp.db, sp.namespace, 0, sp.monotonicVersions, nil)
+	sp.reader.Close() // just in case
+	sp.reader = sp.kvs.NewSnapshot()
+	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), sp.reader, sp.namespace, 0, sp.monotonicVersions, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/state_test_util.go
+++ b/integration/state_test_util.go
@@ -616,7 +616,10 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 
 	// Create a mock StateDB for DualStateDB
 	fabricDB, _ := fabricstate.NewWriteDB("testchannel", ":memory:")
-	fabricStateDB, _ := endorser.NewStateDB(context.TODO(), fabricDB, "testns", 0, false)
+	fabricDBWrapper := endorser.NewVersionedDBWrapper(fabricDB)
+	fabricDBSnapshot := fabricDBWrapper.NewSnapshot()
+	defer fabricDBSnapshot.Close()
+	fabricStateDB, _ := endorser.NewStateDB(context.TODO(), fabricDBSnapshot, "testns", 0, false)
 
 	// Use DualStateDB instead of plain StateDB for debugging
 	statedb := endorser.NewDualStateDB(ethStateDB, fabricStateDB)
@@ -670,7 +673,9 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 
 	// Create new StateDB for the reopened state - now reading from block 1
 	// since we just committed block 0
-	fabricStateDB, _ = endorser.NewStateDB(context.TODO(), fabricDB, "testns", 1, false)
+	fabricDBSnapshot2 := fabricDBWrapper.NewSnapshot()
+	defer fabricDBSnapshot2.Close()
+	fabricStateDB, _ = endorser.NewStateDB(context.TODO(), fabricDBSnapshot2, "testns", 1, false)
 	statedb = endorser.NewDualStateDB(ethStateDB, fabricStateDB)
 
 	return StateTestState{statedb, trieDB, snaps}

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package integration
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -17,13 +16,11 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	ethstate "github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -86,87 +83,6 @@ func (th *TestHarness) NewStatePrimer() (*StatePrimer, error) {
 	return th.Primer.Reset()
 }
 
-// PrimeGenesisAlloc primes ledger state from an Ethereum genesis allocation and
-// injects the resulting ethStateDB into all endorsers for state reuse.
-func (th *TestHarness) PrimeGenesisAlloc(ctx context.Context, pre types.GenesisAlloc, wait bool) error {
-	if len(pre) == 0 {
-		return nil
-	}
-
-	primer, err := th.NewStatePrimer()
-	if err != nil {
-		return err
-	}
-
-	// Sort addresses to ensure deterministic account creation order
-	// (Go map iteration order is random, which affects the state trie structure)
-	var addresses []ethcommon.Address
-	for addr := range pre {
-		addresses = append(addresses, addr)
-	}
-	sort.Slice(addresses, func(i, j int) bool {
-		return bytes.Compare(addresses[i].Bytes(), addresses[j].Bytes()) < 0
-	})
-
-	// Convert each test account to StatePrimer operations in sorted order
-	for _, addr := range addresses {
-		account := pre[addr]
-		// Set nonce (always set it, even if 0, to ensure consistent state tracking)
-		n := account.Nonce
-		nonce := &n
-
-		// Set balance
-		var balance *big.Int
-		if account.Balance != nil {
-			balance = account.Balance
-		}
-
-		// Set code
-		var code []byte
-		if len(account.Code) > 0 {
-			code = account.Code
-		}
-
-		// Set storage
-		var storage map[ethcommon.Hash]ethcommon.Hash
-		if len(account.Storage) > 0 {
-			storage = account.Storage
-		}
-
-		// Apply all account properties
-		primer.SetAccount(addr, nonce, code, balance, storage)
-	}
-
-	// Extract the ethStateDB before committing
-	ethStateDB := primer.GetEthStateDB()
-
-	// Commit the ethStateDB to finalize the primed state
-	// This is critical: we commit with deleteEmptyObjects=false to preserve all primed accounts
-	root, err := ethStateDB.Commit(0, false, false)
-	if err != nil {
-		return fmt.Errorf("failed to commit primed ethStateDB: %w", err)
-	}
-
-	// Create a new ethStateDB from the committed root
-	// This ensures we start transaction execution with a clean, committed state
-	stateDB := ethStateDB.Database()
-	ethStateDB, err = ethstate.New(root, stateDB)
-	if err != nil {
-		return fmt.Errorf("failed to create new ethStateDB from committed root: %w", err)
-	}
-
-	// Commit all state changes to the Fabric ledger
-	if err := primer.Commit(ctx, wait); err != nil {
-		return err
-	}
-
-	for _, end := range th.endorsers {
-		end.SetEthStateDB(ethStateDB)
-	}
-
-	return nil
-}
-
 // PrimeStateFromJSON builds a proposal that contains a RWSet derived from the contents of
 // `jsonFilePath` as the chaincode results, creates a ProposalResponses signed by the given
 // endorsers and submits them via the submitter. This causes Fabric peers to apply the state
@@ -199,7 +115,7 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 //
 // Sync goroutines are started in the background using ctx. The returned synchronizers
 // can be used by callers that need to wait for the initial sync to complete.
-func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig endorser.EVMConfig, primeDBPath string, bypass bool, ends []*endorser.Endorser, dbs []*endorser.LightKVS, builders []endorsement.Builder) (*TestHarness, *network.Synchronizer, error) {
+func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig endorser.EVMConfig, primeDBPath string, bypass bool, ends []core.Endorser, dbs []*endorser.LightKVS, builders []endorsement.Builder) (*TestHarness, *network.Synchronizer, error) {
 	// Build gateway signer.
 	var gwSigner sdk.Signer
 	if cfg.Gateway.Identity.MSPDir != "" {
@@ -329,9 +245,35 @@ func applyConfigOverrides(cfg *config.Config, overrides map[string]any) error {
 	return nil
 }
 
+// EndorserFactory is a function that creates an endorser along with its dependencies.
+// It returns core.Endorser interface which both *endorser.Endorser and *testimpl.EndorserWrapper implement.
+type EndorserFactory func(t *testing.T, ecfg econf.Endorser, channel, namespace string, evmConfig endorser.EVMConfig, protocol string) (*endorser.LightKVS, endorsement.Builder, core.Endorser)
+
+// buildEndorsers creates endorsers using the provided factory function.
+func buildEndorsers(t *testing.T, cfg config.Config, evmConfig endorser.EVMConfig, factory EndorserFactory) ([]*endorser.LightKVS, []endorsement.Builder, []core.Endorser) {
+	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
+	builders := make([]endorsement.Builder, len(cfg.Endorsers))
+	ends := make([]core.Endorser, len(cfg.Endorsers))
+	for i, ecfg := range cfg.Endorsers {
+		dbs[i], builders[i], ends[i] = factory(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
+	}
+	return dbs, builders, ends
+}
+
+// defaultEndorserFactory creates regular endorsers without wrapping.
+func defaultEndorserFactory(t *testing.T, ecfg econf.Endorser, channel, namespace string, evmConfig endorser.EVMConfig, protocol string) (*endorser.LightKVS, endorsement.Builder, core.Endorser) {
+	db, builder, end := newEndorser(t, ecfg, channel, namespace, evmConfig, protocol)
+	return db, builder, end
+}
+
 // newLocalTestHarness commits updates directly to the DB, bypassing peers and orderers.
 // Exported for use by eth-tests package.
 func NewLocalTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EVMConfig, primeDbPath, networkType string, configOverrides map[string]any) (*TestHarness, error) {
+	return newLocalTestHarnessWithFactory(t, logger, evmConfig, primeDbPath, networkType, configOverrides, defaultEndorserFactory)
+}
+
+// newLocalTestHarnessWithFactory is like NewLocalTestHarness but allows custom endorser creation.
+func newLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig endorser.EVMConfig, primeDbPath, networkType string, configOverrides map[string]any, factory EndorserFactory) (*TestHarness, error) {
 	bypass := networkType == "bypass"
 
 	orderer := &common.Endpoint{Host: "127.0.0.1", Port: 1337}
@@ -381,14 +323,8 @@ func NewLocalTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EVM
 		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
 	}
 
-	// Build all endorsers.
-	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
-	builders := make([]endorsement.Builder, len(cfg.Endorsers))
-	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
-	for i, ecfg := range cfg.Endorsers {
-		// this function now returns our new lightkvs
-		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
-	}
+	// Build all endorsers using the factory
+	dbs, builders, ends := buildEndorsers(t, cfg, evmConfig, factory)
 
 	if !bypass {
 		nw, err := fabrictest.Start("basic", networkType, fabrictest.Config{}, dbs[0])
@@ -436,14 +372,8 @@ func newFabricTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EV
 		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
 	}
 
-	// Build all endorsers.
-	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
-	builders := make([]endorsement.Builder, len(cfg.Endorsers))
-	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
-	for i, ecfg := range cfg.Endorsers {
-		// this function now returns our new lightkvs
-		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
-	}
+	// Build all endorsers
+	dbs, builders, ends := buildEndorsers(t, cfg, evmConfig, defaultEndorserFactory)
 
 	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, ends, dbs, builders)
 	if err != nil {
@@ -470,14 +400,8 @@ func NewFabricXTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.E
 		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
 	}
 
-	// Build all endorsers.
-	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
-	builders := make([]endorsement.Builder, len(cfg.Endorsers))
-	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
-	for i, ecfg := range cfg.Endorsers {
-		// this function now returns our new lightkvs
-		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
-	}
+	// Build all endorsers
+	dbs, builders, ends := buildEndorsers(t, cfg, evmConfig, defaultEndorserFactory)
 
 	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, ends, dbs, builders)
 	if err != nil {
@@ -537,7 +461,7 @@ func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 type TestHarness struct {
 	DBs            []*endorser.LightKVS
 	Gateways       []*core.Gateway
-	endorsers      []*endorser.Endorser
+	endorsers      []core.Endorser
 	ethChainConfig *params.ChainConfig
 	Primer         *StatePrimer
 }

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -52,7 +52,6 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/network"
 	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
 	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
-	"github.com/hyperledger/fabric-x-sdk/state"
 )
 
 // GetERC20BalanceSlot computes the storage slot for a balance in an ERC-20 mapping(address => uint256).
@@ -200,22 +199,7 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 //
 // Sync goroutines are started in the background using ctx. The returned synchronizers
 // can be used by callers that need to wait for the initial sync to complete.
-func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig endorser.EVMConfig, primeDBPath string, bypass bool) (*TestHarness, *network.Synchronizer, error) {
-	t.Helper()
-
-	// Derive ChainConfig from cfg.Network.ChainID when not explicitly provided.
-	if evmConfig.ChainConfig == nil {
-		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
-	}
-
-	// Build all endorsers.
-	dbs := make([]*state.VersionedDB, len(cfg.Endorsers))
-	builders := make([]endorsement.Builder, len(cfg.Endorsers))
-	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
-	for i, ecfg := range cfg.Endorsers {
-		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
-	}
-
+func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig endorser.EVMConfig, primeDBPath string, bypass bool, ends []*endorser.Endorser, dbs []*endorser.LightKVS, builders []endorsement.Builder) (*TestHarness, *network.Synchronizer, error) {
 	// Build gateway signer.
 	var gwSigner sdk.Signer
 	if cfg.Gateway.Identity.MSPDir != "" {
@@ -298,6 +282,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 		endorsers:      ends,
 		ethChainConfig: evmConfig.ChainConfig,
 		Primer:         primer,
+		DBs:            dbs,
 	}
 
 	if err := th.PrimeStateFromJSON(t.Context(), primeDBPath, !bypass); err != nil {
@@ -352,16 +337,6 @@ func NewLocalTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EVM
 	orderer := &common.Endpoint{Host: "127.0.0.1", Port: 1337}
 	peer := &common.Endpoint{Host: "127.0.0.1", Port: 1337}
 
-	if !bypass {
-		nw, err := fabrictest.Start("basic", networkType, fabrictest.Config{})
-		if err != nil {
-			t.Fatalf("fabrictest.Start: %v", err)
-		}
-		t.Cleanup(nw.Stop)
-		orderer.Port = nw.OrdererPort
-		peer.Port = nw.PeerPort
-	}
-
 	// bypass mode uses Fabric block format
 	protocol := networkType
 	if bypass {
@@ -401,7 +376,31 @@ func NewLocalTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EVM
 		return nil, err
 	}
 
-	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass)
+	// Derive ChainConfig from cfg.Network.ChainID when not explicitly provided.
+	if evmConfig.ChainConfig == nil {
+		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
+	}
+
+	// Build all endorsers.
+	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
+	builders := make([]endorsement.Builder, len(cfg.Endorsers))
+	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
+	for i, ecfg := range cfg.Endorsers {
+		// this function now returns our new lightkvs
+		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
+	}
+
+	if !bypass {
+		nw, err := fabrictest.Start("basic", networkType, fabrictest.Config{}, dbs[0])
+		if err != nil {
+			t.Fatalf("fabrictest.Start: %v", err)
+		}
+		t.Cleanup(nw.Stop)
+		orderer.Port = nw.OrdererPort
+		peer.Port = nw.PeerPort
+	}
+
+	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass, ends, dbs, builders)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +431,21 @@ func newFabricTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.EV
 		return nil, err
 	}
 
-	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false)
+	// Derive ChainConfig from cfg.Network.ChainID when not explicitly provided.
+	if evmConfig.ChainConfig == nil {
+		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
+	}
+
+	// Build all endorsers.
+	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
+	builders := make([]endorsement.Builder, len(cfg.Endorsers))
+	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
+	for i, ecfg := range cfg.Endorsers {
+		// this function now returns our new lightkvs
+		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
+	}
+
+	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, ends, dbs, builders)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +465,21 @@ func NewFabricXTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.E
 		return nil, err
 	}
 
-	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false)
+	// Derive ChainConfig from cfg.Network.ChainID when not explicitly provided.
+	if evmConfig.ChainConfig == nil {
+		evmConfig.ChainConfig = common.BuildChainConfig(cfg.Network.ChainID)
+	}
+
+	// Build all endorsers.
+	dbs := make([]*endorser.LightKVS, len(cfg.Endorsers))
+	builders := make([]endorsement.Builder, len(cfg.Endorsers))
+	ends := make([]*endorser.Endorser, len(cfg.Endorsers))
+	for i, ecfg := range cfg.Endorsers {
+		// this function now returns our new lightkvs
+		dbs[i], builders[i], ends[i] = newEndorser(t, ecfg, cfg.Network.Channel, cfg.Network.Namespace, evmConfig, cfg.Network.Protocol)
+	}
+
+	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, ends, dbs, builders)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +487,7 @@ func NewFabricXTestHarness(t *testing.T, logger sdk.Logger, evmConfig endorser.E
 	return th, nil
 }
 
-func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, evmConfig endorser.EVMConfig, protocol string) (*state.VersionedDB, endorsement.Builder, *endorser.Endorser) {
+func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, evmConfig endorser.EVMConfig, protocol string) (*endorser.LightKVS, endorsement.Builder, *endorser.Endorser) {
 	t.Helper()
 
 	var signer sdk.Signer
@@ -474,11 +501,11 @@ func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 		}
 	}
 
-	endorserDB, err := state.NewWriteDB(channel, cfg.DbConnStr)
-	if err != nil {
-		t.Fatalf("NewWriteDB: %v", err)
-	}
-	t.Cleanup(func() { endorserDB.Close() })
+	// Create LightKVS for versioned key-value storage with snapshot isolation
+	lightKVS := endorser.NewLightKVS()
+
+	// Cleanup is a no-op for LightKVS
+	t.Cleanup(func() { lightKVS.Close() })
 
 	// the shape of endorsements and blocks differs per protocol.
 	var builder endorsement.Builder
@@ -492,12 +519,9 @@ func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 	default:
 		t.Fatalf("unsupported protocol: %q", protocol)
 	}
-	if err != nil {
-		t.Fatalf("NewSynchronizer: %v", err)
-	}
 
 	end, err := endorser.New(
-		endorser.NewEVMEngine(namespace, endorserDB, evmConfig, monotonicVersions),
+		endorser.NewEVMEngine(namespace, lightKVS, evmConfig, monotonicVersions),
 		builder,
 		evmConfig.ChainConfig.ChainID.Int64(),
 	)
@@ -505,12 +529,13 @@ func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 		t.Fatalf("endorser.New: %v", err)
 	}
 
-	return endorserDB, builder, end
+	return lightKVS, builder, end
 }
 
 // TestHarness provides access to gateways and endorsers for testing.
 // Exported for use by eth-tests package.
 type TestHarness struct {
+	DBs            []*endorser.LightKVS
 	Gateways       []*core.Gateway
 	endorsers      []*endorser.Endorser
 	ethChainConfig *params.ChainConfig


### PR DESCRIPTION
This commit introduces a new LightKVS implementation that provides versioned key-value storage with snapshot isolation semantics, replacing the previous database-backed state management approach.

The core change replaces direct database access with a snapshot-based model where each transaction execution operates on an isolated point-in-time view of the state. The new LightKVS maintains versioned state in memory and provides snapshot creation through a KVSSnapshotter interface, ensuring that concurrent transactions see consistent state without interference. This approach eliminates the need for external database connections during endorsement while maintaining proper MVCC semantics.

The EVMEngine has been updated to accept a KVSSnapshotter instead of a ReadStore, allowing it to create fresh snapshots for each transaction execution. The executor now properly manages snapshot lifecycle with explicit Close calls to prevent resource leaks. The synchronizer components in both Fabric and Fabric-X protocols have been adapted to work with the new storage abstraction, passing the same LightKVS instance for both read and write operations.