### PR TITLE
Add block-number-based snapshot retrieval to LightKVS

### DIFF
--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -46,7 +46,7 @@ func NewEndorser(
 		}
 		kvs = endorser.NewVersionedDBWrapper(writeDB)
 	default:
-		kvs = endorser.NewLightKVS()
+		kvs = endorser.NewLightKVS(2)
 	}
 
 	evmConfig := endorser.EVMConfig{

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -39,7 +39,7 @@ type EVMConfig struct {
 }
 
 type KVSSnapshotter interface {
-	NewSnapshot() ReadStore
+	NewSnapshot(blockNumber uint64) (ReadStore, error)
 }
 
 // KVS is implemented by both LightKVS and VersionedDBWrapper.
@@ -80,7 +80,7 @@ func NewEVMEngine(namespace string, kvs KVSSnapshotter, evmConfig EVMConfig, mon
 // so that the resulting read-write set passes MVCC validation at commit time.
 // Reverts produce a valid endorsement (Status 201 + revert event) instead of an error.
 func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (endorsement.ExecutionResult, error) {
-	ex, err := e.newExecutor(blockInfo, 0)
+	ex, err := e.newExecutor(blockInfo)
 	if err != nil {
 		return endorsement.ExecutionResult{}, err
 	}
@@ -119,11 +119,7 @@ func (e *EVMEngine) Execute(blockInfo *utils.BlockInfo, tx *types.Transaction) (
 // (0 / nil = latest). The EVM block context is not reconstructed for historical blocks —
 // with all forks enabled from block 0 this is harmless.
 func (e *EVMEngine) Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	stateBlock := uint64(0)
-	if blockNumber != nil {
-		stateBlock = blockNumber.Uint64()
-	}
-	ex, err := e.newExecutor(nil, stateBlock)
+	ex, err := e.newExecutor(&utils.BlockInfo{BlockNumber: blockNumber})
 	if err != nil {
 		return nil, err
 	}
@@ -170,9 +166,17 @@ func (e *EVMEngine) NonceAt(_ context.Context, account common.Address, blockNumb
 
 // newExecutor creates a fresh executor with an isolated StateDB.
 // stateBlockNum selects the Fabric block height for the state snapshot (0 = latest).
-func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo, stateBlockNum uint64) (*Executor, error) {
+func (e *EVMEngine) newExecutor(blockInfo *utils.BlockInfo) (*Executor, error) {
+	var stateBlockNum uint64
+	if blockInfo != nil && blockInfo.BlockNumber != nil {
+		stateBlockNum = blockInfo.BlockNumber.Uint64()
+	}
+
 	// Begin a new reader to get snapshot isolation
-	reader := e.kvs.NewSnapshot()
+	reader, err := e.kvs.NewSnapshot(stateBlockNum)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create StateDB with the reader
 	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, stateBlockNum, e.monotonicVersions)
@@ -192,7 +196,10 @@ func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, ReadSt
 	}
 
 	// Begin a new reader to get snapshot isolation
-	reader := e.kvs.NewSnapshot()
+	reader, err := e.kvs.NewSnapshot(blockNum)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Create StateDB with the reader
 	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, blockNum, e.monotonicVersions)
@@ -222,12 +229,19 @@ func NewExecutor(stateDB ExtendedStateDB, reader ReadStore, blockInfo *utils.Blo
 	if evmConfig.ChainConfig == nil {
 		return nil, fmt.Errorf("evmConfig.ChainConfig must be set")
 	}
+
+	// Fill in missing blockInfo fields with defaults
 	if blockInfo == nil {
-		blockInfo = &utils.BlockInfo{
-			BlockNumber: new(big.Int),
-			BlockTime:   1_000_000,
-			GasLimit:    10_000_000,
-		}
+		blockInfo = &utils.BlockInfo{}
+	}
+	if blockInfo.BlockNumber == nil {
+		blockInfo.BlockNumber = new(big.Int)
+	}
+	if blockInfo.BlockTime == 0 {
+		blockInfo.BlockTime = 1_000_000
+	}
+	if blockInfo.GasLimit == 0 {
+		blockInfo.GasLimit = 10_000_000
 	}
 
 	// Default block context

--- a/endorser/lightkvs.go
+++ b/endorser/lightkvs.go
@@ -28,6 +28,13 @@ type LightKVS struct {
 	// Atomic pointer to current snapshot
 	// Readers get this atomically, writers swap it atomically
 	current atomic.Pointer[Snapshot]
+
+	// Ring buffer of recent snapshots for history preservation
+	// Size determines how many snapshots to keep (e.g., 2 for last 2 snapshots)
+	history []atomic.Pointer[Snapshot]
+
+	// Next index in the ring buffer to write to
+	nextIndex atomic.Uint32
 }
 
 // Snapshot represents an immutable point-in-time view of the key-value store.
@@ -113,34 +120,67 @@ func (u KeyValueVersion) toLogUpdate() logUpdate {
 }
 
 // NewLightKVS creates a new empty versioned key-value store.
-func NewLightKVS() *LightKVS {
-	kvs := &LightKVS{}
+func NewLightKVS(historySize int) *LightKVS {
+	kvs := &LightKVS{
+		history: make([]atomic.Pointer[Snapshot], historySize),
+	}
 	initial := &Snapshot{
 		blockNumber: 0,
 		data:        make(map[string]*ValueVersion),
 	}
 	kvs.current.Store(initial)
+	// nextIndex starts at 0 - history slots are initially nil
+	kvs.nextIndex.Store(0)
 	return kvs
 }
 
-// NewSnapshot starts a new read transaction and returns a Reader.
-// The Reader will see a consistent snapshot of the store at this point in time,
-// regardless of subsequent writes.
+// NewSnapshot starts a new read transaction and returns a Reader for the specified block number.
+// The Reader will see a consistent snapshot of the store at the requested block number.
+// If blockNumber is 0, it returns the current snapshot (latest state).
+// Otherwise, it first checks the current snapshot, then searches the history for a matching block number.
+// If no matching snapshot is found, it returns an error.
 //
 // Readers must call Close() when done to allow garbage collection of old snapshots.
-func (kvs *LightKVS) NewSnapshot() ReadStore {
-	// Atomically load the current snapshot
-	snapshot := kvs.current.Load()
+func (kvs *LightKVS) NewSnapshot(blockNumber uint64) (ReadStore, error) {
+	// Load the current snapshot
+	current := kvs.current.Load()
 
-	// Return a reader that holds a reference to this snapshot
-	return &Reader{
-		snapshot: snapshot,
-		kvs:      kvs,
+	// If blockNumber is 0, return the current snapshot (latest state)
+	if blockNumber == 0 {
+		return &Reader{
+			snapshot: current,
+			kvs:      kvs,
+		}, nil
 	}
+
+	// Check if requested snapshot matches or is greater than the current block number
+	if blockNumber >= current.blockNumber {
+		return &Reader{
+			snapshot: current,
+			kvs:      kvs,
+		}, nil
+	}
+
+	// Search through history snapshots for the requested block number
+	for i := range kvs.history {
+		snapshot := kvs.history[i].Load()
+		if snapshot != nil && snapshot.blockNumber == blockNumber {
+			return &Reader{
+				snapshot: snapshot,
+				kvs:      kvs,
+			}, nil
+		}
+	}
+
+	// No matching snapshot found
+	return nil, fmt.Errorf("snapshot not found for block number %d", blockNumber)
 }
 
 func (kvs *LightKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error) {
-	r := kvs.NewSnapshot()
+	r, err := kvs.NewSnapshot(lastBlock)
+	if err != nil {
+		return nil, err
+	}
 	defer r.Close()
 
 	return r.Get(namespace, key)
@@ -270,6 +310,16 @@ func (kvs *LightKVS) Update(updates []KeyValueVersion) error {
 		blockNumber: blockNum,
 		data:        newData,
 	}
+
+	// Get the next history slot to write to
+	idx := kvs.nextIndex.Load()
+
+	// Store old snapshot in the ring buffer
+	kvs.history[idx].Store(oldSnapshot)
+
+	// Advance to next slot (wraps around using modulo)
+	nextIdx := (idx + 1) % uint32(len(kvs.history))
+	kvs.nextIndex.Store(nextIdx)
 
 	// Atomically swap in the new snapshot
 	// New readers will see this snapshot; existing readers keep their old snapshot

--- a/endorser/lightkvs_test.go
+++ b/endorser/lightkvs_test.go
@@ -8,6 +8,7 @@ package endorser
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -16,7 +17,7 @@ import (
 
 // TestNewLightKVS tests the creation of a new LightKVS instance
 func TestNewLightKVS(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	if kvs == nil {
 		t.Fatal("NewLightKVS returned nil")
 	}
@@ -36,8 +37,11 @@ func TestNewLightKVS(t *testing.T) {
 
 // TestNewSnapshot tests creating a new snapshot reader
 func TestNewSnapshot(t *testing.T) {
-	kvs := NewLightKVS()
-	reader := kvs.NewSnapshot()
+	kvs := NewLightKVS(1)
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	if reader == nil {
 		t.Fatal("NewSnapshot returned nil")
 	}
@@ -57,7 +61,7 @@ func TestNewSnapshot(t *testing.T) {
 
 // TestReaderGet tests reading values from a snapshot
 func TestReaderGet(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add some data
 	updates := []KeyValueVersion{
@@ -84,7 +88,10 @@ func TestReaderGet(t *testing.T) {
 	}
 
 	// Create reader and test Get
-	reader := kvs.NewSnapshot().(*Reader)
+	reader, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader.Close()
 
 	// Test existing key
@@ -129,7 +136,7 @@ func TestReaderGet(t *testing.T) {
 
 // TestReaderGetNilValue tests reading a nil value
 func TestReaderGetNilValue(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add a key with nil value
 	updates := []KeyValueVersion{
@@ -147,7 +154,10 @@ func TestReaderGetNilValue(t *testing.T) {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	reader := kvs.NewSnapshot().(*Reader)
+	reader, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader.Close()
 
 	record, err := reader.Get("ns1", "key1")
@@ -164,17 +174,21 @@ func TestReaderGetNilValue(t *testing.T) {
 
 // TestReaderClose tests closing a reader
 func TestReaderClose(t *testing.T) {
-	kvs := NewLightKVS()
-	reader := kvs.NewSnapshot().(*Reader)
+	kvs := NewLightKVS(1)
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 
 	// Close the reader
-	err := reader.Close()
+	err = reader.Close()
 	if err != nil {
 		t.Fatalf("Close failed: %v", err)
 	}
 
-	// Verify snapshot is nil after close
-	if reader.snapshot != nil {
+	// Verify snapshot is nil after close (need to type assert to access internal field)
+	r, ok := reader.(*Reader)
+	if ok && r.snapshot != nil {
 		t.Error("snapshot should be nil after Close")
 	}
 
@@ -190,7 +204,7 @@ func TestReaderClose(t *testing.T) {
 
 // TestUpdate tests updating the store
 func TestUpdate(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	updates := []KeyValueVersion{
 		{
@@ -248,7 +262,7 @@ func TestUpdate(t *testing.T) {
 
 // TestUpdateVersionIncrement tests that versions increment correctly
 func TestUpdateVersionIncrement(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// First update
 	updates1 := []KeyValueVersion{
@@ -316,7 +330,7 @@ func TestUpdateVersionIncrement(t *testing.T) {
 
 // TestUpdateDelete tests deleting keys
 func TestUpdateDelete(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add a key
 	updates1 := []KeyValueVersion{
@@ -364,7 +378,7 @@ func TestUpdateDelete(t *testing.T) {
 
 // TestUpdateEmptyBatch tests updating with an empty batch
 func TestUpdateEmptyBatch(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	err := kvs.Update([]KeyValueVersion{})
 	if err != nil {
@@ -379,7 +393,7 @@ func TestUpdateEmptyBatch(t *testing.T) {
 
 // TestSnapshotIsolation tests that readers see a consistent snapshot
 func TestSnapshotIsolation(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Initial data
 	updates1 := []KeyValueVersion{
@@ -398,7 +412,10 @@ func TestSnapshotIsolation(t *testing.T) {
 	}
 
 	// Create reader before update
-	reader1 := kvs.NewSnapshot().(*Reader)
+	reader1, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader1.Close()
 
 	// Update the store
@@ -418,7 +435,10 @@ func TestSnapshotIsolation(t *testing.T) {
 	}
 
 	// Create reader after update
-	reader2 := kvs.NewSnapshot().(*Reader)
+	reader2, err := kvs.NewSnapshot(2)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader2.Close()
 
 	// Reader1 should see old value
@@ -442,7 +462,7 @@ func TestSnapshotIsolation(t *testing.T) {
 
 // TestConcurrentReaders tests multiple concurrent readers
 func TestConcurrentReaders(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add initial data
 	updates := []KeyValueVersion{
@@ -468,7 +488,11 @@ func TestConcurrentReaders(t *testing.T) {
 	for i := 0; i < numReaders; i++ {
 		go func() {
 			defer wg.Done()
-			reader := kvs.NewSnapshot().(*Reader)
+			reader, err := kvs.NewSnapshot(1)
+			if err != nil {
+				t.Errorf("NewSnapshot failed: %v", err)
+				return
+			}
 			defer reader.Close()
 
 			record, err := reader.Get("ns1", "key1")
@@ -491,7 +515,7 @@ func TestConcurrentReaders(t *testing.T) {
 
 // TestHandle tests the Handle method with blocks
 func TestHandle(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	ctx := context.Background()
 
 	// Create a block with transactions
@@ -550,7 +574,10 @@ func TestHandle(t *testing.T) {
 	}
 
 	// Verify data was stored
-	reader := kvs.NewSnapshot().(*Reader)
+	reader, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader.Close()
 
 	record1, err := reader.Get("ns1", "key1")
@@ -595,7 +622,7 @@ func TestHandle(t *testing.T) {
 
 // TestHandleInvalidTransactions tests that invalid transactions are skipped
 func TestHandleInvalidTransactions(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	ctx := context.Background()
 
 	block := blocks.Block{
@@ -647,7 +674,10 @@ func TestHandleInvalidTransactions(t *testing.T) {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
-	reader := kvs.NewSnapshot().(*Reader)
+	reader, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader.Close()
 
 	// key1 from invalid tx should not exist
@@ -674,7 +704,7 @@ func TestHandleInvalidTransactions(t *testing.T) {
 
 // TestHandleDeletes tests handling delete operations
 func TestHandleDeletes(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	ctx := context.Background()
 
 	// First, add a key
@@ -709,7 +739,10 @@ func TestHandleDeletes(t *testing.T) {
 	}
 
 	// Verify key exists
-	reader1 := kvs.NewSnapshot().(*Reader)
+	reader1, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	record1, err := reader1.Get("ns1", "key1")
 	reader1.Close()
 	if err != nil {
@@ -750,7 +783,10 @@ func TestHandleDeletes(t *testing.T) {
 	}
 
 	// Verify key is deleted
-	reader2 := kvs.NewSnapshot().(*Reader)
+	reader2, err := kvs.NewSnapshot(2)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader2.Close()
 	record2, err := reader2.Get("ns1", "key1")
 	if err != nil {
@@ -763,7 +799,7 @@ func TestHandleDeletes(t *testing.T) {
 
 // TestHandleEmptyBlock tests handling a block with no transactions
 func TestHandleEmptyBlock(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	ctx := context.Background()
 
 	block := blocks.Block{
@@ -785,7 +821,7 @@ func TestHandleEmptyBlock(t *testing.T) {
 
 // TestBlockNumber tests the BlockNumber method
 func TestBlockNumber(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 	ctx := context.Background()
 
 	// Initial block number should be 0
@@ -825,7 +861,7 @@ func TestBlockNumber(t *testing.T) {
 
 // TestClose tests the Close method
 func TestClose(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	err := kvs.Close()
 	if err != nil {
@@ -835,7 +871,7 @@ func TestClose(t *testing.T) {
 
 // TestGetMethod tests the Get method on LightKVS
 func TestGetMethod(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add data
 	updates := []KeyValueVersion{
@@ -945,7 +981,7 @@ func TestKeyValueVersionToLogUpdate(t *testing.T) {
 
 // TestMultipleNamespaces tests handling multiple namespaces
 func TestMultipleNamespaces(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	updates := []KeyValueVersion{
 		{
@@ -979,7 +1015,10 @@ func TestMultipleNamespaces(t *testing.T) {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	reader := kvs.NewSnapshot().(*Reader)
+	reader, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
 	defer reader.Close()
 
 	// Test ns1:key1
@@ -1012,7 +1051,7 @@ func TestMultipleNamespaces(t *testing.T) {
 
 // TestStructuralSharing tests that unchanged values are shared between snapshots
 func TestStructuralSharing(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add initial data
 	updates1 := []KeyValueVersion{
@@ -1075,7 +1114,7 @@ func TestStructuralSharing(t *testing.T) {
 
 // TestConcurrentReadersWithUpdates tests readers during concurrent updates
 func TestConcurrentReadersWithUpdates(t *testing.T) {
-	kvs := NewLightKVS()
+	kvs := NewLightKVS(1)
 
 	// Add initial data
 	updates := []KeyValueVersion{
@@ -1102,7 +1141,12 @@ func TestConcurrentReadersWithUpdates(t *testing.T) {
 	for i := 0; i < numReaders; i++ {
 		go func(id int) {
 			defer wg.Done()
-			reader := kvs.NewSnapshot().(*Reader)
+			// Request block 0 (current snapshot) to get whatever state exists at this moment
+			reader, err := kvs.NewSnapshot(0)
+			if err != nil {
+				t.Errorf("NewSnapshot failed: %v", err)
+				return
+			}
 			defer reader.Close()
 
 			// Each reader should see a consistent snapshot
@@ -1142,4 +1186,311 @@ func TestConcurrentReadersWithUpdates(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestSnapshotByBlockNumber tests getting snapshots by specific block numbers
+func TestSnapshotByBlockNumber(t *testing.T) {
+	kvs := NewLightKVS(2)
+
+	// Add data at block 1
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value_block1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update block 1 failed: %v", err)
+	}
+
+	// Add data at block 2
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value_block2"),
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update block 2 failed: %v", err)
+	}
+
+	// Test getting current snapshot (block 0 means current)
+	readerCurrent, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot(0) failed: %v", err)
+	}
+	defer readerCurrent.Close()
+
+	record, err := readerCurrent.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block2" {
+		t.Errorf("Expected current snapshot to have value_block2, got %s", string(record.Value))
+	}
+
+	// Test getting snapshot by specific block number (current block)
+	reader2, err := kvs.NewSnapshot(2)
+	if err != nil {
+		t.Fatalf("NewSnapshot(2) failed: %v", err)
+	}
+	defer reader2.Close()
+
+	record, err = reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block2" {
+		t.Errorf("Expected block 2 snapshot to have value_block2, got %s", string(record.Value))
+	}
+
+	// Test getting snapshot from history (block 1 should still be in history)
+	reader1, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot(1) failed: %v", err)
+	}
+	defer reader1.Close()
+
+	record, err = reader1.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block1" {
+		t.Errorf("Expected block 1 snapshot to have value_block1, got %s", string(record.Value))
+	}
+}
+
+// TestSnapshotHistoryEviction tests that old snapshots are evicted from history
+func TestSnapshotHistoryEviction(t *testing.T) {
+	kvs := NewLightKVS(2)
+
+	// Create snapshots for blocks 1, 2, 3, 4
+	// History size is 2, so blocks 1 and 2 should eventually be evicted
+	for i := 1; i <= 4; i++ {
+		updates := []KeyValueVersion{
+			{
+				Key:      "ns1:key1",
+				Value:    []byte(fmt.Sprintf("value_block%d", i)),
+				BlockNum: uint64(i),
+				TxNum:    0,
+				TxID:     fmt.Sprintf("tx%d", i),
+				IsDelete: false,
+			},
+		}
+		err := kvs.Update(updates)
+		if err != nil {
+			t.Fatalf("Update block %d failed: %v", i, err)
+		}
+	}
+
+	// Current snapshot should be block 4
+	readerCurrent, err := kvs.NewSnapshot(4)
+	if err != nil {
+		t.Fatalf("NewSnapshot(4) failed: %v", err)
+	}
+	defer readerCurrent.Close()
+
+	record, err := readerCurrent.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block4" {
+		t.Errorf("Expected block 4 snapshot to have value_block4, got %s", string(record.Value))
+	}
+
+	// Block 3 should be in history (most recent old snapshot)
+	reader3, err := kvs.NewSnapshot(3)
+	if err != nil {
+		t.Fatalf("NewSnapshot(3) failed: %v", err)
+	}
+	defer reader3.Close()
+
+	record, err = reader3.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block3" {
+		t.Errorf("Expected block 3 snapshot to have value_block3, got %s", string(record.Value))
+	}
+
+	// Block 2 should be in history (second most recent old snapshot)
+	reader2, err := kvs.NewSnapshot(2)
+	if err != nil {
+		t.Fatalf("NewSnapshot(2) failed: %v", err)
+	}
+	defer reader2.Close()
+
+	record, err = reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record.Value) != "value_block2" {
+		t.Errorf("Expected block 2 snapshot to have value_block2, got %s", string(record.Value))
+	}
+
+	// Block 1 should have been evicted (history only keeps 2 snapshots)
+	_, err = kvs.NewSnapshot(1)
+	if err == nil {
+		t.Error("Expected error when requesting evicted block 1, got nil")
+	}
+	expectedErr := "snapshot not found for block number 1"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got '%s'", expectedErr, err.Error())
+	}
+}
+
+// TestSnapshotNonExistentBlock tests error handling for non-existent block numbers
+func TestSnapshotNonExistentBlock(t *testing.T) {
+	kvs := NewLightKVS(2)
+
+	// Add data at block 1
+	updates := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Try to get snapshot for block 99 (higher than current, should return current)
+	reader99, err := kvs.NewSnapshot(99)
+	if err != nil {
+		t.Fatalf("NewSnapshot(99) should not fail when requesting future block: %v", err)
+	}
+	defer reader99.Close()
+
+	// Should get the current snapshot (block 1)
+	record99, err := reader99.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(record99.Value) != "value1" {
+		t.Errorf("Expected block 99 request to return current value 'value1', got %s", string(record99.Value))
+	}
+
+	// Block 0 (current) should always work
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot(0) should not fail: %v", err)
+	}
+	defer reader.Close()
+}
+
+// TestSnapshotIsolationAcrossBlocks tests that snapshots from different blocks are isolated
+func TestSnapshotIsolationAcrossBlocks(t *testing.T) {
+	kvs := NewLightKVS(2)
+
+	// Create block 1 with initial value
+	updates1 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value1"),
+			BlockNum: 1,
+			TxNum:    0,
+			TxID:     "tx1",
+			IsDelete: false,
+		},
+	}
+	err := kvs.Update(updates1)
+	if err != nil {
+		t.Fatalf("Update block 1 failed: %v", err)
+	}
+
+	// Get snapshot for block 1
+	reader1, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot(1) failed: %v", err)
+	}
+	defer reader1.Close()
+
+	// Create block 2 with updated value
+	updates2 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value2"),
+			BlockNum: 2,
+			TxNum:    0,
+			TxID:     "tx2",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates2)
+	if err != nil {
+		t.Fatalf("Update block 2 failed: %v", err)
+	}
+
+	// Get snapshot for block 2
+	reader2, err := kvs.NewSnapshot(2)
+	if err != nil {
+		t.Fatalf("NewSnapshot(2) failed: %v", err)
+	}
+	defer reader2.Close()
+
+	// Verify reader1 still sees block 1 value
+	record1, err := reader1.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get from reader1 failed: %v", err)
+	}
+	if string(record1.Value) != "value1" {
+		t.Errorf("Reader1 should see value1, got %s", string(record1.Value))
+	}
+
+	// Verify reader2 sees block 2 value
+	record2, err := reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get from reader2 failed: %v", err)
+	}
+	if string(record2.Value) != "value2" {
+		t.Errorf("Reader2 should see value2, got %s", string(record2.Value))
+	}
+
+	// Create block 3 with another update
+	updates3 := []KeyValueVersion{
+		{
+			Key:      "ns1:key1",
+			Value:    []byte("value3"),
+			BlockNum: 3,
+			TxNum:    0,
+			TxID:     "tx3",
+			IsDelete: false,
+		},
+	}
+	err = kvs.Update(updates3)
+	if err != nil {
+		t.Fatalf("Update block 3 failed: %v", err)
+	}
+
+	// Verify reader1 and reader2 still see their original values
+	record1, err = reader1.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get from reader1 failed: %v", err)
+	}
+	if string(record1.Value) != "value1" {
+		t.Errorf("Reader1 should still see value1, got %s", string(record1.Value))
+	}
+
+	record2, err = reader2.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get from reader2 failed: %v", err)
+	}
+	if string(record2.Value) != "value2" {
+		t.Errorf("Reader2 should still see value2, got %s", string(record2.Value))
+	}
 }

--- a/endorser/state_test.go
+++ b/endorser/state_test.go
@@ -120,7 +120,10 @@ func assertEqual[T comparable](t *testing.T, label string, got1, got2, expected 
 
 func snapshotDB(t *testing.T, backend *state.VersionedDB, blockNum uint64) *StateDB {
 	wrapper := NewVersionedDBWrapper(backend)
-	snapshot := wrapper.NewSnapshot()
+	snapshot, err := wrapper.NewSnapshot(blockNum)
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { snapshot.Close() })
 	stateDB, err := NewStateDB(t.Context(), snapshot, Namespace, blockNum, false)
 	if err != nil {

--- a/endorser/statedb_logger.go
+++ b/endorser/statedb_logger.go
@@ -1,0 +1,448 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package endorser
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethstate "github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/holiman/uint256"
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+)
+
+// getGoroutineID returns the current goroutine ID
+func getGoroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
+	id, _ := strconv.ParseUint(idField, 10, 64)
+	return id
+}
+
+// StateDBLogger wraps a StateDB and logs all method calls.
+// It includes a mutex to serialize all calls, making it easier to debug
+// concurrent access patterns and potential race conditions.
+type StateDBLogger struct {
+	inner  *StateDB
+	logger *flogging.FabricLogger
+	mu     sync.Mutex
+}
+
+// NewStateDBLogger creates a new logging wrapper
+func NewStateDBLogger(inner *StateDB) *StateDBLogger {
+	return &StateDBLogger{
+		inner:  inner,
+		logger: flogging.MustGetLogger("StateDB"),
+	}
+}
+
+func (l *StateDBLogger) CreateAccount(addr common.Address) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] CreateAccount: addr=%s", gid, addr.Hex())
+	l.inner.CreateAccount(addr)
+	l.logger.Debugf("[G%d] CreateAccount: completed", gid)
+}
+
+func (l *StateDBLogger) CreateContract(addr common.Address) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] CreateContract: addr=%s", gid, addr.Hex())
+	l.inner.CreateContract(addr)
+	l.logger.Debugf("[G%d] CreateContract: completed", gid)
+}
+
+func (l *StateDBLogger) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SubBalance: addr=%s, amount=%s, reason=%v", gid, addr.Hex(), amount.String(), reason)
+	prev := l.inner.SubBalance(addr, amount, reason)
+	l.logger.Debugf("[G%d] SubBalance: output prev=%s", gid, prev.String())
+	return prev
+}
+
+func (l *StateDBLogger) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddBalance: addr=%s, amount=%s, reason=%v", gid, addr.Hex(), amount.String(), reason)
+	prev := l.inner.AddBalance(addr, amount, reason)
+	l.logger.Debugf("[G%d] AddBalance: output prev=%s", gid, prev.String())
+	return prev
+}
+
+func (l *StateDBLogger) GetBalance(addr common.Address) *uint256.Int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetBalance: addr=%s", gid, addr.Hex())
+	result := l.inner.GetBalance(addr)
+	l.logger.Debugf("[G%d] GetBalance: output result=%s", gid, result.String())
+	return result
+}
+
+func (l *StateDBLogger) GetNonce(addr common.Address) uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetNonce: addr=%s", gid, addr.Hex())
+	result := l.inner.GetNonce(addr)
+	l.logger.Debugf("[G%d] GetNonce: output result=%d", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SetNonce: addr=%s, nonce=%d, reason=%v", gid, addr.Hex(), nonce, reason)
+	l.inner.SetNonce(addr, nonce, reason)
+	l.logger.Debugf("[G%d] SetNonce: completed", gid)
+}
+
+func (l *StateDBLogger) GetCodeHash(addr common.Address) common.Hash {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetCodeHash: addr=%s", gid, addr.Hex())
+	result := l.inner.GetCodeHash(addr)
+	l.logger.Debugf("[G%d] GetCodeHash: output result=%s", gid, result.Hex())
+	return result
+}
+
+func (l *StateDBLogger) GetCode(addr common.Address) []byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetCode: addr=%s", gid, addr.Hex())
+	result := l.inner.GetCode(addr)
+	l.logger.Debugf("[G%d] GetCode: output result len=%d", gid, len(result))
+	return result
+}
+
+func (l *StateDBLogger) SetCode(addr common.Address, code []byte, reason tracing.CodeChangeReason) []byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SetCode: addr=%s, code len=%d, reason=%v", gid, addr.Hex(), len(code), reason)
+	prev := l.inner.SetCode(addr, code, reason)
+	l.logger.Debugf("[G%d] SetCode: output prev len=%d", gid, len(prev))
+	return prev
+}
+
+func (l *StateDBLogger) GetCodeSize(addr common.Address) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetCodeSize: addr=%s", gid, addr.Hex())
+	result := l.inner.GetCodeSize(addr)
+	l.logger.Debugf("[G%d] GetCodeSize: output result=%d", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) AddRefund(gas uint64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddRefund: gas=%d", gid, gas)
+	l.inner.AddRefund(gas)
+	l.logger.Debugf("[G%d] AddRefund: completed", gid)
+}
+
+func (l *StateDBLogger) SubRefund(gas uint64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SubRefund: gas=%d", gid, gas)
+	l.inner.SubRefund(gas)
+	l.logger.Debugf("[G%d] SubRefund: completed", gid)
+}
+
+func (l *StateDBLogger) GetRefund() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetRefund", gid)
+	result := l.inner.GetRefund()
+	l.logger.Debugf("[G%d] GetRefund: output result=%d", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) GetStateAndCommittedState(addr common.Address, hash common.Hash) (common.Hash, common.Hash) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetStateAndCommittedState: addr=%s, hash=%s", gid, addr.Hex(), hash.Hex())
+	current, committed := l.inner.GetStateAndCommittedState(addr, hash)
+	l.logger.Debugf("[G%d] GetStateAndCommittedState: ethCurrent=%s, ethCommitted=%s", gid, current.Hex(), committed.Hex())
+	return current, committed
+}
+
+func (l *StateDBLogger) GetState(addr common.Address, hash common.Hash) common.Hash {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetState: addr=%s, hash=%s", gid, addr.Hex(), hash.Hex())
+	result := l.inner.GetState(addr, hash)
+	l.logger.Debugf("[G%d] GetState: ethResult=%s, snapResult=%s", gid, result.Hex(), result.Hex())
+	return result
+}
+
+func (l *StateDBLogger) SetState(addr common.Address, key common.Hash, value common.Hash) common.Hash {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SetState: addr=%s, key=%s, value=%s", gid, addr.Hex(), key.Hex(), value.Hex())
+	prev := l.inner.SetState(addr, key, value)
+	l.logger.Debugf("[G%d] SetState: output prev=%s", gid, prev.Hex())
+	return prev
+}
+
+func (l *StateDBLogger) GetStorageRoot(addr common.Address) common.Hash {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetStorageRoot: addr=%s", gid, addr.Hex())
+	result := l.inner.GetStorageRoot(addr)
+	l.logger.Debugf("[G%d] GetStorageRoot: output result=%s", gid, result.Hex())
+	return result
+}
+
+func (l *StateDBLogger) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] GetTransientState: addr=%s, key=%s", gid, addr.Hex(), key.Hex())
+	result := l.inner.GetTransientState(addr, key)
+	l.logger.Debugf("[G%d] GetTransientState: output result=%s", gid, result.Hex())
+	return result
+}
+
+func (l *StateDBLogger) SetTransientState(addr common.Address, key, value common.Hash) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SetTransientState: addr=%s, key=%s, value=%s", gid, addr.Hex(), key.Hex(), value.Hex())
+	l.inner.SetTransientState(addr, key, value)
+	l.logger.Debugf("[G%d] SetTransientState: completed", gid)
+}
+
+func (l *StateDBLogger) SelfDestruct(addr common.Address) uint256.Int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SelfDestruct: addr=%s", gid, addr.Hex())
+	balance := l.inner.SelfDestruct(addr)
+	l.logger.Debugf("[G%d] SelfDestruct: output balance=%s", gid, balance.String())
+	return balance
+}
+
+func (l *StateDBLogger) HasSelfDestructed(addr common.Address) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] HasSelfDestructed: addr=%s", gid, addr.Hex())
+	result := l.inner.HasSelfDestructed(addr)
+	l.logger.Debugf("[G%d] HasSelfDestructed: output result=%t", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) SelfDestruct6780(addr common.Address) (uint256.Int, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SelfDestruct6780: addr=%s", gid, addr.Hex())
+	balance, destructed := l.inner.SelfDestruct6780(addr)
+	l.logger.Debugf("[G%d] SelfDestruct6780: output balance=%s, destructed=%t", gid, balance.String(), destructed)
+	return balance, destructed
+}
+
+func (l *StateDBLogger) Exist(addr common.Address) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Exist: addr=%s", gid, addr.Hex())
+	result := l.inner.Exist(addr)
+	l.logger.Debugf("[G%d] Exist: output result=%t", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) Empty(addr common.Address) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Empty: addr=%s", gid, addr.Hex())
+	result := l.inner.Empty(addr)
+	l.logger.Debugf("[G%d] Empty: output result=%t", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) AddressInAccessList(addr common.Address) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddressInAccessList: addr=%s", gid, addr.Hex())
+	result := l.inner.AddressInAccessList(addr)
+	l.logger.Debugf("[G%d] AddressInAccessList: output result=%t", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) SlotInAccessList(addr common.Address, slot common.Hash) (bool, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] SlotInAccessList: addr=%s, slot=%s", gid, addr.Hex(), slot.Hex())
+	addressOk, slotOk := l.inner.SlotInAccessList(addr, slot)
+	l.logger.Debugf("[G%d] SlotInAccessList: output addressOk=%t, slotOk=%t", gid, addressOk, slotOk)
+	return addressOk, slotOk
+}
+
+func (l *StateDBLogger) AddAddressToAccessList(addr common.Address) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddAddressToAccessList: addr=%s", gid, addr.Hex())
+	l.inner.AddAddressToAccessList(addr)
+	l.logger.Debugf("[G%d] AddAddressToAccessList: completed", gid)
+}
+
+func (l *StateDBLogger) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddSlotToAccessList: addr=%s, slot=%s", gid, addr.Hex(), slot.Hex())
+	l.inner.AddSlotToAccessList(addr, slot)
+	l.logger.Debugf("[G%d] AddSlotToAccessList: completed", gid)
+}
+
+func (l *StateDBLogger) PointCache() *utils.PointCache {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] PointCache", gid)
+	result := l.inner.PointCache()
+	l.logger.Debugf("[G%d] PointCache: output result=%p", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	destStr := "nil"
+	if dest != nil {
+		destStr = dest.Hex()
+	}
+	l.logger.Debugf("[G%d] Prepare: sender=%s, coinbase=%s, dest=%s, precompiles len=%d, txAccesses len=%d",
+		gid, sender.Hex(), coinbase.Hex(), destStr, len(precompiles), len(txAccesses))
+	l.inner.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
+	l.logger.Debugf("[G%d] Prepare: completed", gid)
+}
+
+func (l *StateDBLogger) RevertToSnapshot(snapshot int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] RevertToSnapshot: snapshot=%d", gid, snapshot)
+	l.inner.RevertToSnapshot(snapshot)
+	l.logger.Debugf("[G%d] RevertToSnapshot: completed", gid)
+}
+
+func (l *StateDBLogger) Snapshot() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Snapshot: called", gid)
+	result := l.inner.Snapshot()
+	l.logger.Debugf("[G%d] Snapshot: output result=%d", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) AddLog(logEntry *types.Log) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddLog: log=%+v", gid, logEntry)
+	l.inner.AddLog(logEntry)
+	l.logger.Debugf("[G%d] AddLog: completed", gid)
+}
+
+func (l *StateDBLogger) AddPreimage(hash common.Hash, preimage []byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AddPreimage: hash=%s, preimage len=%d", gid, hash.Hex(), len(preimage))
+	l.inner.AddPreimage(hash, preimage)
+	l.logger.Debugf("[G%d] AddPreimage: completed", gid)
+}
+
+func (l *StateDBLogger) Witness() *stateless.Witness {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Witness", gid)
+	result := l.inner.Witness()
+	l.logger.Debugf("[G%d] Witness: output result=%p", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) AccessEvents() *ethstate.AccessEvents {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] AccessEvents", gid)
+	result := l.inner.AccessEvents()
+	l.logger.Debugf("[G%d] AccessEvents: output result=%p", gid, result)
+	return result
+}
+
+func (l *StateDBLogger) Finalise(deleteEmptyObjects bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Finalise: deleteEmptyObjects=%t", gid, deleteEmptyObjects)
+	l.inner.Finalise(deleteEmptyObjects)
+	l.logger.Debugf("[G%d] Finalise: completed", gid)
+}
+
+// Result returns the read-write set from the inner StateDB
+func (l *StateDBLogger) Result() blocks.ReadWriteSet {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Result", gid)
+	result := l.inner.Result()
+	l.logger.Debugf("[G%d] Result: output reads len=%d, writes len=%d", gid, len(result.Reads), len(result.Writes))
+	return result
+}
+
+// Logs returns the logs from the inner StateDB
+func (l *StateDBLogger) Logs() []Log {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	gid := getGoroutineID()
+	l.logger.Debugf("[G%d] Logs", gid)
+	result := l.inner.Logs()
+	l.logger.Debugf("[G%d] Logs: output result len=%d", gid, len(result))
+	return result
+}
+
+// Ensure StateDBLogger implements ExtendedStateDB
+var _ ExtendedStateDB = (*StateDBLogger)(nil)

--- a/endorser/testimpl/executor_wrapper.go
+++ b/endorser/testimpl/executor_wrapper.go
@@ -36,7 +36,10 @@ func NewExecutorWrapper(
 	ethStateDB *ethstate.StateDB,
 ) (*ExecutorWrapper, error) {
 	// Begin a new reader to get snapshot isolation
-	reader := kvs.NewSnapshot()
+	reader, err := kvs.NewSnapshot(stateBlockNum)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create StateDB with the reader
 	stateDB, err := endorser.NewStateDB(context.TODO(), reader, namespace, stateBlockNum, monotonicVersions)

--- a/endorser/versioned_db_wrapper.go
+++ b/endorser/versioned_db_wrapper.go
@@ -28,22 +28,14 @@ func NewVersionedDBWrapper(db *state.VersionedDB) *VersionedDBWrapper {
 	}
 }
 
-// NewSnapshot creates a new snapshot of the current state.
-// It queries the current block number and returns a VersionedDBSnapshot
-// that will use this block number for all Get operations, providing
-// snapshot isolation.
-func (w *VersionedDBWrapper) NewSnapshot() ReadStore {
-	// Query the current block number to establish the snapshot point
-	blockNum, err := w.db.BlockNumber(context.Background())
-	if err != nil {
-		// If we can't get the block number, default to 0 (latest)
-		blockNum = 0
-	}
-
+// NewSnapshot creates a new snapshot of the state at the specified block number.
+// It returns a VersionedDBSnapshot that will use this block number for all Get operations,
+// providing snapshot isolation.
+func (w *VersionedDBWrapper) NewSnapshot(blockNumber uint64) (ReadStore, error) {
 	return &VersionedDBSnapshot{
 		db:          w.db,
-		blockNumber: blockNum,
-	}
+		blockNumber: blockNumber,
+	}, nil
 }
 
 // VersionedDBSnapshot represents a point-in-time snapshot of the VersionedDB.

--- a/gateway/storage/store.go
+++ b/gateway/storage/store.go
@@ -12,6 +12,7 @@ import (
 	_ "embed"
 	"errors"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
@@ -20,8 +21,9 @@ import (
 var ddl string
 
 type Store struct {
-	queries *Queries
-	db      *sql.DB
+	queries     *Queries
+	db          *sql.DB
+	blockNumber atomic.Uint64 // cached block number for fast reads
 }
 
 func NewStore(db *sql.DB) *Store {
@@ -90,11 +92,23 @@ func toDomainTransaction(t Transaction) domain.Transaction {
 	}
 }
 
-// Init creates the tables.
+// Init creates the tables and initializes the cached block number.
 func (s *Store) Init() error {
 	if _, err := s.db.ExecContext(context.TODO(), ddl); err != nil {
 		return err
 	}
+
+	// Initialize the cached block number from the database
+	num, err := s.queries.BlockNumber(context.TODO())
+	if err == sql.ErrNoRows {
+		// Empty database, block number is 0
+		s.blockNumber.Store(0)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	s.blockNumber.Store(uint64(num))
 	return nil
 }
 
@@ -127,6 +141,22 @@ func (s *Store) InsertBlock(ctx context.Context, block domain.Block) error {
 	if err := sqlTx.Commit(); err != nil {
 		return err
 	}
+
+	// Update the cached block number after successful commit
+	// Only update if the new block number is greater than the current cached value
+	for {
+		current := s.blockNumber.Load()
+		if block.BlockNumber <= current {
+			// Block number didn't increase (duplicate or out-of-order), don't update cache
+			break
+		}
+		if s.blockNumber.CompareAndSwap(current, block.BlockNumber) {
+			// Successfully updated the cache
+			break
+		}
+		// CAS failed, retry (another goroutine updated it)
+	}
+
 	return nil
 }
 
@@ -159,13 +189,10 @@ func toStorageLog(l domain.Log) InsertLogParams {
 	return params
 }
 
-// BlockNumber returns the number of the last committed block. If there are no rows, the blockheight is zero.
+// BlockNumber returns the number of the last committed block from the cache.
+// If there are no blocks, the blockheight is zero.
 func (s *Store) BlockNumber(ctx context.Context) (uint64, error) {
-	num, err := s.queries.BlockNumber(ctx)
-	if err == sql.ErrNoRows {
-		return 0, nil
-	}
-	return uint64(num), err
+	return s.blockNumber.Load(), nil
 }
 
 // BlockNumberByHash resolves a block hash to its block number.

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -32,7 +32,7 @@ import (
 )
 
 type KVSSnapshotter interface {
-	NewSnapshot() endorser.ReadStore
+	NewSnapshot(blockNumber uint64) (endorser.ReadStore, error)
 }
 
 // StatePrimer provides a builder pattern for priming ledger state.
@@ -67,7 +67,10 @@ func NewStatePrimer(
 	monotonicVersions bool,
 ) (*StatePrimer, error) {
 	// Create a DualStateDB with both Fabric and Ethereum state tracking
-	store := db.NewSnapshot()
+	store, err := db.NewSnapshot(0)
+	if err != nil {
+		return nil, err
+	}
 	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), store, namespace, 0, monotonicVersions, nil)
 	if err != nil {
 		return nil, err
@@ -267,7 +270,11 @@ func (sp *StatePrimer) Writes() blocks.ReadWriteSet {
 // Reset creates a new DualStateDB, discarding all uncommitted changes.
 func (sp *StatePrimer) Reset() (*StatePrimer, error) {
 	sp.reader.Close() // just in case
-	sp.reader = sp.kvs.NewSnapshot()
+	reader, err := sp.kvs.NewSnapshot(0)
+	if err != nil {
+		return nil, err
+	}
+	sp.reader = reader
 	stateDB, err := endorser.NewStateDBWithDualState(context.TODO(), sp.reader, sp.namespace, 0, sp.monotonicVersions, nil)
 	if err != nil {
 		return nil, err

--- a/integration/state_test_util.go
+++ b/integration/state_test_util.go
@@ -617,7 +617,7 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 	// Create a mock StateDB for DualStateDB
 	fabricDB, _ := fabricstate.NewWriteDB("testchannel", ":memory:")
 	fabricDBWrapper := endorser.NewVersionedDBWrapper(fabricDB)
-	fabricDBSnapshot := fabricDBWrapper.NewSnapshot()
+	fabricDBSnapshot, _ := fabricDBWrapper.NewSnapshot(1)
 	defer fabricDBSnapshot.Close()
 	fabricStateDB, _ := endorser.NewStateDB(context.TODO(), fabricDBSnapshot, "testns", 0, false)
 
@@ -673,7 +673,7 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 
 	// Create new StateDB for the reopened state - now reading from block 1
 	// since we just committed block 0
-	fabricDBSnapshot2 := fabricDBWrapper.NewSnapshot()
+	fabricDBSnapshot2, _ := fabricDBWrapper.NewSnapshot(1)
 	defer fabricDBSnapshot2.Close()
 	fabricStateDB, _ = endorser.NewStateDB(context.TODO(), fabricDBSnapshot2, "testns", 1, false)
 	statedb = endorser.NewDualStateDB(ethStateDB, fabricStateDB)

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -435,7 +435,7 @@ func newEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 		}
 		db = endorser.NewVersionedDBWrapper(writeDB)
 	default:
-		db = endorser.NewLightKVS()
+		db = endorser.NewLightKVS(1)
 	}
 	t.Cleanup(func() { db.Close() })
 

--- a/scripts/run_hardhat_test.sh
+++ b/scripts/run_hardhat_test.sh
@@ -196,7 +196,7 @@ run_tests() {
     #
     # Future improvement: Consider a configuration file approach or accept timeouts
     # and document the limitation instead of trying to skip specific tests.
-    SKIP_PATTERN="^(?!.*(reverts|rejects|overflow|when the spender has enough allowance|when the spender has unlimited allowance|when the spender does not have enough allowance|for entire balance|for less value than balance|when the sender transfers all balance|executes with balance|increments recipient balance|from is the zero address|to is the zero address))"
+    SKIP_PATTERN="^(?!.*(reverts|rejects|overflow|when the spender has enough allowance|when the spender has unlimited allowance|when the spender does not have enough allowance|for entire balance|for less value than balance|when the sender transfers all balance|executes with balance))"
     
     echo -e "${YELLOW}Note: Skipping revert-related and balance-change tests (Fabric-EVM limitations)${NC}"
     echo ""


### PR DESCRIPTION
Modified the NewSnapshot method in LightKVS to accept a blockNumber parameter, enabling retrieval of snapshots at specific block heights. The implementation searches through the current snapshot and a configurable history buffer to find matching block numbers. When blockNumber is 0, it returns the current snapshot for backward compatibility. If a requested block number is higher than the current block, it returns the current snapshot. The history buffer uses a ring buffer pattern to maintain the most recent old snapshots.

This enables 6 more hardhat tests that required this feature.