### PR TITLE
tests: prove query state is ledger-derived and rebuildable

### DIFF
--- a/gateway/core/chain_ledger_derived_state_test.go
+++ b/gateway/core/chain_ledger_derived_state_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	fc "github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	sdkstate "github.com/hyperledger/fabric-x-sdk/state"
+	_ "modernc.org/sqlite"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+type ledgerDerivedSnapshot struct {
+	Latest domain.Block
+	Blocks []domain.Block
+	Txs    []domain.Transaction
+	Logs   []domain.Log
+}
+
+func ledgerDerivedHash(prefix byte) []byte {
+	hash := make([]byte, 32)
+	hash[0] = prefix
+	return hash
+}
+
+func ledgerDerivedBalanceWrite(addr common.Address, bal int64) blocks.KVWrite {
+	return blocks.KVWrite{
+		Key:   "acc:" + addr.Hex() + ":bal",
+		Value: big.NewInt(bal).Bytes(),
+	}
+}
+
+func ledgerDerivedNonceWrite(addr common.Address, nonce uint64) blocks.KVWrite {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, nonce)
+	return blocks.KVWrite{
+		Key:   "acc:" + addr.Hex() + ":nonce",
+		Value: buf,
+	}
+}
+
+func ledgerDerivedEvents(t *testing.T, txID string, logs []sdkstate.Log) []byte {
+	t.Helper()
+
+	payload, err := json.Marshal(logs)
+	require.NoError(t, err)
+
+	event, err := fc.MarshalLogs(payload, "evmcc", txID)
+	require.NoError(t, err)
+	return event
+}
+
+func newLedgerDerivedChain(t *testing.T, dir string) *Chain {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	chain, err := NewChain(filepath.Join(dir, "gateway.db"), filepath.Join(dir, "trie"))
+	require.NoError(t, err)
+	return chain
+}
+
+func captureLedgerDerivedSnapshot(t *testing.T, chain *Chain, blockCount int, txHashes [][]byte) ledgerDerivedSnapshot {
+	t.Helper()
+
+	latest, err := chain.LatestBlock(t.Context(), false)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+
+	snapshot := ledgerDerivedSnapshot{
+		Latest: *latest,
+		Blocks: make([]domain.Block, 0, blockCount),
+		Txs:    make([]domain.Transaction, 0, len(txHashes)),
+	}
+
+	for i := 1; i <= blockCount; i++ {
+		block, err := chain.GetBlockByNumber(t.Context(), uint64(i), false)
+		require.NoError(t, err)
+		require.NotNil(t, block)
+		snapshot.Blocks = append(snapshot.Blocks, *block)
+	}
+
+	for _, txHash := range txHashes {
+		tx, err := chain.GetTransactionByHash(t.Context(), txHash)
+		require.NoError(t, err)
+		require.NotNil(t, tx)
+		snapshot.Txs = append(snapshot.Txs, *tx)
+	}
+
+	logs, err := chain.GetLogs(t.Context(), domain.LogFilter{})
+	require.NoError(t, err)
+	snapshot.Logs = logs
+
+	return snapshot
+}
+
+func TestGatewayStateCanBeDiscardedAndRebuiltFromLedgerHistory(t *testing.T) {
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	from1 := crypto.PubkeyToAddress(key1.PublicKey)
+	from2 := crypto.PubkeyToAddress(key2.PublicKey)
+	sink := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	emitter := common.HexToAddress("0x5555555555555555555555555555555555555555")
+
+	tx1 := createTestEthTx(t, key1, sink, big.NewInt(15))
+	tx1Bytes, err := tx1.MarshalBinary()
+	require.NoError(t, err)
+
+	tx2 := createTestEthTx(t, key2, sink, big.NewInt(9))
+	tx2Bytes, err := tx2.MarshalBinary()
+	require.NoError(t, err)
+
+	tx3 := createTestEthTx(t, key1, sink, big.NewInt(5))
+	tx3Bytes, err := tx3.MarshalBinary()
+	require.NoError(t, err)
+
+	history := []blocks.Block{
+		{
+			Number:     1,
+			Hash:       ledgerDerivedHash(0x01),
+			ParentHash: ledgerDerivedHash(0x00),
+			Timestamp:  1010,
+			Transactions: []blocks.Transaction{{
+				ID:        "fabric-tx-1",
+				Number:    0,
+				Valid:     true,
+				Status:    0,
+				InputArgs: [][]byte{[]byte("invoke"), tx1Bytes},
+				NsRWS: []blocks.NsReadWriteSet{{
+					Namespace: "evmcc",
+					RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+						ledgerDerivedBalanceWrite(from1, 85),
+						ledgerDerivedNonceWrite(from1, 1),
+						ledgerDerivedBalanceWrite(sink, 15),
+					}},
+				}},
+			}},
+		},
+		{
+			Number:     2,
+			Hash:       ledgerDerivedHash(0x02),
+			ParentHash: ledgerDerivedHash(0x01),
+			Timestamp:  1020,
+			Transactions: []blocks.Transaction{
+				{
+					ID:        "fabric-tx-2",
+					Number:    0,
+					Valid:     true,
+					Status:    0,
+					InputArgs: [][]byte{[]byte("invoke"), tx2Bytes},
+					Events: ledgerDerivedEvents(t, "fabric-tx-2", []sdkstate.Log{{
+						Address: emitter.Bytes(),
+						Topics:  [][]byte{ledgerDerivedHash(0xA1)},
+						Data:    []byte{0xCA, 0xFE},
+					}}),
+					NsRWS: []blocks.NsReadWriteSet{{
+						Namespace: "evmcc",
+						RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+							ledgerDerivedBalanceWrite(from2, 91),
+							ledgerDerivedNonceWrite(from2, 1),
+							ledgerDerivedBalanceWrite(sink, 24),
+						}},
+					}},
+				},
+				{
+					ID:        "fabric-tx-3",
+					Number:    1,
+					Valid:     false,
+					Status:    11,
+					InputArgs: [][]byte{[]byte("invoke"), tx3Bytes},
+					NsRWS: []blocks.NsReadWriteSet{{
+						Namespace: "evmcc",
+						RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+							ledgerDerivedBalanceWrite(from1, 80),
+							ledgerDerivedNonceWrite(from1, 2),
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	source := newLedgerDerivedChain(t, sourceDir)
+	for _, block := range history {
+		require.NoError(t, source.Handle(t.Context(), block))
+	}
+
+	expectedRoot := source.ts.Root()
+	expectedSnapshot := captureLedgerDerivedSnapshot(
+		t,
+		source,
+		len(history),
+		[][]byte{tx1.Hash().Bytes(), tx2.Hash().Bytes(), tx3.Hash().Bytes()},
+	)
+
+	require.NoError(t, source.Close())
+	require.NoError(t, os.RemoveAll(sourceDir))
+
+	rebuilt := newLedgerDerivedChain(t, filepath.Join(t.TempDir(), "rebuilt"))
+	defer rebuilt.Close()
+	for _, block := range history {
+		require.NoError(t, rebuilt.Handle(t.Context(), block))
+	}
+
+	require.Equal(t, expectedRoot, rebuilt.ts.Root())
+
+	rebuiltSnapshot := captureLedgerDerivedSnapshot(
+		t,
+		rebuilt,
+		len(history),
+		[][]byte{tx1.Hash().Bytes(), tx2.Hash().Bytes(), tx3.Hash().Bytes()},
+	)
+	require.Equal(t, expectedSnapshot, rebuiltSnapshot)
+}

--- a/gateway/storage/store_ledger_derived_test.go
+++ b/gateway/storage/store_ledger_derived_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package storage
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+	"github.com/stretchr/testify/require"
+)
+
+type storeSnapshot struct {
+	Latest domain.Block
+	Blocks []domain.Block
+	Txs    []domain.Transaction
+	Logs   []domain.Log
+}
+
+func ledgerDerivedBlocks() []domain.Block {
+	block1Hash := makeHash(0xA1)
+	block2Hash := makeHash(0xA2)
+
+	tx1Hash := makeHash(0x11)
+	tx2Hash := makeHash(0x12)
+	tx3Hash := makeHash(0x13)
+
+	return []domain.Block{
+		{
+			BlockNumber: 1,
+			BlockHash:   block1Hash,
+			ParentHash:  makeHash(0x00),
+			StateRoot:   makeHash(0x31),
+			Timestamp:   1001,
+			Transactions: []domain.Transaction{
+				{
+					TxHash:          tx1Hash,
+					BlockHash:       block1Hash,
+					BlockNumber:     1,
+					TxIndex:         0,
+					RawTx:           []byte{0x01, 0xA1},
+					FromAddress:     makeAddress(0x21),
+					ToAddress:       makeAddress(0x31),
+					Status:          1,
+					FabricTxID:      "fabric-tx-1",
+					FabricTxStatus:  0,
+					ContractAddress: nil,
+					Logs: []domain.Log{
+						{
+							BlockNumber: 1,
+							BlockHash:   block1Hash,
+							TxHash:      tx1Hash,
+							TxIndex:     0,
+							LogIndex:    0,
+							Address:     makeAddress(0x41),
+							Topics:      [][]byte{makeHash(0x51)},
+							Data:        []byte{0x01},
+						},
+					},
+				},
+				{
+					TxHash:         tx2Hash,
+					BlockHash:      block1Hash,
+					BlockNumber:    1,
+					TxIndex:        1,
+					RawTx:          []byte{0x01, 0xA2},
+					FromAddress:    makeAddress(0x22),
+					ToAddress:      makeAddress(0x32),
+					Status:         0,
+					FabricTxID:     "fabric-tx-2",
+					FabricTxStatus: 11,
+				},
+			},
+		},
+		{
+			BlockNumber: 2,
+			BlockHash:   block2Hash,
+			ParentHash:  block1Hash,
+			StateRoot:   makeHash(0x32),
+			Timestamp:   1002,
+			Transactions: []domain.Transaction{
+				{
+					TxHash:         tx3Hash,
+					BlockHash:      block2Hash,
+					BlockNumber:    2,
+					TxIndex:        0,
+					RawTx:          []byte{0x01, 0xA3},
+					FromAddress:    makeAddress(0x23),
+					ToAddress:      makeAddress(0x33),
+					Status:         1,
+					FabricTxID:     "fabric-tx-3",
+					FabricTxStatus: 0,
+					Logs: []domain.Log{
+						{
+							BlockNumber: 2,
+							BlockHash:   block2Hash,
+							TxHash:      tx3Hash,
+							TxIndex:     0,
+							LogIndex:    0,
+							Address:     makeAddress(0x43),
+							Topics:      [][]byte{makeHash(0x53), makeHash(0x63)},
+							Data:        []byte{0x03, 0x04},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func tableColumns(t *testing.T, store *Store, table string) []string {
+	t.Helper()
+
+	rows, err := store.db.QueryContext(t.Context(), fmt.Sprintf("PRAGMA table_info(%s)", table))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var (
+		cid        int
+		name       string
+		dataType   string
+		notNull    int
+		defaultV   any
+		primaryKey int
+	)
+	cols := []string{}
+	for rows.Next() {
+		err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultV, &primaryKey)
+		require.NoError(t, err)
+		cols = append(cols, name)
+	}
+	require.NoError(t, rows.Err())
+	return cols
+}
+
+func userTables(t *testing.T, store *Store) []string {
+	t.Helper()
+
+	rows, err := store.db.QueryContext(t.Context(), `
+		SELECT name
+		FROM sqlite_master
+		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		ORDER BY name`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		require.NoError(t, rows.Scan(&table))
+		tables = append(tables, table)
+	}
+	require.NoError(t, rows.Err())
+	return tables
+}
+
+func captureStoreSnapshot(t *testing.T, store *Store, blocks []domain.Block) storeSnapshot {
+	t.Helper()
+
+	latest, err := store.LatestBlock(t.Context(), false)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+
+	snapshot := storeSnapshot{
+		Latest: *latest,
+		Blocks: make([]domain.Block, 0, len(blocks)),
+		Txs:    make([]domain.Transaction, 0),
+	}
+
+	for _, block := range blocks {
+		got, err := store.GetBlockByNumber(t.Context(), block.BlockNumber, false)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		snapshot.Blocks = append(snapshot.Blocks, *got)
+
+		for _, tx := range block.Transactions {
+			gotTx, err := store.GetTransactionByHash(t.Context(), tx.TxHash)
+			require.NoError(t, err)
+			require.NotNil(t, gotTx)
+			snapshot.Txs = append(snapshot.Txs, *gotTx)
+		}
+	}
+
+	logs, err := store.GetLogs(t.Context(), domain.LogFilter{})
+	require.NoError(t, err)
+	snapshot.Logs = logs
+
+	return snapshot
+}
+
+func TestSchemaContainsOnlyLedgerDerivedTables(t *testing.T) {
+	store := setupTestDB(t)
+
+	require.Equal(t, []string{"blocks", "logs", "transactions"}, userTables(t, store))
+
+	expectedColumns := map[string][]string{
+		"blocks": {
+			"block_number",
+			"block_hash",
+			"parent_hash",
+			"state_root",
+			"timestamp",
+			"extra_data",
+		},
+		"transactions": {
+			"tx_hash",
+			"block_hash",
+			"block_number",
+			"tx_index",
+			"raw_tx",
+			"from_address",
+			"to_address",
+			"contract_address",
+			"status",
+			"fabric_tx_id",
+			"fabric_tx_status",
+		},
+		"logs": {
+			"block_number",
+			"block_hash",
+			"tx_hash",
+			"tx_index",
+			"log_index",
+			"address",
+			"topic0",
+			"topic1",
+			"topic2",
+			"topic3",
+			"data",
+		},
+	}
+
+	for table, want := range expectedColumns {
+		got := tableColumns(t, store, table)
+		require.Truef(t, slices.Equal(want, got), "%s columns mismatch: want %v, got %v", table, want, got)
+	}
+}
+
+func TestStoreRebuildFromLedgerDerivedBlocksReproducesQueryableData(t *testing.T) {
+	blocks := ledgerDerivedBlocks()
+
+	original := setupTestDB(t)
+	for _, block := range blocks {
+		require.NoError(t, original.InsertBlock(t.Context(), block))
+	}
+	originalSnapshot := captureStoreSnapshot(t, original, blocks)
+
+	rebuilt := setupTestDB(t)
+	for _, block := range blocks {
+		require.NoError(t, rebuilt.InsertBlock(t.Context(), block))
+	}
+	rebuiltSnapshot := captureStoreSnapshot(t, rebuilt, blocks)
+
+	require.Equal(t, originalSnapshot, rebuiltSnapshot)
+}

--- a/gateway/storage/store_ledger_derived_test.go
+++ b/gateway/storage/store_ledger_derived_test.go
@@ -8,7 +8,6 @@ package storage
 
 import (
 	"fmt"
-	"slices"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
@@ -196,7 +195,7 @@ func captureStoreSnapshot(t *testing.T, store *Store, blocks []domain.Block) sto
 func TestSchemaContainsOnlyLedgerDerivedTables(t *testing.T) {
 	store := setupTestDB(t)
 
-	require.Equal(t, []string{"blocks", "logs", "transactions"}, userTables(t, store))
+	require.ElementsMatch(t, []string{"blocks", "logs", "transactions"}, userTables(t, store))
 
 	expectedColumns := map[string][]string{
 		"blocks": {
@@ -237,7 +236,7 @@ func TestSchemaContainsOnlyLedgerDerivedTables(t *testing.T) {
 
 	for table, want := range expectedColumns {
 		got := tableColumns(t, store, table)
-		require.Truef(t, slices.Equal(want, got), "%s columns mismatch: want %v, got %v", table, want, got)
+		require.ElementsMatchf(t, want, got, "%s columns mismatch: want %v, got %v", table, want, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

  Adds ledger-derived-state coverage for gateway persistence.

  Verifies that gateway state is rebuildable from committed ledger history by checking that:

  - the gateway query store contains only ledger-derived user tables
  - the same ledger-derived block data reproduces the same query results in a fresh store
  - local gateway state can be discarded and rebuilt from committed ledger history with the same result

  Refs #66.

  ## Test plan

  - `gofmt -l .`
  - `go vet $(go list ./... | grep -v '/integration')`
  - `go tool staticcheck ./...`
  - `go test -count=1 $(go list ./... | grep -v '/integration')`
