### PR TITLE
Implement transaction tracking with pending status

### DIFF
--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -49,7 +49,8 @@ type Backend interface {
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) // ethereum.ContractCaller
 
 	// Transactions. Our transactions also include the status, so we can build receipts out of the same data.
-	TransactionByHash(ctx context.Context, hash common.Hash) (tx *domain.Transaction, isPending bool, err error)
+	// For pending transactions, BlockNumber will be 0 (converted to null in JSON response).
+	TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, error)
 	GetTransactionByBlockHashAndIndex(ctx context.Context, hash common.Hash, idx int64) (*domain.Transaction, error)
 	GetTransactionByBlockNumberAndIndex(ctx context.Context, num uint64, idx int64) (*domain.Transaction, error)
 	GetLogs(ctx context.Context, query domain.LogFilter) ([]domain.Log, error)
@@ -256,7 +257,7 @@ func (api *EthAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) 
 // eth_getTransactionByHash
 func (api *EthAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
 	logger.Debugf("EthAPI.GetTransactionByHash() called with hash=%s", hash.Hex())
-	tx, _, err := api.b.TransactionByHash(ctx, hash)
+	tx, err := api.b.TransactionByHash(ctx, hash)
 	if err != nil {
 		logger.Debugf("EthAPI.GetTransactionByHash() returning error: %v", err)
 		return nil, err
@@ -301,7 +302,7 @@ func (api *EthAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, num 
 // eth_getTransactionReceipt
 func (api *EthAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (*rpcReceipt, error) {
 	logger.Debugf("EthAPI.GetTransactionReceipt() called with hash=%s", hash.Hex())
-	r, _, err := api.b.TransactionByHash(ctx, hash)
+	r, err := api.b.TransactionByHash(ctx, hash)
 	if err != nil {
 		logger.Debugf("EthAPI.GetTransactionReceipt() returning error: %v", err)
 		return nil, err

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -319,8 +319,8 @@ func (s *stubBackend) SendTransaction(ctx context.Context, tx *types.Transaction
 func (s *stubBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	return nil, s.callErr
 }
-func (s *stubBackend) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, bool, error) {
-	return nil, false, nil
+func (s *stubBackend) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, error) {
+	return nil, nil
 }
 func (s *stubBackend) GetTransactionByBlockHashAndIndex(ctx context.Context, hash common.Hash, idx int64) (*domain.Transaction, error) {
 	return nil, nil

--- a/gateway/api/models.go
+++ b/gateway/api/models.go
@@ -151,6 +151,7 @@ type RPCBlock struct {
 
 // rpcTransaction converts a domain.Transaction to an RPCTransaction with block metadata.
 // Returns nil if the transaction cannot be converted.
+// For pending transactions (BlockHash == nil or BlockNumber == 0), the block fields are set to nil.
 func rpcTransaction(tx *domain.Transaction) *RPCTransaction {
 	if tx == nil {
 		return nil
@@ -161,17 +162,25 @@ func rpcTransaction(tx *domain.Transaction) *RPCTransaction {
 		return nil
 	}
 
-	blockHash := common.Hash(tx.BlockHash)
-	blockNumber := hexutil.Big(*big.NewInt(int64(tx.BlockNumber)))
-	txIndex := hexutil.Uint64(tx.TxIndex)
-
-	return &RPCTransaction{
-		tx:               ethTx,
-		From:             common.BytesToAddress(tx.FromAddress),
-		BlockHash:        &blockHash,
-		BlockNumber:      &blockNumber,
-		TransactionIndex: &txIndex,
+	rpcTx := &RPCTransaction{
+		tx:   ethTx,
+		From: common.BytesToAddress(tx.FromAddress),
 	}
+
+	// Check if this is a pending transaction (BlockHash is nil or BlockNumber is 0)
+	// For pending transactions, leave block fields as nil
+	if tx.BlockHash != nil && tx.BlockNumber != 0 {
+		blockHash := common.Hash(tx.BlockHash)
+		blockNumber := hexutil.Big(*big.NewInt(int64(tx.BlockNumber)))
+		txIndex := hexutil.Uint64(tx.TxIndex)
+
+		rpcTx.BlockHash = &blockHash
+		rpcTx.BlockNumber = &blockNumber
+		rpcTx.TransactionIndex = &txIndex
+	}
+	// else: leave BlockHash, BlockNumber, TransactionIndex as nil (pending transaction)
+
+	return rpcTx
 }
 
 // rpcBlock returns a block in the form the RPC API can return. Some values are mocked.

--- a/gateway/api/models.go
+++ b/gateway/api/models.go
@@ -47,7 +47,7 @@ func (r *rpcReceipt) MarshalJSON() ([]byte, error) {
 
 // receipt returns a receipt in the form the RPC API can return. Some values are mocked.
 func receipt(r *domain.Transaction) *rpcReceipt {
-	if r == nil {
+	if r == nil || r.BlockHash == nil {
 		return nil
 	}
 

--- a/gateway/api/receipt_test.go
+++ b/gateway/api/receipt_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package api
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
+)
+
+func TestNilBlockNum(t *testing.T) {
+	nonce := uint64(0)
+	to := common.HexToAddress("0xcafe")
+	value := big.NewInt(1e18)
+	gasLimit := uint64(21000)
+	maxFeePerGas := big.NewInt(20000000000)
+	maxPriorityFeePerGas := big.NewInt(2000000000)
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     nonce,
+		GasFeeCap: maxFeePerGas,
+		GasTipCap: maxPriorityFeePerGas,
+		Gas:       gasLimit,
+		To:        &to,
+		Value:     value,
+		Data:      nil,
+	})
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("HexToECDSA failed: %s", err)
+	}
+
+	rawTx, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary failed: %s", err)
+	}
+
+	fromAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	r := receipt(&domain.Transaction{
+		TxHash:      tx.Hash().Bytes(),
+		BlockHash:   nil, // nil signals pending to API layer
+		BlockNumber: 0,   // 0 signals pending to API layer
+		TxIndex:     0,   // Value doesn't matter - API layer checks BlockNumber==0 for pending
+		RawTx:       rawTx,
+		FromAddress: fromAddress.Bytes(),
+		ToAddress:   to.Bytes(),
+	})
+
+	if r != nil {
+		t.Fatalf("Expected nil receipt, got %v", r)
+	}
+}

--- a/gateway/api/rpcerrors_test.go
+++ b/gateway/api/rpcerrors_test.go
@@ -9,63 +9,14 @@ package api
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	ethcore "github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hyperledger/fabric-x-evm/gateway/api/rpcerr"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
-
-func TestNilBlockNum(t *testing.T) {
-	nonce := uint64(0)
-	to := common.HexToAddress("0xcafe")
-	value := big.NewInt(1e18)
-	gasLimit := uint64(21000)
-	maxFeePerGas := big.NewInt(20000000000)
-	maxPriorityFeePerGas := big.NewInt(2000000000)
-	tx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   big.NewInt(1),
-		Nonce:     nonce,
-		GasFeeCap: maxFeePerGas,
-		GasTipCap: maxPriorityFeePerGas,
-		Gas:       gasLimit,
-		To:        &to,
-		Value:     value,
-		Data:      nil,
-	})
-
-	privateKey, err := crypto.GenerateKey()
-	if err != nil {
-		t.Fatalf("HexToECDSA failed: %s", err)
-	}
-
-	rawTx, err := tx.MarshalBinary()
-	if err != nil {
-		t.Fatalf("MarshalBinary failed: %s", err)
-	}
-
-	fromAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
-
-	r := receipt(&domain.Transaction{
-		TxHash:      tx.Hash().Bytes(),
-		BlockHash:   nil, // nil signals pending to API layer
-		BlockNumber: 0,   // 0 signals pending to API layer
-		TxIndex:     0,   // Value doesn't matter - API layer checks BlockNumber==0 for pending
-		RawTx:       rawTx,
-		FromAddress: fromAddress.Bytes(),
-		ToAddress:   to.Bytes(),
-	})
-
-	if r != nil {
-		t.Fatalf("Expected nil receipt, got %v", r)
-	}
-}
 
 func TestClassifyValidationError_NilReturnsNil(t *testing.T) {
 	if err := classifyValidationError(nil); err != nil {

--- a/gateway/api/rpcerrors_test.go
+++ b/gateway/api/rpcerrors_test.go
@@ -9,14 +9,63 @@ package api
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	ethcore "github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hyperledger/fabric-x-evm/gateway/api/rpcerr"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
+
+func TestNilBlockNum(t *testing.T) {
+	nonce := uint64(0)
+	to := common.HexToAddress("0xcafe")
+	value := big.NewInt(1e18)
+	gasLimit := uint64(21000)
+	maxFeePerGas := big.NewInt(20000000000)
+	maxPriorityFeePerGas := big.NewInt(2000000000)
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     nonce,
+		GasFeeCap: maxFeePerGas,
+		GasTipCap: maxPriorityFeePerGas,
+		Gas:       gasLimit,
+		To:        &to,
+		Value:     value,
+		Data:      nil,
+	})
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("HexToECDSA failed: %s", err)
+	}
+
+	rawTx, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary failed: %s", err)
+	}
+
+	fromAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	r := receipt(&domain.Transaction{
+		TxHash:      tx.Hash().Bytes(),
+		BlockHash:   nil, // nil signals pending to API layer
+		BlockNumber: 0,   // 0 signals pending to API layer
+		TxIndex:     0,   // Value doesn't matter - API layer checks BlockNumber==0 for pending
+		RawTx:       rawTx,
+		FromAddress: fromAddress.Bytes(),
+		ToAddress:   to.Bytes(),
+	})
+
+	if r != nil {
+		t.Fatalf("Expected nil receipt, got %v", r)
+	}
+}
 
 func TestClassifyValidationError_NilReturnsNil(t *testing.T) {
 	if err := classifyValidationError(nil); err != nil {

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -124,12 +124,14 @@ func buildApp(cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorse
 		return nil, fmt.Errorf("failed to create gateway: %w", err)
 	}
 
+	// Create synchronizer with both chain and gateway as handlers
+	// Chain must be called first to persist blocks, then gateway to mark transactions complete
 	var gwSync *network.Synchronizer
 	switch cfg.Network.Protocol {
 	case "fabric":
-		gwSync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain)
+		gwSync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain, gateway)
 	case "fabric-x", "":
-		gwSync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain)
+		gwSync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain, gateway)
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %q", cfg.Network.Protocol)
 	}

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 	"github.com/hyperledger/fabric-x-evm/utils"
 	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
 )
 
 type Signer interface {
@@ -252,25 +253,66 @@ func (g *Gateway) NonceAt(ctx context.Context, account common.Address, blockNumb
 
 // Transactions
 
-// TransactionByHash retrieves a past transaction data from local storage, reconstructs a Transaction object and returns it.
-// We always return false for "is pending".
-func (g *Gateway) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, bool, error) {
+// TransactionByHash retrieves transaction data from either the queue or database.
+// It first checks if the transaction is in the queue (pending or in-progress),
+// then queries the database for committed transactions.
+//
+// Return values represent three possible states:
+// - State 1 (Pending): Transaction in queue → tx with BlockNumber=0 (becomes null in JSON)
+// - State 2 (Completed): Transaction in database → tx with block data populated
+// - State 3 (Not Found): Transaction in neither location → nil
+//
+// The pending status is signaled by BlockNumber=0, which the API layer converts to null.
+func (g *Gateway) TransactionByHash(ctx context.Context, hash common.Hash) (*domain.Transaction, error) {
+	// Check if transaction is pending in the queue (either waiting or being processed)
+	if pendingTx := g.txQueue.IsPending(hash); pendingTx != nil {
+		// Transaction is pending - return it with zero block fields
+		// The API layer will convert these to nil in the JSON response
+		rawTx, err := pendingTx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		from, err := types.Sender(g.signer, pendingTx)
+		if err != nil {
+			return nil, err
+		}
+
+		var toAddr []byte
+		if to := pendingTx.To(); to != nil {
+			toAddr = to.Bytes()
+		}
+
+		return &domain.Transaction{
+			TxHash:      hash.Bytes(),
+			BlockHash:   nil, // nil signals pending to API layer
+			BlockNumber: 0,   // 0 signals pending to API layer
+			TxIndex:     0,   // Value doesn't matter - API layer checks BlockNumber==0 for pending
+			RawTx:       rawTx,
+			FromAddress: from.Bytes(),
+			ToAddress:   toAddr,
+		}, nil
+	}
+
+	// Transaction not in queue, check database for committed transaction
 	tx, err := g.store.GetTransactionByHash(ctx, hash.Bytes())
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if tx == nil {
-		return nil, false, nil
+		// Transaction not found in queue or database
+		return nil, nil
 	}
 
 	// Fetch logs for the transaction (needed for receipts)
 	logs, err := g.store.GetLogsByTxHash(ctx, hash.Bytes())
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	tx.Logs = logs
 
-	return tx, false, nil
+	// Transaction found in database
+	return tx, nil
 }
 
 // GetTransactionByBlockHashAndIndex retrieves a transaction based on block hash in the transaction index in that block.
@@ -301,5 +343,16 @@ func (g *Gateway) Stop() error {
 		// Close submitter connection
 		err = g.submitter.Close()
 	})
+	return err
+}
+
+// Handle processes block notifications and marks transactions as complete.
+// This method implements blocks.BlockHandler and can be registered with the synchronizer
+// to receive notifications when blocks are committed. It converts the blocks.Block to domain.Block
+// and delegates to the TxQueue's Handle method.
+func (g *Gateway) Handle(ctx context.Context, b blocks.Block) error {
+	// Convert blocks.Block to domain.Block using the shared conversion function
+	domainBlock := ConvertToDomain(b)
+	err := g.txQueue.Handle(ctx, &domainBlock)
 	return err
 }

--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -72,7 +72,7 @@ func NewChain(dbConnStr, triePath string, withTrie bool) (*Chain, error) {
 // Handle implements blocks.BlockHandler. It commits the block's write sets to the trie,
 // then persists the block and its transactions to the database.
 func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
-	ebl := c.convertToDomain(b)
+	ebl := ConvertToDomain(b)
 
 	if c.ts != nil {
 		stateRoot, err := c.ts.Commit(ctx, b)
@@ -102,9 +102,10 @@ func (c *Chain) Close() error {
 	return c.db.Close()
 }
 
-// convertToDomain maps a Fabric SDK block to the gateway domain model,
+// ConvertToDomain maps a Fabric SDK block to the gateway domain model,
 // extracting and decoding the embedded Ethereum transactions.
-func (c *Chain) convertToDomain(b blocks.Block) domain.Block {
+// This is a standalone function so it can be reused by other components like Gateway.
+func ConvertToDomain(b blocks.Block) domain.Block {
 	ebl := domain.Block{
 		BlockNumber:  b.Number,
 		BlockHash:    b.Hash,

--- a/gateway/core/chain_test.go
+++ b/gateway/core/chain_test.go
@@ -61,7 +61,8 @@ func TestConvertToDomain_ValidTx(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	_ = c
+	got := ConvertToDomain(b)
 
 	assert.Equal(t, uint64(42), got.BlockNumber)
 	assert.Equal(t, []byte("block-hash"), got.BlockHash)
@@ -88,7 +89,8 @@ func TestConvertToDomain_InvalidTxStatus(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	_ = c
+	got := ConvertToDomain(b)
 
 	require.Len(t, got.Transactions, 1)
 	assert.Equal(t, uint8(0), got.Transactions[0].Status)
@@ -104,7 +106,8 @@ func TestConvertToDomain_SkipsInsufficientInputArgs(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	_ = c
+	got := ConvertToDomain(b)
 
 	assert.Len(t, got.Transactions, 0)
 }
@@ -120,7 +123,8 @@ func TestConvertToDomain_SkipsInvalidEthBytes(t *testing.T) {
 	}
 
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	_ = c
+	got := ConvertToDomain(b)
 
 	assert.Len(t, got.Transactions, 0)
 }
@@ -128,7 +132,8 @@ func TestConvertToDomain_SkipsInvalidEthBytes(t *testing.T) {
 func TestConvertToDomain_EmptyBlock(t *testing.T) {
 	b := blocks.Block{Number: 5}
 	c := &Chain{}
-	got := c.convertToDomain(b)
+	_ = c
+	got := ConvertToDomain(b)
 
 	assert.Equal(t, uint64(5), got.BlockNumber)
 	assert.Len(t, got.Transactions, 0)

--- a/gateway/core/chain_test.go
+++ b/gateway/core/chain_test.go
@@ -60,8 +60,6 @@ func TestConvertToDomain_ValidTx(t *testing.T) {
 		}},
 	}
 
-	c := &Chain{}
-	_ = c
 	got := ConvertToDomain(b)
 
 	assert.Equal(t, uint64(42), got.BlockNumber)
@@ -88,8 +86,6 @@ func TestConvertToDomain_InvalidTxStatus(t *testing.T) {
 		}},
 	}
 
-	c := &Chain{}
-	_ = c
 	got := ConvertToDomain(b)
 
 	require.Len(t, got.Transactions, 1)
@@ -105,8 +101,6 @@ func TestConvertToDomain_SkipsInsufficientInputArgs(t *testing.T) {
 		},
 	}
 
-	c := &Chain{}
-	_ = c
 	got := ConvertToDomain(b)
 
 	assert.Len(t, got.Transactions, 0)
@@ -122,8 +116,6 @@ func TestConvertToDomain_SkipsInvalidEthBytes(t *testing.T) {
 		}},
 	}
 
-	c := &Chain{}
-	_ = c
 	got := ConvertToDomain(b)
 
 	assert.Len(t, got.Transactions, 0)
@@ -131,8 +123,6 @@ func TestConvertToDomain_SkipsInvalidEthBytes(t *testing.T) {
 
 func TestConvertToDomain_EmptyBlock(t *testing.T) {
 	b := blocks.Block{Number: 5}
-	c := &Chain{}
-	_ = c
 	got := ConvertToDomain(b)
 
 	assert.Equal(t, uint64(5), got.BlockNumber)

--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -7,19 +7,30 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package core
 
 import (
+	"context"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
-// TxQueue is a simple in-memory FIFO queue for transactions
+// TxQueue is a two-queue system for tracking transaction lifecycle.
+// Transactions flow: pendingQueue -> inProgressMap -> completed (removed from tracking)
+//
+// Locking strategy:
+// - Write operations (Enqueue, Dequeue, Complete, Close) use exclusive Lock()
+// - Read operations (IsPending) use shared RLock() for concurrent queries
+// - This allows multiple simultaneous pending status checks without blocking writers
+//
+// Thread-safety: All map and slice operations are protected by the RWMutex.
+// The inProgressMap is safe for concurrent access as long as proper locking is used.
 type TxQueue struct {
-	mu            sync.Mutex
-	cond          *sync.Cond
-	pendingQueue  []*types.Transaction
-	inProgressMap map[common.Hash]*types.Transaction
-	done          bool
+	mu            sync.RWMutex                       // Protects all fields below
+	cond          *sync.Cond                         // Signals when new transactions arrive
+	pendingQueue  []*types.Transaction               // FIFO queue of transactions waiting to be processed
+	inProgressMap map[common.Hash]*types.Transaction // Transactions currently being processed by workers
+	done          bool                               // Shutdown flag
 }
 
 // NewTxQueue creates a new transaction queue
@@ -28,11 +39,13 @@ func NewTxQueue() *TxQueue {
 		pendingQueue:  make([]*types.Transaction, 0),
 		inProgressMap: make(map[common.Hash]*types.Transaction),
 	}
+	// sync.Cond requires a Locker; RWMutex implements Locker interface
 	q.cond = sync.NewCond(&q.mu)
 	return q
 }
 
-// Enqueue adds a transaction to the queue
+// Enqueue adds a transaction to the queue.
+// This method uses a write lock to ensure exclusive access when modifying the queue.
 func (q *TxQueue) Enqueue(tx *types.Transaction) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -41,8 +54,10 @@ func (q *TxQueue) Enqueue(tx *types.Transaction) {
 	q.cond.Signal() // Wake up one waiting worker
 }
 
-// Dequeue removes and returns a transaction from the queue
-// Blocks if queue is empty until a transaction is available or queue is closed
+// Dequeue removes a transaction from the pending queue and moves it to the in-progress map.
+// Blocks if queue is empty until a transaction is available or queue is closed.
+// Returns (transaction, true) if successful, or (nil, false) if queue is closed and empty.
+// This method uses a write lock to ensure exclusive access during the queue modification.
 func (q *TxQueue) Dequeue() (*types.Transaction, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -56,24 +71,67 @@ func (q *TxQueue) Dequeue() (*types.Transaction, bool) {
 	}
 
 	tx := q.pendingQueue[0]
-	q.pendingQueue[0] = nil
+	q.pendingQueue[0] = nil // Prevent memory leak
 	q.pendingQueue = q.pendingQueue[1:]
-	q.inProgressMap[tx.Hash()] = tx
+	q.inProgressMap[tx.Hash()] = tx // Track as in-progress
 	return tx, true
 }
 
-// Close signals that no more transactions will be enqueued
+// Close signals that no more transactions will be enqueued and initiates shutdown.
+// Any transactions in the pendingQueue will be processed by workers that are already waiting.
+// Transactions in the inProgressMap at shutdown time will be lost - they are currently being
+// processed by workers and will not complete. Clients should resubmit these transactions if needed.
+// This method uses a write lock to ensure exclusive access during shutdown.
 func (q *TxQueue) Close() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	q.done = true
-	q.cond.Broadcast() // Wake up all waiting workers
+	q.cond.Broadcast() // Wake up all waiting workers so they can exit
 }
 
-// Complete removes a transaction from the in-progress map
+// IsPending checks if a transaction is in either the pending queue or in-progress map.
+// Returns the transaction if found in either location, nil otherwise.
+// This method uses a read lock, allowing multiple concurrent queries without blocking writers.
+func (q *TxQueue) IsPending(txHash common.Hash) *types.Transaction {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	// Check if transaction is in the in-progress map (O(1) lookup)
+	if tx, exists := q.inProgressMap[txHash]; exists {
+		return tx
+	}
+
+	// Check if transaction is in the pending queue (O(n) lookup)
+	for _, tx := range q.pendingQueue {
+		if tx.Hash() == txHash {
+			return tx
+		}
+	}
+
+	return nil
+}
+
+// Complete removes a transaction from the in-progress map after it has been committed.
+// This should be called by the Gateway's callback when a block containing the transaction
+// is committed to the ledger. This method is idempotent - safe to call multiple times.
+// This method uses a write lock to ensure exclusive access when modifying the map.
 func (q *TxQueue) Complete(hash common.Hash) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	delete(q.inProgressMap, hash)
+}
+
+// Handle processes block notifications from the synchronizer and marks transactions as complete.
+// This method is designed to be registered as a callback with the block synchronizer.
+// It extracts all transaction hashes from the committed block and removes them from the in-progress map.
+// This method is safe to call concurrently and will not block block processing.
+func (q *TxQueue) Handle(ctx context.Context, block *domain.Block) error {
+	// Mark all transactions in the block as complete
+	for _, tx := range block.Transactions {
+		txHash := common.BytesToHash(tx.TxHash)
+		q.Complete(txHash)
+	}
+
+	return nil
 }

--- a/gateway/core/txqueue_test.go
+++ b/gateway/core/txqueue_test.go
@@ -7,11 +7,13 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package core
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +65,116 @@ func TestTxQueue_DequeueMovesTxToInProgressMap(t *testing.T) {
 	inProgressTx, exists := q.inProgressMap[tx.Hash()]
 	require.True(t, exists)
 	assert.Equal(t, tx.Hash(), inProgressTx.Hash())
+}
+
+func TestTxQueue_IsPending_FindsInPendingQueue(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+
+	result := q.IsPending(tx.Hash())
+	require.NotNil(t, result)
+	assert.Equal(t, tx.Hash(), result.Hash())
+}
+
+func TestTxQueue_IsPending_FindsInProgressMap(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+	q.Dequeue() // Moves to inProgressMap
+
+	result := q.IsPending(tx.Hash())
+	require.NotNil(t, result)
+	assert.Equal(t, tx.Hash(), result.Hash())
+}
+
+func TestTxQueue_IsPending_ReturnsNilWhenNotFound(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+
+	result := q.IsPending(tx.Hash())
+	assert.Nil(t, result)
+}
+
+func TestTxQueue_IsPending_ReturnsNilAfterComplete(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+	q.Dequeue() // Moves to inProgressMap
+	q.Complete(tx.Hash())
+
+	result := q.IsPending(tx.Hash())
+	assert.Nil(t, result)
+}
+
+func TestTxQueue_Complete_RemovesFromInProgressMap(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+	q.Dequeue() // Moves to inProgressMap
+
+	q.Complete(tx.Hash())
+
+	_, exists := q.inProgressMap[tx.Hash()]
+	assert.False(t, exists)
+}
+
+func TestTxQueue_Complete_IsIdempotent(t *testing.T) {
+	q := NewTxQueue()
+	tx := testTx(1)
+	q.Enqueue(tx)
+	q.Dequeue()
+
+	// Call Complete multiple times
+	q.Complete(tx.Hash())
+	q.Complete(tx.Hash())
+	q.Complete(tx.Hash())
+
+	// Should not panic and map should be empty
+	assert.Len(t, q.inProgressMap, 0)
+}
+
+func TestTxQueue_Handle_MarksTransactionsComplete(t *testing.T) {
+	q := NewTxQueue()
+	tx1 := testTx(1)
+	tx2 := testTx(2)
+
+	// Enqueue and dequeue to move to inProgressMap
+	q.Enqueue(tx1)
+	q.Enqueue(tx2)
+	q.Dequeue()
+	q.Dequeue()
+
+	// Verify both are in progress
+	assert.NotNil(t, q.IsPending(tx1.Hash()))
+	assert.NotNil(t, q.IsPending(tx2.Hash()))
+
+	// Create a block with these transactions
+	block := &domain.Block{
+		BlockNumber: 1,
+		Transactions: []domain.Transaction{
+			{TxHash: tx1.Hash().Bytes()},
+			{TxHash: tx2.Hash().Bytes()},
+		},
+	}
+
+	// Handle the block
+	err := q.Handle(context.Background(), block)
+	require.NoError(t, err)
+
+	// Verify both are now complete (not pending)
+	assert.Nil(t, q.IsPending(tx1.Hash()))
+	assert.Nil(t, q.IsPending(tx2.Hash()))
+}
+
+func TestTxQueue_Handle_EmptyBlock(t *testing.T) {
+	q := NewTxQueue()
+
+	block := &domain.Block{
+		BlockNumber:  1,
+		Transactions: []domain.Transaction{},
+	}
+
+	err := q.Handle(context.Background(), block)
+	require.NoError(t, err)
 }

--- a/gateway/testimpl/test_eth_api.go
+++ b/gateway/testimpl/test_eth_api.go
@@ -16,6 +16,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -161,7 +162,14 @@ func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Byt
 			tx, err := api.backend.TransactionByHash(ctx, txHash)
 			if err != nil {
 				// Transaction not found yet, continue polling
+				hardhatLogger.Debugf("got error %w while polling TransactionByHash for hash %s", err, txHash)
 				continue
+			}
+
+			// this should never happen: `api.EthAPI.SendRawTransaction` synchronously enqueues the transaction
+			// and so `api.backend.TransactionByHash` must for sure find it in the pending queue or inprogress map
+			if tx == nil {
+				panic("programming error - synchronously enqueued transaction was not found")
 			}
 
 			// Check if transaction has been included in a block
@@ -172,7 +180,7 @@ func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Byt
 			}
 
 			// Transaction is still pending, continue polling
-			// Note: We continue immediately since blocks should be fast in tests
+			runtime.Gosched()
 		}
 	}
 }

