### PR TITLE
feat: wired Gateway and Chain together

### DIFF
--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -70,7 +70,16 @@ type Store interface {
 // New creates a new Ethereum Gateway.
 // It accepts a Chain instance which is used to register a callback for transaction completion notification.
 // This establishes the notification pipeline: when Chain commits a block, it calls the registered callback which removes completed transactions from the Gateway's queue.
-func New(ec *EndorsementClient, submitter Submitter, store Store, chain *Chain, chainID int64, workerCount int) (*Gateway, error) {
+func New(ec *EndorsementClient, submitter Submitter, chain *Chain, chainID int64, workerCount int) (*Gateway, error) {
+	if ec == nil {
+		return nil, fmt.Errorf("endorsement client cannot be nil")
+	}
+	if submitter == nil {
+		return nil, fmt.Errorf("submitter cannot be nil")
+	}
+	if chain == nil {
+		return nil, fmt.Errorf("chain cannot be nil")
+	}
 	if workerCount <= 0 {
 		workerCount = 1
 	}
@@ -79,7 +88,7 @@ func New(ec *EndorsementClient, submitter Submitter, store Store, chain *Chain, 
 	g := &Gateway{
 		endorsers:   ec,
 		submitter:   submitter,
-		store:       store,
+		store:       chain,
 		chain:       chain,
 		chainID:     cid,
 		chainConfig: cmn.BuildChainConfig(chainID),
@@ -89,7 +98,7 @@ func New(ec *EndorsementClient, submitter Submitter, store Store, chain *Chain, 
 	}
 
 	// Register callback with Chain to handle transaction completion notification.
-	// This callback is invoked when the Chain commits a block, allowing the Gateway to remove completed transactions from the pending queue.
+	// This callback is invoked when the Chain commits a block, marking transactions as completed.
 	chain.SetTxCompletionCallback(func(txHashes []common.Hash) {
 		for _, hash := range txHashes {
 			g.txQueue.Complete(hash)

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -41,6 +41,7 @@ type Submitter interface {
 type Gateway struct {
 	submitter   Submitter
 	endorsers   *EndorsementClient
+	chain       *Chain
 	store       Store
 	chainID     *big.Int
 	chainConfig *params.ChainConfig
@@ -67,22 +68,35 @@ type Store interface {
 }
 
 // New creates a new Ethereum Gateway.
-func New(ec *EndorsementClient, submitter Submitter, store Store, chainID int64, workerCount int) (*Gateway, error) {
+// It accepts a Chain instance which is used to register a callback for transaction completion notification.
+// This establishes the notification pipeline: when Chain commits a block, it calls the registered callback which removes completed transactions from the Gateway's queue.
+func New(ec *EndorsementClient, submitter Submitter, store Store, chain *Chain, chainID int64, workerCount int) (*Gateway, error) {
 	if workerCount <= 0 {
 		workerCount = 1
 	}
 
 	cid := big.NewInt(chainID)
-	return &Gateway{
+	g := &Gateway{
 		endorsers:   ec,
 		submitter:   submitter,
 		store:       store,
+		chain:       chain,
 		chainID:     cid,
 		chainConfig: cmn.BuildChainConfig(chainID),
 		signer:      types.LatestSignerForChainID(cid),
 		txQueue:     NewTxQueue(),
 		workerCount: workerCount,
-	}, nil
+	}
+
+	// Register callback with Chain to handle transaction completion notification.
+	// This callback is invoked when the Chain commits a block, allowing the Gateway to remove completed transactions from the pending queue.
+	chain.SetTxCompletionCallback(func(txHashes []common.Hash) {
+		for _, hash := range txHashes {
+			g.txQueue.Complete(hash)
+		}
+	})
+
+	return g, nil
 }
 
 // Start initializes the worker pool to process transactions from the queue

--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -27,9 +27,10 @@ import (
 // (for block ingestion) and core.Store (via the embedded *storage.Store, for API queries).
 type Chain struct {
 	*storage.Store
-	db       *sql.DB
-	ts       *trie.Store
-	prevHash common.Hash // Ethereum hash of last committed block; seeded from DB on startup
+	db                   *sql.DB
+	ts                   *trie.Store
+	prevHash             common.Hash // Ethereum hash of last committed block; seeded from DB on startup
+	txCompletionCallback func([]common.Hash)
 }
 
 // NewChain opens the SQLite database and trie store, seeds state from the latest committed
@@ -70,6 +71,7 @@ func NewChain(dbConnStr, triePath string, withTrie bool) (*Chain, error) {
 
 // Handle implements blocks.BlockHandler. It commits the block's write sets to the trie,
 // then persists the block and its transactions to the database.
+// After successful persistence, it notifies any registered callback about the completed transactions.
 func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 	ebl := c.convertToDomain(b)
 
@@ -90,6 +92,15 @@ func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 		return err
 	}
 
+	// Notify callback about completed transactions
+	if c.txCompletionCallback != nil && len(ebl.Transactions) > 0 {
+		txHashes := make([]common.Hash, 0, len(ebl.Transactions))
+		for _, tx := range ebl.Transactions {
+			txHashes = append(txHashes, common.BytesToHash(tx.TxHash))
+		}
+		c.txCompletionCallback(txHashes)
+	}
+
 	return nil
 }
 
@@ -99,6 +110,12 @@ func (c *Chain) Close() error {
 		c.ts.Close()
 	}
 	return c.db.Close()
+}
+
+// SetTxCompletionCallback registers a callback that is invoked when a block with transactions is committed.
+// The callback is called with the list of transaction hashes from the committed block.
+func (c *Chain) SetTxCompletionCallback(callback func([]common.Hash)) {
+	c.txCompletionCallback = callback
 }
 
 // convertToDomain maps a Fabric SDK block to the gateway domain model,


### PR DESCRIPTION
resolves #134 

Wired Gateway and Chain to communicate via callback when blocks are committed, allowing the Gateway to mark transactions as completed in its pending queue.

Changes:
`/gateway/core/api.go`: 
- Added `chain *Chain` field to Gateway struct to hold reference for callback registration.
- Updated `New()` constructor signature to accept `chain *Chain` instead of `store Store`.
- Registered transaction completion callback in `New()` that marks transactions as completed when blocks are committed.

`/gateway/core/chain.go`:
- Added `txCompletionCallback` field to Chain struct to store the registered callback
- Implemented `SetTxCompletionCallback()` method to allow Gateway to register its callback.
- Modified `Handle()` method to invoke the callback with transaction hashes after successfully committing a block.