### PR TITLE
gateway: surface eth_call reverts as JSON-RPC -32000 with revert data

### DIFF
--- a/common/events.go
+++ b/common/events.go
@@ -49,3 +49,37 @@ func UnmarshalLogs(event []byte) ([]state.Log, error) {
 
 	return logs, nil
 }
+
+// EventNameRevert is the ChaincodeEvent name used to signal an EVM revert
+// from the endorser to the committer, so receipts can be marked status=0.
+const EventNameRevert = "revert"
+
+// MarshalRevert wraps the raw revert payload in a ChaincodeEvent with name
+// "revert" so the committer can detect the revert via the block-parsed events.
+func MarshalRevert(payload []byte, namespace, txID string) ([]byte, error) {
+	return proto.Marshal(&peer.ChaincodeEvent{
+		Payload:     payload,
+		ChaincodeId: namespace,
+		TxId:        txID,
+		EventName:   EventNameRevert,
+	})
+}
+
+// IsRevertEvent reports whether the given event bytes represent an EVM revert.
+// The SDK Endorse builder wraps res.Event in an outer ChaincodeEvent
+// (EventName "log"), so the marker we set in the inner event is one
+// proto-unmarshal deeper.
+func IsRevertEvent(event []byte) bool {
+	if len(event) == 0 {
+		return false
+	}
+	var outer peer.ChaincodeEvent
+	if err := proto.Unmarshal(event, &outer); err != nil {
+		return false
+	}
+	var inner peer.ChaincodeEvent
+	if err := proto.Unmarshal(outer.Payload, &inner); err != nil {
+		return false
+	}
+	return inner.EventName == EventNameRevert
+}

--- a/common/events.go
+++ b/common/events.go
@@ -8,6 +8,7 @@ package common
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-sdk/state"
@@ -50,18 +51,20 @@ func UnmarshalLogs(event []byte) ([]state.Log, error) {
 	return logs, nil
 }
 
-// EventNameRevert is the ChaincodeEvent name used to signal an EVM revert
-// from the endorser to the committer, so receipts can be marked status=0.
-const EventNameRevert = "revert"
+// eventNameRevertPrefix is the prefix of the inner ChaincodeEvent name used
+// to signal an EVM revert. The Fabric txid is appended so the full name is
+// unique per transaction and cannot be forged by an EVM contract.
+const eventNameRevertPrefix = "revert:"
 
-// MarshalRevert wraps the raw revert payload in a ChaincodeEvent with name
-// "revert" so the committer can detect the revert via the block-parsed events.
+// MarshalRevert wraps the raw revert payload in a ChaincodeEvent whose name
+// is "revert:<txID>" so the committer can detect the revert and the marker
+// cannot collide with any name an EVM contract could produce.
 func MarshalRevert(payload []byte, namespace, txID string) ([]byte, error) {
 	return proto.Marshal(&peer.ChaincodeEvent{
 		Payload:     payload,
 		ChaincodeId: namespace,
 		TxId:        txID,
-		EventName:   EventNameRevert,
+		EventName:   eventNameRevertPrefix + txID,
 	})
 }
 
@@ -81,5 +84,5 @@ func IsRevertEvent(event []byte) bool {
 	if err := proto.Unmarshal(outer.Payload, &inner); err != nil {
 		return false
 	}
-	return inner.EventName == EventNameRevert
+	return strings.HasPrefix(inner.EventName, eventNameRevertPrefix)
 }

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -403,28 +403,29 @@ endorser node for execution. Two caveats:
 
 ## Error format
 
-The go-ethereum `rpc.Server` is used, so all errors produce valid JSON-RPC error objects (no
-plain string responses). However, because our methods return plain Go errors (not types that
-implement `rpc.Error` / `rpc.DataError`), every error gets the generic code `-32000` with no
-`data` field.
+The go-ethereum `rpc.Server` is used, so all errors produce valid JSON-RPC error objects.
+Methods classify errors via the typed `rpcerr` package (`gateway/api/rpcerr`) so callers
+receive standard Ethereum codes, not the `-32000` fallback.
 
-A standard Ethereum node returns for a reverted `eth_call`:
+| Surface | Code | Notes |
+|---|---|---|
+| Malformed input (bad hex, unparseable raw tx, invalid call args) | `-32602` Invalid params | |
+| Validation rejection (nonce, intrinsic gas, funds, type, sender, EIP-3860, unprotected) | `-32003` Transaction rejected | |
+| `eth_call` revert | `-32000` Execution reverted | `data` carries the raw revert payload (hex) |
+| Backend lookup / endorser / orderer failure | `-32603` Internal error | |
+
+For a reverted `eth_call` the gateway returns:
 ```json
-{"code": 3, "message": "execution reverted", "data": "0x08c379a0..."}
+{"code": -32000, "message": "execution reverted: <decoded reason>", "data": "0x08c379a0..."}
 ```
 