--- a/gateway/testimpl/test_eth_api.go
+++ b/gateway/testimpl/test_eth_api.go
@@ -132,10 +132,47 @@ func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs
 		return common.Hash{}, fmt.Errorf("failed to marshal transaction: %w", err)
 	}
 
-	_, err = api.EthAPI.SendRawTransaction(ctx, hexutil.Bytes(txBytes))
+	// Call our overridden SendRawTransaction which makes it synchronous
+	txHash, err := api.SendRawTransaction(ctx, hexutil.Bytes(txBytes))
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	return signedTx.Hash(), nil
+	return txHash, nil
+}
+
+// SendRawTransaction overrides the base implementation to make it synchronous for Hardhat compatibility.
+// It sends the transaction and polls until it's committed to a block, mimicking Hardhat's auto-mining behavior.
+func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+	// Call the underlying SendRawTransaction
+	txHash, err := api.EthAPI.SendRawTransaction(ctx, input)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	// Poll until the transaction is committed (has a block number > 0)
+	// This mimics Hardhat's auto-mining behavior where transactions are mined immediately
+	for {
+		select {
+		case <-ctx.Done():
+			return common.Hash{}, ctx.Err()
+		default:
+			// Check if transaction is committed
+			tx, err := api.backend.TransactionByHash(ctx, txHash)
+			if err != nil {
+				// Transaction not found yet, continue polling
+				continue
+			}
+
+			// Check if transaction has been included in a block
+			// BlockNumber is 0 for pending transactions, > 0 for committed
+			if tx.BlockNumber > 0 {
+				// Transaction is committed
+				return txHash, nil
+			}
+
+			// Transaction is still pending, continue polling
+			// Note: We continue immediately since blocks should be fast in tests
+		}
+	}
 }

