### PR TITLE
TxQueue data model refactor

### DIFF
--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -73,7 +73,7 @@ func (q *TxQueue) Close() {
 
 // Complete removes a transaction from the in-progress map
 func (q *TxQueue) Complete(hash common.Hash) {
-        q.mu.Lock()
-        defer q.mu.Unlock()
-        delete(q.inProgressMap, hash)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	delete(q.inProgressMap, hash)
 }

--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -56,6 +56,7 @@ func (q *TxQueue) Dequeue() (*types.Transaction, bool) {
 	}
 
 	tx := q.pendingQueue[0]
+	q.pendingQueue[0] = nil
 	q.pendingQueue = q.pendingQueue[1:]
 	q.inProgressMap[tx.Hash()] = tx
 	return tx, true
@@ -68,4 +69,11 @@ func (q *TxQueue) Close() {
 
 	q.done = true
 	q.cond.Broadcast() // Wake up all waiting workers
+}
+
+// Complete removes a transaction from the in-progress map
+func (q *TxQueue) Complete(hash common.Hash) {
+        q.mu.Lock()
+        defer q.mu.Unlock()
+        delete(q.inProgressMap, hash)
 }

--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -9,21 +9,24 @@ package core
 import (
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // TxQueue is a simple in-memory FIFO queue for transactions
 type TxQueue struct {
-	mu    sync.Mutex
-	cond  *sync.Cond
-	queue []*types.Transaction
-	done  bool
+	mu            sync.Mutex
+	cond          *sync.Cond
+	pendingQueue  []*types.Transaction
+	inProgressMap map[common.Hash]*types.Transaction
+	done          bool
 }
 
 // NewTxQueue creates a new transaction queue
 func NewTxQueue() *TxQueue {
 	q := &TxQueue{
-		queue: make([]*types.Transaction, 0),
+		pendingQueue:  make([]*types.Transaction, 0),
+		inProgressMap: make(map[common.Hash]*types.Transaction),
 	}
 	q.cond = sync.NewCond(&q.mu)
 	return q
@@ -34,7 +37,7 @@ func (q *TxQueue) Enqueue(tx *types.Transaction) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	q.queue = append(q.queue, tx)
+	q.pendingQueue = append(q.pendingQueue, tx)
 	q.cond.Signal() // Wake up one waiting worker
 }
 
@@ -44,16 +47,17 @@ func (q *TxQueue) Dequeue() (*types.Transaction, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	for len(q.queue) == 0 && !q.done {
+	for len(q.pendingQueue) == 0 && !q.done {
 		q.cond.Wait()
 	}
 
-	if q.done && len(q.queue) == 0 {
+	if q.done && len(q.pendingQueue) == 0 {
 		return nil, false
 	}
 
-	tx := q.queue[0]
-	q.queue = q.queue[1:]
+	tx := q.pendingQueue[0]
+	q.pendingQueue = q.pendingQueue[1:]
+	q.inProgressMap[tx.Hash()] = tx
 	return tx, true
 }
 

--- a/gateway/core/txqueue_test.go
+++ b/gateway/core/txqueue_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testTx(nonce uint64) *types.Transaction {
+	return types.NewTransaction(
+		nonce,
+		common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		big.NewInt(1),
+		21000,
+		big.NewInt(1),
+		nil,
+	)
+}
+
+func TestNewTxQueue_InitializesPendingAndInProgress(t *testing.T) {
+	q := NewTxQueue()
+
+	require.NotNil(t, q.cond)
+	require.NotNil(t, q.pendingQueue)
+	require.NotNil(t, q.inProgressMap)
+	assert.Len(t, q.pendingQueue, 0)
+	assert.Len(t, q.inProgressMap, 0)
+	assert.False(t, q.done)
+}
+
+func TestTxQueue_EnqueueAddsToPendingQueue(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+
+	q.Enqueue(tx)
+
+	require.Len(t, q.pendingQueue, 1)
+	assert.Equal(t, tx, q.pendingQueue[0])
+	assert.Len(t, q.inProgressMap, 0)
+}
+
+func TestTxQueue_DequeueMovesTxToInProgressMap(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+
+	got, ok := q.Dequeue()
+	require.True(t, ok)
+	require.NotNil(t, got)
+	assert.Equal(t, tx.Hash(), got.Hash())
+	assert.Len(t, q.pendingQueue, 0)
+
+	inProgressTx, exists := q.inProgressMap[tx.Hash()]
+	require.True(t, exists)
+	assert.Equal(t, tx.Hash(), inProgressTx.Hash())
+}


### PR DESCRIPTION
Refactored TxQueue to use:

- `pendingQueue []*types.Transaction`
- `inProgressMap map[common.Hash]*types.Transaction`

## Changes

- Updated constructor to initialize both structures
- Updated enqueue path to append to pendingQueue
- Updated dequeue to keep behavior consistent with the new structure (it now pops from pendingQueue and tracks the tx in inProgressMap), since the old queue field no longer exists

## Files Updated

- `gateway/core/txqueue.go`
- `gateway/core/txqueue_test.go`

## Tests Added

- `TestNewTxQueue_InitializesPendingAndInProgress`
- `TestTxQueue_EnqueueAddsToPendingQueue`
- `TestTxQueue_DequeueMovesTxToInProgressMap`

## Qualification Run

- `go test ./gateway/core -run TxQueue -count=1` passed
- `go test ./gateway/core -count=1` passed