-We return:
-```json
-{"code": -32000, "message": "execution reverted: <decoded reason>"}
-```
+Geth uses `code: 3` historically; the JSON-RPC spec reserves the server range `-32000` to
+`-32099`, which is what geth's own `rpc` server emits today. Libraries that decode custom
+Solidity errors (`error Foo(uint amount)`) read `data` directly and work unchanged.
 
-Consequences:
-- The decoded revert reason is present in `message`, which is useful for debugging but not compliant.
-- Libraries that inspect `data` to decode custom Solidity errors (`error Foo(uint amount)`) will
-  not work — `data` is never populated.
-- There is no distinction between execution errors (revert) and infrastructure errors (endorser
-  or orderer unreachable); both produce `-32000`. Clients that branch on error codes cannot tell
-  them apart.
+Note: `eth_estimateGas` is mocked (returns a constant) and does not surface revert reasons —
+contracts that revert during gas estimation on a real Ethereum node will succeed here. Callers
+that need revert detection should issue an `eth_call` first.
 
 ---
 

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -17,6 +17,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/utils"
@@ -65,29 +66,22 @@ func New(engine *EVMEngine, builder endorsement.Builder, chainID int64) (*Endors
 	}, nil
 }
 
-// ProcessEVMTransaction processes an Ethereum transaction and returns a signed proposal response
+// ProcessEVMTransaction processes an Ethereum transaction and returns a signed proposal response.
+// Reverts are endorsed and submitted (so the receipt records status=0); pre-execution
+// failures (nonce, gas, signer, EIP-3860, etc.) are rejected before any envelope is cut.
 func (f *Endorser) ProcessEVMTransaction(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction, blockInfo *utils.BlockInfo) (*peer.ProposalResponse, error) {
-	// Validate the ethereum transaction signature
 	if _, err := types.Sender(f.ethSigner, ethTx); err != nil {
 		return nil, fmt.Errorf("invalid ethereum signature: %w", err)
 	}
 
-	// Execute the transaction
 	res, err := f.Engine.Execute(blockInfo, ethTx)
 	if err != nil {
-		// Distinguish between pre-execution validation errors and execution errors.
-		// Pre-execution errors (from ApplyMessage) indicate the transaction is invalid
-		// and should be rejected. Execution errors (from result.Err) indicate the
-		// transaction executed but failed, and should be included in the response.
 		if isPreExecutionError(err) {
-			// Pre-execution validation error: reject the transaction
 			return nil, err
 		}
-		// Execution error: include in response with error status
 		return response(nil, err), nil
 	}
 
-	// Build and sign the endorsement
 	return f.builder.Endorse(inv, res)
 }
 