--- a/gateway/testimpl/test_eth_api_test.go
+++ b/gateway/testimpl/test_eth_api_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
 func TestTestEthAPI_Accounts(t *testing.T) {
@@ -152,7 +153,8 @@ func TestTestEthAPI_SendTransaction_Validation(t *testing.T) {
 // mockBackend is a minimal Backend implementation for testing
 type mockBackend struct {
 	api.Backend
-	sendTxFunc func(*types.Transaction) error
+	sendTxFunc   func(*types.Transaction) error
+	txByHashFunc func(common.Hash) (*domain.Transaction, error)
 }
 
 func (m *mockBackend) SendTransaction(_ context.Context, tx *types.Transaction) error {
@@ -168,4 +170,14 @@ func (m *mockBackend) ChainID(_ context.Context) (*big.Int, error) {
 
 func (m *mockBackend) NonceAt(_ context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
 	return 0, nil // Return nonce 0 for testing
+}
+
+func (m *mockBackend) TransactionByHash(_ context.Context, hash common.Hash) (*domain.Transaction, error) {
+	if m.txByHashFunc != nil {
+		return m.txByHashFunc(hash)
+	}
+	// Default: return a committed transaction (BlockNumber > 0) to satisfy the polling loop
+	return &domain.Transaction{
+		BlockNumber: 1,
+	}, nil
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -90,6 +90,11 @@ var cases = []testCase{
 		fn:    testRevertHandling,
 		nodes: 2,
 	},
+	{
+		name:  "pending_transaction_status",
+		fn:    testPendingTransactionStatus,
+		nodes: 2,
+	},
 }
 
 // TestLocal tests a good portion of the fabric functionality, with the difference that
@@ -986,4 +991,92 @@ func testRevertHandling(t *testing.T, th *TestHarness) {
 			t.Errorf("receipt.Status = %d, want %d (failed)", receipt.Status, types.ReceiptStatusFailed)
 		}
 	})
+}
+
+// testPendingTransactionStatus verifies that transactions return isPending=true while in the queue
+// and isPending=false after commit. This test races to catch a transaction in the pending state
+// by submitting it and immediately querying in a tight loop.
+func testPendingTransactionStatus(t *testing.T, th *TestHarness) {
+	node := th.Gateways[0]
+	ec, err := NewNativeEthClient(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counter, err := NewEthClient(contracts.CounterMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepare a deployment transaction
+	deployTx, _, err := counter.txForDeploy(t.Context(), node, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Channel to signal when we've sent the transaction
+	txSent := make(chan bool, 1)
+	caughtPending := make(chan bool, 1)
+
+	// Start a goroutine that will poll for the transaction immediately after we send it
+	go func() {
+		// Wait for the signal that transaction was sent
+		<-txSent
+
+		// Poll aggressively for the transaction
+		for range 1000 {
+			tx, isPending, err := ec.TransactionByHash(t.Context(), deployTx.Hash())
+
+			// Skip if transaction not found yet (still being processed by gateway)
+			if err != nil {
+				continue
+			}
+
+			// Check if we caught it in pending state
+			if tx != nil && isPending {
+				t.Logf("✓ Successfully caught transaction %s in pending state (isPending=true)", deployTx.Hash().Hex())
+				caughtPending <- true
+				return
+			}
+
+			// If we found it but it's already committed, we missed the window
+			if tx != nil && !isPending {
+				t.Logf("Transaction %s already committed (isPending=false), missed pending window", deployTx.Hash().Hex())
+				caughtPending <- false
+				return
+			}
+		}
+
+		t.Log("Could not catch transaction in pending state after 1000 attempts (timing issue)")
+		caughtPending <- false
+	}()
+
+	// Send the transaction and immediately signal the polling goroutine
+	if err := ec.SendTransaction(t.Context(), deployTx); err != nil {
+		t.Fatal(err)
+	}
+	txSent <- true
+
+	// Wait for the polling goroutine to finish and check if we caught it pending
+	caught := <-caughtPending
+	if !caught {
+		t.Fatal("Failed to catch transaction in pending state - this test requires catching isPending=true")
+	}
+
+	// Wait for the transaction to commit
+	waitForCommitT(t, ec, deployTx)
+
+	// Verify it's now committed (not pending)
+	tx, isPending, err := ec.TransactionByHash(t.Context(), deployTx.Hash())
+	if err != nil {
+		t.Fatalf("TransactionByHash after commit: %v", err)
+	}
+	if tx == nil {
+		t.Fatal("Transaction not found after commit")
+	}
+	if isPending {
+		t.Error("Transaction still marked as pending after commit (isPending should be false)")
+	}
+
+	t.Logf("Transaction successfully committed (isPending=false)")
 }

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -139,7 +139,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 	}
 	t.Cleanup(func() { chain.Close() })
 
-	// Build submitter.
+	// Build submitter and synchronizer
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
 		orderers[i] = o.ToOrdererConf()
@@ -148,39 +148,52 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 	var submitter core.Submitter
 	var sync *network.Synchronizer
 	var err1 error
+
 	if bypass {
+		// Use local submitter for bypass mode (no network communication)
 		submitter = local.NewLocalSubmitter(dbs[0], cfg.Network.Channel, cfg.Network.Namespace, nfab.NewTxPackager(gwSigner), bfab.NewBlockParser(logger), false)
 	} else {
-		handlers := make([]blocks.BlockHandler, 0, len(dbs)+1)
-		for _, db := range dbs {
-			handlers = append(handlers, db)
-		}
-		// by adding `chain` as last handler, we're sure that by the time the
-		// gateway sees the transaction as committed, all endorsers will have
-		// updated their ledger state
-		handlers = append(handlers, chain)
-
+		// Create network submitter
 		switch cfg.Network.Protocol {
 		case "fabric":
-			sync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 			submitter, err1 = nfab.NewSubmitter(orderers, gwSigner, 0, logger)
 		case "fabric-x", "":
-			sync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 			submitter, err1 = nfabx.NewSubmitter(orderers, gwSigner, 0, logger)
 		default:
 			return nil, nil, fmt.Errorf("unsupported protocol: %q", cfg.Network.Protocol)
 		}
-		if err := errors.Join(err, err1); err != nil {
-			return nil, nil, err
+		if err1 != nil {
+			return nil, nil, err1
 		}
 	}
 
+	// Create gateway before synchronizer so we can register it as a handler
 	gw, err := core.New(ec, submitter, chain, cfg.Network.ChainID, cfg.Gateway.WorkerCount)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Create synchronizer with handlers (endorsers, chain, and gateway) - only for non-bypass mode
 	if !bypass {
+		handlers := make([]blocks.BlockHandler, 0, len(dbs)+2)
+		for _, db := range dbs {
+			handlers = append(handlers, db)
+		}
+		// Add chain before gateway to ensure blocks are persisted before marking transactions complete
+		handlers = append(handlers, chain, gw)
+
+		switch cfg.Network.Protocol {
+		case "fabric":
+			sync, err = nfab.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+		case "fabric-x", "":
+			sync, err = nfabx.NewSynchronizer(chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+		default:
+			return nil, nil, fmt.Errorf("unsupported protocol: %q", cfg.Network.Protocol)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
 		go func() error { return sync.Start(t.Context()) }()
 	}
 


### PR DESCRIPTION
This commit transforms the Gateway's simple FIFO transaction queue into a two-queue system that tracks both pending and in-progress transactions, enabling accurate responses to "is this transaction pending?" queries from Ethereum clients.

The core change refactors TxQueue to maintain two separate data structures: a pendingQueue slice for transactions waiting to be processed, and an inProgressMap for fast O(1) lookup of transactions currently being endorsed and submitted by workers. This eliminates the previous gap where transactions would disappear from tracking once dequeued, making them appear non-existent to clients during the multi-second endorsement process.

To support this, the Backend interface's TransactionByHash signature was simplified to return only the transaction and error, with pending status now indicated by BlockNumber being 0 (which the API layer converts to null in JSON responses). The Gateway was registered as a block handler in the synchronizer, positioned after the chain handler to ensure blocks are persisted before transactions are marked complete.

A critical test regression was discovered in Hardhat tests. The solution was to override SendRawTransaction in the test API to make it synchronous by polling until the transaction is committed, mimicking Hardhat's auto-mining behavior.

Closes: 

- https://github.com/hyperledger/fabric-x-evm/issues/131
- https://github.com/hyperledger/fabric-x-evm/issues/132
- https://github.com/hyperledger/fabric-x-evm/issues/133
- https://github.com/hyperledger/fabric-x-evm/issues/134