### PR TITLE
gateway/core: surface tx-conversion errors instead of panicking

### DIFF
--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -72,7 +72,10 @@ func NewChain(dbConnStr, triePath string, withTrie bool) (*Chain, error) {
 // Handle implements blocks.BlockHandler. It commits the block's write sets to the trie,
 // then persists the block and its transactions to the database.
 func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
-	ebl := c.convertToDomain(b)
+	ebl, err := c.convertToDomain(b)
+	if err != nil {
+		return err
+	}
 
 	if c.ts != nil {
 		stateRoot, err := c.ts.Commit(ctx, b)
@@ -104,7 +107,7 @@ func (c *Chain) Close() error {
 
 // convertToDomain maps a Fabric SDK block to the gateway domain model,
 // extracting and decoding the embedded Ethereum transactions.
-func (c *Chain) convertToDomain(b blocks.Block) domain.Block {
+func (c *Chain) convertToDomain(b blocks.Block) (domain.Block, error) {
 	ebl := domain.Block{
 		BlockNumber:  b.Number,
 		BlockHash:    b.Hash,
@@ -129,13 +132,13 @@ func (c *Chain) convertToDomain(b blocks.Block) domain.Block {
 
 		etx, err := convertTransaction(tx.InputArgs[1], b.Hash, b.Number, tx.Number, tx.ID, status, tx.Status, tx.Events, &logIndex)
 		if err != nil {
-			panic(err) // we surface this for now instead of swallowing it
+			return domain.Block{}, fmt.Errorf("convert tx %s: %w", tx.ID, err)
 		}
 
 		ebl.Transactions = append(ebl.Transactions, etx)
 	}
 
-	return ebl
+	return ebl, nil
 }
 
 // convertTransaction converts an Ethereum transaction to a domain.Transaction.

--- a/gateway/core/chain_test.go
+++ b/gateway/core/chain_test.go
@@ -61,7 +61,8 @@ func TestConvertToDomain_ValidTx(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	got, err := c.convertToDomain(b)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint64(42), got.BlockNumber)
 	assert.Equal(t, []byte("block-hash"), got.BlockHash)
@@ -88,7 +89,8 @@ func TestConvertToDomain_InvalidTxStatus(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	got, err := c.convertToDomain(b)
+	require.NoError(t, err)
 
 	require.Len(t, got.Transactions, 1)
 	assert.Equal(t, uint8(0), got.Transactions[0].Status)
@@ -104,7 +106,8 @@ func TestConvertToDomain_SkipsInsufficientInputArgs(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	got, err := c.convertToDomain(b)
+	require.NoError(t, err)
 
 	assert.Len(t, got.Transactions, 0)
 }
@@ -120,15 +123,33 @@ func TestConvertToDomain_SkipsInvalidEthBytes(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	got, err := c.convertToDomain(b)
+	require.NoError(t, err)
 
 	assert.Len(t, got.Transactions, 0)
+}
+
+func TestConvertToDomain_ReturnsErrorOnUnparseableTx(t *testing.T) {
+	b := blocks.Block{
+		Number: 1,
+		Transactions: []blocks.Transaction{{
+			ID:        "tx-bad-bytes",
+			Valid:     true,
+			InputArgs: [][]byte{{byte(co.ProposalTypeEVMTx)}, []byte("not-an-eth-tx")},
+		}},
+	}
+
+	c := &Chain{}
+	_, err := c.convertToDomain(b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tx-bad-bytes")
 }
 
 func TestConvertToDomain_EmptyBlock(t *testing.T) {
 	b := blocks.Block{Number: 5}
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	got, err := c.convertToDomain(b)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint64(5), got.BlockNumber)
 	assert.Len(t, got.Transactions, 0)


### PR DESCRIPTION
## Summary

`Chain.convertToDomain` panicked when `convertTransaction` failed to parse a transaction's ETH payload, with a `// we surface this for now instead of swallowing it` comment. The path is genuinely "should never happen" (the tx is already endorsed, ordered and committed), but panicking inside the block-ingest goroutine takes down the gateway and gives the `BlockHandler` caller no chance to react.

This PR replaces the panic with proper error propagation, matching the maintainer's note on #171 surface the error now, decide on stronger handling closer to release.

## Changes

- **[gateway/core/chain.go](gateway/core/chain.go)**
  - `convertToDomain` signature changed to `(domain.Block, error)`. On `convertTransaction` failure it now returns `fmt.Errorf("convert tx %s: %w", tx.ID, err)` instead of panicking. The failing Fabric tx id is included so operators can correlate with the ledger.
  - `Handle` (which already returned `error` for `blocks.BlockHandler`) propagates the error untouched.

- **[gateway/core/chain_test.go](gateway/core/chain_test.go)**
  - All 5 existing `convertToDomain` call sites updated for the new return signature.
  - New test `TestConvertToDomain_ReturnsErrorOnUnparseableTx` exercises the previously-panicking path: a tx with a valid `ProposalTypeEVMTx` marker but unparseable ETH bytes. Asserts an error is returned and that the tx id appears in the message.


## Test plan

- [x] `go build ./...` clean
- [x] `go test ./gateway/core/` —10/10 pass, including the new error-path test

Closes #171