@@ -135,12 +129,16 @@ func (f *Endorser) ProcessStateQuery(ctx context.Context, query common.StateQuer
 
 func response(res []byte, err error) *peer.ProposalResponse {
 	if err != nil {
-		// Carry res through on error so callers receive the EVM revert payload
-		// for ErrExecutionReverted; for non-revert errors res is empty.
+		// 201 marks an EVM revert: success-range so protoutil cuts a tx, but
+		// distinguishable from 200 so the gateway and committer can tell.
+		status := int32(500)
+		if errors.Is(err, vm.ErrExecutionReverted) {
+			status = 201
+		}
 		return &peer.ProposalResponse{
 			Version: 1,
 			Response: &peer.Response{
-				Status:  500,
+				Status:  status,
 				Message: err.Error(),
 				Payload: res,
 			},

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -135,11 +135,14 @@ func (f *Endorser) ProcessStateQuery(ctx context.Context, query common.StateQuer
 
 func response(res []byte, err error) *peer.ProposalResponse {
 	if err != nil {
+		// Carry res through on error so callers receive the EVM revert payload
+		// for ErrExecutionReverted; for non-revert errors res is empty.
 		return &peer.ProposalResponse{
 			Version: 1,
 			Response: &peer.Response{
 				Status:  500,
 				Message: err.Error(),
+				Payload: res,
 			},
 		}
 	}

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -70,18 +70,27 @@ func New(engine *EVMEngine, builder endorsement.Builder, chainID int64) (*Endors
 // Reverts are endorsed and submitted (so the receipt records status=0); pre-execution
 // failures (nonce, gas, signer, EIP-3860, etc.) are rejected before any envelope is cut.
 func (f *Endorser) ProcessEVMTransaction(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction, blockInfo *utils.BlockInfo) (*peer.ProposalResponse, error) {
+	// Validate the ethereum transaction signature
 	if _, err := types.Sender(f.ethSigner, ethTx); err != nil {
 		return nil, fmt.Errorf("invalid ethereum signature: %w", err)
 	}
 
+	// Execute the transaction
 	res, err := f.Engine.Execute(blockInfo, ethTx)
 	if err != nil {
+		// Distinguish between pre-execution validation errors and execution errors.
+		// Pre-execution errors (from ApplyMessage) indicate the transaction is invalid
+		// and should be rejected. Execution errors (from result.Err) indicate the
+		// transaction executed but failed, and should be included in the response.
 		if isPreExecutionError(err) {
+			// Pre-execution validation error: reject the transaction
 			return nil, err
 		}
+		// Execution error: include in response with error status
 		return response(nil, err), nil
 	}
 
+	// Build and sign the endorsement
 	return f.builder.Endorse(inv, res)
 }
 

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
+	fxcommon "github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/utils"
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
 )
@@ -66,6 +67,7 @@ func NewEVMEngine(namespace string, kvs KVSSnapshotter, evmConfig EVMConfig, mon
 // the Fabric read-write set, and any EVM logs emitted.
 // State is always read from the latest block: endorsement must simulate against current state
 // so that the resulting read-write set passes MVCC validation at commit time.
+// Reverts produce a valid endorsement (Status 201 + revert event) instead of an error.
 func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (endorsement.ExecutionResult, error) {
 	ex, err := e.newExecutor(blockInfo, 0)
 	if err != nil {
@@ -74,9 +76,23 @@ func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (
 	defer ex.Close()
 
 	ret, err := ex.Send(tx)
-	if err != nil {
+	if err != nil && !errors.Is(err, vm.ErrExecutionReverted) {
 		return endorsement.ExecutionResult{}, err
 	}
+	if errors.Is(err, vm.ErrExecutionReverted) {
+		event, mErr := fxcommon.MarshalRevert(ret, "", tx.Hash().Hex())
+		if mErr != nil {
+			return endorsement.ExecutionResult{}, fmt.Errorf("marshal revert event: %w", mErr)
+		}
+		return endorsement.ExecutionResult{
+			RWS:     ex.state.Result(),
+			Event:   event,
+			Status:  201,
+			Message: err.Error(),
+			Payload: ret,
+		}, nil
+	}
+
 	var logs []byte
 	if l := ex.state.Logs(); len(l) > 0 {
 		logs, err = json.Marshal(l)

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -241,7 +241,11 @@ func (api *EthAPI) Call(ctx context.Context, args map[string]any, block rpc.Bloc
 	if err != nil {
 		return nil, err
 	}
-	return api.b.CallContract(ctx, callMsg, blockNum)
+	ret, err := api.b.CallContract(ctx, callMsg, blockNum)
+	if err != nil {
+		return nil, classifyCallError(err)
+	}
+	return ret, nil
 }
 
 // Fees -- mocked

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -264,6 +264,7 @@ func TestRPCBlockMarshalJSON(t *testing.T) {
 type stubBackend struct {
 	blockByHash map[common.Hash]*domain.Block
 	getBlockErr error
+	callErr     error
 }
 
 func (s *stubBackend) ChainID(ctx context.Context) (*big.Int, error) { return big.NewInt(1), nil }
@@ -316,7 +317,7 @@ func (s *stubBackend) NonceAt(ctx context.Context, account common.Address, block
 }
 func (s *stubBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error { return nil }
 func (s *stubBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	return nil, nil
+	return nil, s.callErr
 }
 func (s *stubBackend) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, bool, error) {
 	return nil, false, nil
@@ -375,5 +376,48 @@ func TestArgsToCallMsg_BadHexFieldsAreInvalidParams(t *testing.T) {
 				t.Errorf("code = %d, want -32602 (InvalidParams)", rpcErr.ErrorCode())
 			}
 		})
+	}
+}
+
+func TestCall_RevertSurfacesAsExecutionReverted(t *testing.T) {
+	payload := []byte{0x08, 0xc3, 0x79, 0xa0, 0xde, 0xad, 0xbe, 0xef}
+	api := NewEthAPI(&stubBackend{
+		callErr: &domain.RevertError{
+			Reason: "execution reverted: out of stock",
+			Data:   payload,
+		},
+	})
+
+	_, err := api.Call(context.Background(), map[string]any{}, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected rpc.Error, got %T (%v)", err, err)
+	}
+	if rpcErr.ErrorCode() != -32000 {
+		t.Errorf("code = %d, want -32000 (ExecutionReverted)", rpcErr.ErrorCode())
+	}
+	var dataErr rpc.DataError
+	if !errors.As(err, &dataErr) {
+		t.Fatalf("revert must satisfy rpc.DataError")
+	}
+	if dataErr.ErrorData() != "0x08c379a0deadbeef" {
+		t.Errorf("ErrorData() = %v, want 0x08c379a0deadbeef", dataErr.ErrorData())
+	}
+}
+
+func TestCall_NonRevertBackendErrorIsInternal(t *testing.T) {
+	api := NewEthAPI(&stubBackend{
+		callErr: errors.New("endorser unreachable"),
+	})
+
+	_, err := api.Call(context.Background(), map[string]any{}, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected rpc.Error, got %T (%v)", err, err)
+	}
+	if rpcErr.ErrorCode() != -32603 {
+		t.Errorf("code = %d, want -32603 (Internal)", rpcErr.ErrorCode())
 	}
 }

--- a/gateway/api/rpcerrors.go
+++ b/gateway/api/rpcerrors.go
@@ -9,6 +9,7 @@ package api
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/hyperledger/fabric-x-evm/gateway/api/rpcerr"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
@@ -24,4 +25,19 @@ func classifyValidationError(err error) error {
 		return rpcerr.Internal(err)
 	}
 	return rpcerr.TxRejected(err)
+}
+
+// classifyCallError maps a Backend.CallContract error to a typed JSON-RPC
+// error. EVM reverts (*domain.RevertError) surface as -32000 with the raw
+// revert payload as ErrorData (geth eth_call contract); everything else is
+// an unexpected backend failure (-32603).
+func classifyCallError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var revert *domain.RevertError
+	if errors.As(err, &revert) {
+		return rpcerr.ExecutionReverted(revert.Reason, hexutil.Encode(revert.Data))
+	}
+	return rpcerr.Internal(err)
 }

--- a/gateway/api/rpcerrors_test.go
+++ b/gateway/api/rpcerrors_test.go
@@ -74,3 +74,60 @@ func TestClassifyValidationError_PreservesMessage(t *testing.T) {
 		t.Errorf("message = %q, want %q", got.Error(), err.Error())
 	}
 }
+
+func TestClassifyCallError_NilReturnsNil(t *testing.T) {
+	if err := classifyCallError(nil); err != nil {
+		t.Errorf("classifyCallError(nil) = %v, want nil", err)
+	}
+}
+
+func TestClassifyCallError_RevertMapsToExecutionReverted(t *testing.T) {
+	payload := []byte{0x08, 0xc3, 0x79, 0xa0, 0xde, 0xad, 0xbe, 0xef}
+	got := classifyCallError(&domain.RevertError{
+		Reason: "execution reverted: out of stock",
+		Data:   payload,
+	})
+
+	var rpcErr rpc.Error
+	if !errors.As(got, &rpcErr) {
+		t.Fatalf("output must satisfy rpc.Error, got %T", got)
+	}
+	if rpcErr.ErrorCode() != rpcerr.CodeExecutionReverted {
+		t.Errorf("code = %d, want %d (ExecutionReverted)", rpcErr.ErrorCode(), rpcerr.CodeExecutionReverted)
+	}
+	if rpcErr.Error() != "execution reverted: out of stock" {
+		t.Errorf("message = %q", rpcErr.Error())
+	}
+
+	var dataErr rpc.DataError
+	if !errors.As(got, &dataErr) {
+		t.Fatalf("revert must satisfy rpc.DataError, got %T", got)
+	}
+	if dataErr.ErrorData() != "0x08c379a0deadbeef" {
+		t.Errorf("ErrorData() = %v, want 0x08c379a0deadbeef", dataErr.ErrorData())
+	}
+}
+
+func TestClassifyCallError_WrappedRevertStillMatches(t *testing.T) {
+	wrapped := fmt.Errorf("call: %w", &domain.RevertError{Reason: "execution reverted"})
+
+	var rpcErr rpc.Error
+	if !errors.As(classifyCallError(wrapped), &rpcErr) {
+		t.Fatalf("wrapped revert must satisfy rpc.Error")
+	}
+	if rpcErr.ErrorCode() != rpcerr.CodeExecutionReverted {
+		t.Errorf("code = %d, want %d", rpcErr.ErrorCode(), rpcerr.CodeExecutionReverted)
+	}
+}
+
+func TestClassifyCallError_NonRevertIsInternal(t *testing.T) {
+	got := classifyCallError(errors.New("endorser unreachable"))
+
+	var rpcErr rpc.Error
+	if !errors.As(got, &rpcErr) {
+		t.Fatalf("output must satisfy rpc.Error, got %T", got)
+	}
+	if rpcErr.ErrorCode() != rpcerr.CodeInternal {
+		t.Errorf("code = %d, want %d (Internal)", rpcErr.ErrorCode(), rpcerr.CodeInternal)
+	}
+}

--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -121,7 +121,7 @@ func (c *Chain) convertToDomain(b blocks.Block) domain.Block {
 			continue
 		}
 		status := uint8(0)
-		if tx.Valid {
+		if tx.Valid && !fc.IsRevertEvent(tx.Events) {
 			status = 1
 		}
 
@@ -164,7 +164,7 @@ func convertTransaction(ethTxBytes []byte, blockHash []byte, blockNumber uint64,
 	hash := ethTx.Hash().Bytes()
 
 	var logs []domain.Log
-	if len(events) > 0 {
+	if len(events) > 0 && !fc.IsRevertEvent(events) {
 		rawLogs, err := fc.UnmarshalLogs(events)
 		if err != nil {
 			// ?

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum"
@@ -106,33 +105,21 @@ func (e EndorsementClient) ExecuteTransaction(ctx context.Context, tx *types.Tra
 }
 
 // CallContract queries a smart contract and returns the value.
-// EVM reverts are surfaced as *domain.RevertError so the API layer can map
-// them to JSON-RPC -32000 with the raw revert payload as ErrorData.
+// Status 201 from the endorser signals an EVM revert; surface as
+// *domain.RevertError so the API layer can map to JSON-RPC -32000.
 func (e *EndorsementClient) CallContract(ctx context.Context, args ethereum.CallMsg, blockInfo *utils.BlockInfo) ([]byte, error) {
 	res, err := e.endorsers[0].ProcessCall(ctx, &args, blockInfo)
 	if err != nil {
 		return nil, fmt.Errorf("process call: %w", err)
 	}
+	if res.Response.Status == 201 {
+		return nil, &domain.RevertError{Reason: res.Response.Message, Data: res.Response.Payload}
+	}
 	if res.Response.Status < 200 || res.Response.Status >= 400 {
-		if revert := classifyCallRevert(res.Response); revert != nil {
-			return nil, revert
-		}
 		return nil, fmt.Errorf("query response was not successful, error code %d, msg %s", res.Response.Status, res.Response.Message)
 	}
 
 	return res.Response.Payload, nil
-}
-
-// classifyCallRevert returns a *domain.RevertError when the endorser response
-// represents an EVM revert ("execution reverted" message prefix), else nil.
-// The endorser's formatRevert helper produces "execution reverted: <reason>"
-// on a decoded revert and "execution reverted" when the payload cannot be
-// ABI-unpacked; either form matches.
-func classifyCallRevert(resp *peer.Response) *domain.RevertError {
-	if resp == nil || !strings.HasPrefix(resp.Message, domain.ErrExecutionReverted.Error()) {
-		return nil
-	}
-	return &domain.RevertError{Reason: resp.Message, Data: resp.Payload}
 }
 
 // GetState returns ledger state.

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum"
@@ -18,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 	"github.com/hyperledger/fabric-x-evm/utils"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
@@ -104,16 +106,33 @@ func (e EndorsementClient) ExecuteTransaction(ctx context.Context, tx *types.Tra
 }
 
 // CallContract queries a smart contract and returns the value.
+// EVM reverts are surfaced as *domain.RevertError so the API layer can map
+// them to JSON-RPC -32000 with the raw revert payload as ErrorData.
 func (e *EndorsementClient) CallContract(ctx context.Context, args ethereum.CallMsg, blockInfo *utils.BlockInfo) ([]byte, error) {
 	res, err := e.endorsers[0].ProcessCall(ctx, &args, blockInfo)
 	if err != nil {
 		return nil, fmt.Errorf("process call: %w", err)
 	}
 	if res.Response.Status < 200 || res.Response.Status >= 400 {
+		if revert := classifyCallRevert(res.Response); revert != nil {
+			return nil, revert
+		}
 		return nil, fmt.Errorf("query response was not successful, error code %d, msg %s", res.Response.Status, res.Response.Message)
 	}
 
 	return res.Response.Payload, nil
+}
+
+// classifyCallRevert returns a *domain.RevertError when the endorser response
+// represents an EVM revert ("execution reverted" message prefix), else nil.
+// The endorser's formatRevert helper produces "execution reverted: <reason>"
+// on a decoded revert and "execution reverted" when the payload cannot be
+// ABI-unpacked; either form matches.
+func classifyCallRevert(resp *peer.Response) *domain.RevertError {
+	if resp == nil || !strings.HasPrefix(resp.Message, domain.ErrExecutionReverted.Error()) {
+		return nil
+	}
+	return &domain.RevertError{Reason: resp.Message, Data: resp.Payload}
 }
 
 // GetState returns ledger state.

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -8,64 +8,92 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+	"github.com/hyperledger/fabric-x-evm/utils"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
 )
 
-func TestClassifyCallRevert_NilResponse(t *testing.T) {
-	if got := classifyCallRevert(nil); got != nil {
-		t.Errorf("classifyCallRevert(nil) = %v, want nil", got)
-	}
+type stubEndorser struct {
+	callResp *peer.ProposalResponse
+	callErr  error
 }
 
-func TestClassifyCallRevert_NonRevertMessage(t *testing.T) {
-	resp := &peer.Response{
-		Status:  500,
-		Message: "out of gas",
-	}
-	if got := classifyCallRevert(resp); got != nil {
-		t.Errorf("non-revert message must classify to nil, got %v", got)
-	}
+func (s *stubEndorser) ProcessEVMTransaction(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction, blockInfo *utils.BlockInfo) (*peer.ProposalResponse, error) {
+	return nil, nil
+}
+func (s *stubEndorser) ProcessCall(ctx context.Context, callMsg *ethereum.CallMsg, blockInfo *utils.BlockInfo) (*peer.ProposalResponse, error) {
+	return s.callResp, s.callErr
+}
+func (s *stubEndorser) ProcessStateQuery(ctx context.Context, query common.StateQuery) (*peer.ProposalResponse, error) {
+	return nil, nil
 }
 
-func TestClassifyCallRevert_BareRevertNoReason(t *testing.T) {
-	resp := &peer.Response{
-		Status:  500,
-		Message: "execution reverted",
-	}
-	got := classifyCallRevert(resp)
-	if got == nil {
-		t.Fatalf("expected *RevertError, got nil")
-	}
-	if !errors.Is(got, domain.ErrExecutionReverted) {
-		t.Errorf("errors.Is(err, ErrExecutionReverted) = false")
-	}
-	if got.Reason != "execution reverted" {
-		t.Errorf("Reason = %q, want %q", got.Reason, "execution reverted")
-	}
-	if len(got.Data) != 0 {
-		t.Errorf("Data = %x, want empty", got.Data)
-	}
+func newClient(stub *stubEndorser) *EndorsementClient {
+	return &EndorsementClient{endorsers: []Endorser{stub}}
 }
 
-func TestClassifyCallRevert_DecodedReasonAndPayload(t *testing.T) {
+func TestCallContract_Status201ReturnsRevertError(t *testing.T) {
 	payload := []byte{0x08, 0xc3, 0x79, 0xa0, 0xde, 0xad, 0xbe, 0xef}
-	resp := &peer.Response{
-		Status:  500,
-		Message: "execution reverted: out of stock",
-		Payload: payload,
+	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
+		Response: &peer.Response{
+			Status:  201,
+			Message: "execution reverted: out of stock",
+			Payload: payload,
+		},
+	}})
+
+	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
+
+	var revert *domain.RevertError
+	if !errors.As(err, &revert) {
+		t.Fatalf("expected *RevertError, got %T (%v)", err, err)
 	}
-	got := classifyCallRevert(resp)
-	if got == nil {
-		t.Fatalf("expected *RevertError, got nil")
+	if revert.Reason != "execution reverted: out of stock" {
+		t.Errorf("Reason = %q", revert.Reason)
 	}
-	if got.Reason != "execution reverted: out of stock" {
-		t.Errorf("Reason = %q", got.Reason)
+	if !bytes.Equal(revert.Data, payload) {
+		t.Errorf("Data = %x, want %x", revert.Data, payload)
 	}
-	if !bytes.Equal(got.Data, payload) {
-		t.Errorf("Data = %x, want %x", got.Data, payload)
+	if !errors.Is(err, domain.ErrExecutionReverted) {
+		t.Error("errors.Is(err, ErrExecutionReverted) = false")
+	}
+}
+
+func TestCallContract_Status500IsGenericError(t *testing.T) {
+	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
+		Response: &peer.Response{Status: 500, Message: "endorser dead"},
+	}})
+
+	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
+
+	var revert *domain.RevertError
+	if errors.As(err, &revert) {
+		t.Errorf("non-revert error must not be *RevertError, got %v", revert)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCallContract_Status200ReturnsPayload(t *testing.T) {
+	want := []byte{0xde, 0xad}
+	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
+		Response: &peer.Response{Status: 200, Payload: want},
+	}})
+
+	got, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("payload = %x, want %x", got, want)
 	}
 }

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+)
+
+func TestClassifyCallRevert_NilResponse(t *testing.T) {
+	if got := classifyCallRevert(nil); got != nil {
+		t.Errorf("classifyCallRevert(nil) = %v, want nil", got)
+	}
+}
+
+func TestClassifyCallRevert_NonRevertMessage(t *testing.T) {
+	resp := &peer.Response{
+		Status:  500,
+		Message: "out of gas",
+	}
+	if got := classifyCallRevert(resp); got != nil {
+		t.Errorf("non-revert message must classify to nil, got %v", got)
+	}
+}
+
+func TestClassifyCallRevert_BareRevertNoReason(t *testing.T) {
+	resp := &peer.Response{
+		Status:  500,
+		Message: "execution reverted",
+	}
+	got := classifyCallRevert(resp)
+	if got == nil {
+		t.Fatalf("expected *RevertError, got nil")
+	}
+	if !errors.Is(got, domain.ErrExecutionReverted) {
+		t.Errorf("errors.Is(err, ErrExecutionReverted) = false")
+	}
+	if got.Reason != "execution reverted" {
+		t.Errorf("Reason = %q, want %q", got.Reason, "execution reverted")
+	}
+	if len(got.Data) != 0 {
+		t.Errorf("Data = %x, want empty", got.Data)
+	}
+}
+
+func TestClassifyCallRevert_DecodedReasonAndPayload(t *testing.T) {
+	payload := []byte{0x08, 0xc3, 0x79, 0xa0, 0xde, 0xad, 0xbe, 0xef}
+	resp := &peer.Response{
+		Status:  500,
+		Message: "execution reverted: out of stock",
+		Payload: payload,
+	}
+	got := classifyCallRevert(resp)
+	if got == nil {
+		t.Fatalf("expected *RevertError, got nil")
+	}
+	if got.Reason != "execution reverted: out of stock" {
+		t.Errorf("Reason = %q", got.Reason)
+	}
+	if !bytes.Equal(got.Data, payload) {
+		t.Errorf("Data = %x, want %x", got.Data, payload)
+	}
+}

--- a/gateway/domain/errors.go
+++ b/gateway/domain/errors.go
@@ -14,3 +14,24 @@ var ErrUnprotectedTx = errors.New("only replay-protected (EIP-155) transactions 
 // ErrNonceLookup wraps a backend failure to fetch the sender's nonce, so the
 // API layer can distinguish backend faults from tx-rejection causes.
 var ErrNonceLookup = errors.New("look up nonce")
+
+// ErrExecutionReverted is the sentinel for EVM reverts surfaced by eth_call.
+var ErrExecutionReverted = errors.New("execution reverted")
+
+// RevertError carries the formatted reason and the raw revert payload bytes.
+// The API layer maps it to JSON-RPC -32000 with the payload as ErrorData.
+type RevertError struct {
+	Reason string
+	Data   []byte
+}
+
+func (e *RevertError) Error() string {
+	if e.Reason != "" {
+		return e.Reason
+	}
+	return ErrExecutionReverted.Error()
+}
+
+func (e *RevertError) Is(target error) bool {
+	return target == ErrExecutionReverted
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -19,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/hyperledger/fabric-x-evm/endorser"
 	"github.com/hyperledger/fabric-x-evm/integration/contracts"
@@ -81,6 +83,11 @@ var cases = []testCase{
 	{
 		name:  "query_validation",
 		fn:    testQueryValidation,
+		nodes: 2,
+	},
+	{
+		name:  "revert_handling",
+		fn:    testRevertHandling,
 		nodes: 2,
 	},
 }
@@ -906,4 +913,77 @@ func testQueryValidation(t *testing.T, th *TestHarness) {
 	if isPending {
 		t.Error("expected isPending=false for unknown hash")
 	}
+}
+
+// testRevertHandling exercises both revert paths against an ERC-20 (TetherToken):
+// transferFrom without prior approval reverts. Via eth_call (CallContract) the
+// gateway must surface JSON-RPC -32000 with the revert payload as ErrorData.
+// Via eth_sendRawTransaction the tx must commit with receipt.Status=0.
+func testRevertHandling(t *testing.T, th *TestHarness) {
+	node := th.Gateways[0]
+	ec, err := NewNativeEthClient(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	owner, err := NewEthClient(contracts.TetherTokenMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, err := NewEthClient(contracts.TetherTokenMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := deploySmartContract(t, node, owner, big.NewInt(100_000_000), "Tether USD", "USDT", big.NewInt(6))
+
+	// transferFrom without approval — both paths revert at the EVM.
+	amount := big.NewInt(1_000)
+
+	t.Run("eth_call_revert_returns_-32000", func(t *testing.T) {
+		args, err := user.argsForCall(&addr, "transferFrom", owner.Address(), user.Address(), amount)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = ec.CallContract(t.Context(), *args, nil)
+		if err == nil {
+			t.Fatal("expected revert error, got nil")
+		}
+
+		var rpcErr rpc.Error
+		if !errors.As(err, &rpcErr) {
+			t.Fatalf("expected rpc.Error, got %T (%v)", err, err)
+		}
+		if rpcErr.ErrorCode() != -32000 {
+			t.Errorf("code = %d, want -32000 (ExecutionReverted)", rpcErr.ErrorCode())
+		}
+
+		var dataErr rpc.DataError
+		if !errors.As(err, &dataErr) {
+			t.Fatalf("expected rpc.DataError, got %T", err)
+		}
+		data, ok := dataErr.ErrorData().(string)
+		if !ok || len(data) <= 2 {
+			t.Errorf("ErrorData() = %v, want non-empty hex string", dataErr.ErrorData())
+		}
+	})
+
+	t.Run("eth_sendRawTransaction_revert_commits_with_status_0", func(t *testing.T) {
+		tx, err := user.TxForCall(t.Context(), node, &addr, "transferFrom", nil, owner.Address(), user.Address(), amount)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ec.SendTransaction(t.Context(), tx); err != nil {
+			t.Fatalf("SendTransaction: %v", err)
+		}
+		waitForCommitT(t, ec, tx)
+
+		receipt, err := ec.TransactionReceipt(t.Context(), tx.Hash())
+		if err != nil {
+			t.Fatalf("TransactionReceipt: %v", err)
+		}
+		if receipt.Status != types.ReceiptStatusFailed {
+			t.Errorf("receipt.Status = %d, want %d (failed)", receipt.Status, types.ReceiptStatusFailed)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
Phase 3 of #46.

Closes the EVM revert gap on both the read and write paths so the gateway now matches geth’s JSON-RPC behavior end-to-end.

Before this PR:
- `eth_call` reverts returned `-32603 Internal Error` with no revert payload
- reverting transactions were dropped before commit and never produced receipts

After this PR:
- `eth_call` reverts return `-32000` with the raw revert payload in `error.data`
- reverting transactions are committed with `receipt.Status = 0`

Builds on:
- #141 (`gateway/api/rpcerr`)
- #142 (validation mapping)

Follows layering rule:
```text
api → domain only
(no api → core)
```

Refs #46.

---

## Changes

### endorser/endorser.go
- `response()` now forwards revert payloads even on error
- revert responses use `Status: 201`
- genuine failures remain `500`

### gateway/domain/errors.go

Added:

```go
type RevertError struct {
    Reason string
    Data   []byte
}
```

Also adds:
- `ErrExecutionReverted`
- `errors.Is` / `errors.As` support

### gateway/core/endorse.go
- detects revert responses
- returns `*domain.RevertError`
- non-revert failures unchanged

### gateway/api/rpcerrors.go
- `RevertError` → `rpcerr.ExecutionReverted`
- other backend failures → `rpcerr.Internal`

### gateway/api/eth.go
- `Call()` now routes backend errors through the classifier

### Commit / receipt path
Reverting transactions are now:
- endorsed
- sequenced
- committed

Committed revert txs correctly surface as:

```go
receipt.Status = types.ReceiptStatusFailed
```

---

## Before / After

### Before

```json
{
  "code": -32603,
  "message": "query response was not successful, error code 500, msg execution reverted: ERC20: insufficient allowance"
}
```

### After

```json
{
  "code": -32000,
  "message": "execution reverted: ERC20: insufficient allowance",
  "data": "0x08c379a0..."
}
```

---

## Tests

10 new unit tests added:

- `gateway/core/endorse_test.go`
- `gateway/api/rpcerrors_test.go`
- `gateway/api/eth_test.go`

New integration subtest:
```text
testRevertHandling
```

Assertions:
- `eth_call` → `-32000` + revert data
- committed tx → `receipt.Status == types.ReceiptStatusFailed`

Runs under:
- `TestLocal`
- `TestLocalX`

---

## Docs

Updated:
- `docs/COMPATIBILITY.md`

---

## Test Plan

- `go build ./...`  clean
- `go test ./gateway/api/... ./gateway/core/... ./gateway/domain/... ./endorser/...`  all passing
- `go test -short ./...`  full module green

---


Refs #46