### PR TITLE
add release targets for docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,87 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+name: Release Fabric-X EVM Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract and validate version from tag
+        id: extract
+        run: |
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "✅ Tag validated: $VERSION"
+          else
+            echo "❌ Invalid tag format: ${GITHUB_REF}. Expected format: refs/tags/v<semver>"
+            exit 1
+          fi
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build cross-architecture binaries
+        run: make build-release
+
+      - name: Set image metadata
+        run: |
+          echo "CREATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          echo "REVISION=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          if [ "$GITHUB_REPOSITORY_OWNER" == "hyperledger" ]; then
+            echo "IMAGE_PREFIX=hyperledger" >> $GITHUB_ENV
+          else
+            echo "IMAGE_PREFIX=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          fi
+          echo "GHCR_PREFIX=$GITHUB_REPOSITORY_OWNER" >> $GITHUB_ENV
+
+      - name: Build and push multi-platform Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.release
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          push: true
+          tags: |
+            docker.io/${{ env.IMAGE_PREFIX }}/fabric-x-evm:${{ env.VERSION }}
+            docker.io/${{ env.IMAGE_PREFIX }}/fabric-x-evm:latest
+            ghcr.io/${{ env.GHCR_PREFIX }}/fabric-x-evm:${{ env.VERSION }}
+            ghcr.io/${{ env.GHCR_PREFIX }}/fabric-x-evm:latest
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            CREATED=${{ env.CREATED }}
+            REVISION=${{ env.REVISION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin
+release
 node_modules
 .gomodcache
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,8 @@ RUN CGO_ENABLED=0 go build -trimpath -o /fxevm ./cmd/fxevm
 
 FROM busybox
 
-COPY --from=build /fxevm /fxevm
-ENTRYPOINT ["/fxevm"]
+COPY --from=build /fxevm /usr/local/bin/fxevm
+EXPOSE 8545
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=30s \
+    CMD ["fxevm", "healthcheck"]
+ENTRYPOINT ["fxevm"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,16 @@
+FROM scratch
+ARG TARGETARCH
+ARG VERSION
+ARG CREATED
+ARG REVISION
+LABEL org.opencontainers.image.title="fabric-x-evm" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${CREATED}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.source="https://github.com/hyperledger/fabric-x-evm"
+COPY release/linux-${TARGETARCH}/fxevm /usr/local/bin/fxevm
+USER 65534:65534
+EXPOSE 8545
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=30s \
+    CMD ["fxevm", "healthcheck"]
+ENTRYPOINT ["fxevm"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Configuration
 FABRIC_VERSION ?= 3.1.4
+RELEASE_ARCHS  := amd64 arm64 s390x
 UID := $(shell id -u)
 GID := $(shell id -g)
 export UID
@@ -8,6 +9,25 @@ export GID
 .PHONY: build
 build:
 	go build -o bin/fxevm ./cmd/fxevm
+
+.PHONY: build-release
+build-release:
+	@for arch in $(RELEASE_ARCHS); do \
+		mkdir -p release/linux-$$arch && \
+		CGO_ENABLED=0 GOOS=linux GOARCH=$$arch go build -trimpath -ldflags '-w -s' \
+			-o release/linux-$$arch/fxevm ./cmd/fxevm || exit 1; \
+	done
+
+.PHONY: build-image
+build-image: build-release
+	docker buildx build \
+		--file Dockerfile.release \
+		--load \
+		--build-arg VERSION=dev \
+		--build-arg CREATED=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
+		--build-arg REVISION=$(shell git rev-parse HEAD) \
+		--tag fabric-x-evm:dev \
+		.
 
 .PHONY: checks
 checks:
@@ -41,6 +61,7 @@ clean-x:
 .PHONY: start-x
 start-x:
 	@if nc -z localhost 7050 2>/dev/null; then echo "Error: port 7050 is already in use — stop any running Fabric orderer before starting."; exit 1; fi
+	@if [ ! -f testdata/crypto/sc-genesis-block.proto.bin ]; then echo "Please run 'make init-x' first."; exit 1; fi
 	@docker run -d --rm -it --name fabric-x-committer-test-node \
 		-p 4001:4001 -p 2110:2110 -p 2114:2114 -p 2117:2117 -p 7001:7001 -p 7050:7050 -p 5433:5433 \
 		-v "$(PWD)/testdata/crypto:/root/config/crypto" \
@@ -120,6 +141,7 @@ start-node:
 .PHONY: start
 start: blockscout.env
 	@if nc -z localhost 7050 2>/dev/null; then echo "Error: port 7050 is already in use — stop any running Fabric orderer before starting."; exit 1; fi
+	@if [ ! -f testdata/crypto/sc-genesis-block.proto.bin ]; then echo "Please run 'make init-x' first."; exit 1; fi
 	@docker compose --profile explorer --env-file blockscout.env up -d --build
 	@echo "Visit the block explorer at http://localhost:8000/ (might take a minute to load)"
 

--- a/cmd/fxevm/healthcheck_cmd.go
+++ b/cmd/fxevm/healthcheck_cmd.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newHealthcheckCmd() *cobra.Command {
+	var addr string
+
+	cmd := &cobra.Command{
+		Use:   "healthcheck",
+		Short: "Check whether the gateway is accepting connections",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHealthcheck(addr)
+		},
+	}
+
+	cmd.Flags().StringVar(&addr, "addr", "localhost:8545", "Address to probe")
+	return cmd
+}
+
+func runHealthcheck(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return fmt.Errorf("gateway unreachable at %s: %w", addr, err)
+	}
+	return conn.Close()
+}

--- a/cmd/fxevm/main.go
+++ b/cmd/fxevm/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	root.AddCommand(newStartCmd())
 	root.AddCommand(newTestNodeCmd())
+	root.AddCommand(newHealthcheckCmd())
 
 	if err := root.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/compose.yml
+++ b/compose.yml
@@ -98,7 +98,7 @@ services:
       fxconfig-init:
         condition: service_completed_successfully
     healthcheck:
-      test: [ "CMD-SHELL", "nc -z localhost 8545" ]
+      test: [ "CMD", "fxevm", "healthcheck" ]
       interval: 2s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
This PR will publish a multi-arch docker image when we push a version tag. Heavily inspired by https://github.com/hyperledger/fabric-x-committer/blob/main/.github/workflows/docker-release.yml.

Added a health check to the binary, so we can have an image `FROM scratch`.