### PR TITLE
Make container platform configurable (enable podman) [depends on 178]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS build
+FROM docker.io/library/golang:1.26 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -o /fxevm ./cmd/fxevm
 
-FROM busybox
+FROM docker.io/library/busybox
 
 COPY --from=build /fxevm /usr/local/bin/fxevm
 EXPOSE 8545

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ GID := $(shell id -g)
 export UID
 export GID
 
+# Container runtime — override for rootless Podman:
+#   make start DOCKER=podman COMPOSE="podman compose"
+# Note: build-image requires docker buildx (or podman buildx).
+DOCKER  ?= docker
+COMPOSE ?= docker compose
+
 .PHONY: build
 build:
 	go build -o bin/fxevm ./cmd/fxevm
@@ -20,7 +26,7 @@ build-release:
 
 .PHONY: build-image
 build-image: build-release
-	docker buildx build \
+	$(DOCKER) buildx build \
 		--file Dockerfile.release \
 		--load \
 		--build-arg VERSION=dev \
@@ -42,7 +48,7 @@ unit-tests:
 
 .PHONY: pre-pull-images
 pre-pull-images:
-	@docker pull hyperledger/fabric-ccenv:$(FABRIC_VERSION) || echo "Warning: Failed to pull fabric-ccenv"
+	@$(DOCKER) pull hyperledger/fabric-ccenv:$(FABRIC_VERSION) || echo "Warning: Failed to pull fabric-ccenv"
 
 .PHONY: integration-tests
 integration-tests: pre-pull-images
@@ -61,25 +67,7 @@ clean-x:
 .PHONY: start-x
 start-x:
 	@if nc -z localhost 7050 2>/dev/null; then echo "Error: port 7050 is already in use — stop any running Fabric orderer before starting."; exit 1; fi
-	@if [ ! -f testdata/crypto/sc-genesis-block.proto.bin ]; then echo "Please run 'make init-x' first."; exit 1; fi
-	@docker run -d --rm -it --name fabric-x-committer-test-node \
-		-p 4001:4001 -p 2110:2110 -p 2114:2114 -p 2117:2117 -p 7001:7001 -p 7050:7050 -p 5433:5433 \
-		-v "$(PWD)/testdata/crypto:/root/config/crypto" \
-		-v "$(PWD)/testdata/crypto/sc-genesis-block.proto.bin:/root/config/sc-genesis-block.proto.bin" \
-		-v "$(PWD)/testdata/crypto/sc-genesis-block.proto.bin:/root/artifacts/config-block.pb.bin" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/server-certs/public-key.pem" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/server-certs/private-key.pem" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/server-certs/ca-certificate.pem" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/client-certs/public-key.pem" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/client-certs/private-key.pem" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/client-certs/ca-certificate.pem" \
-		-e SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR=/root/config/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/msp \
-		-e SC_SIDECAR_ORDERER_IDENTITY_MSP_ID=Org1MSP \
-		-e SC_SIDECAR_ORDERER_CHANNEL_ID=mychannel \
-		-e SC_SIDECAR_ORDERER_SIGNED_ENVELOPES=true \
-		-e SC_QUERY_SERVICE_SERVER_ENDPOINT=:7001 \
-		-e SC_ORDERER_BLOCK_SIZE=1 \
-		docker.io/hyperledger/fabric-x-committer-test-node:0.1.9 run db orderer committer
+	@$(COMPOSE) -f compose.fabric-x.yml up -d
 	@while ! nc -z localhost 7001 2>/dev/null; do sleep 1; done
 	@go tool fxconfig namespace create basic --policy="OR('Org1MSP.member')" --endorse --submit --wait --config=testdata/fxconfig.yaml
 
@@ -89,7 +77,7 @@ test-x:
 
 .PHONY: stop-x
 stop-x:
-	@docker rm -f fabric-x-committer-test-node
+	@$(COMPOSE) -f compose.fabric-x.yml down
 
 .PHONY: start-fablo
 start-fablo:
@@ -136,18 +124,27 @@ eth-tests-slow-legacy:
 .PHONY: start-node
 start-node:
 	@if nc -z localhost 7050 2>/dev/null; then echo "Error: port 7050 is already in use — stop any running Fabric orderer before starting."; exit 1; fi
-	@docker compose --env-file blockscout.env up -d --build
+	@$(COMPOSE) -f compose.fabric-x.yml up -d
+	@echo "Waiting for committer to be ready..."
+	@while ! nc -z localhost 7001 2>/dev/null; do sleep 1; done
+	@$(DOCKER) run --rm --network fabric-x-evm_default \
+		--user "$(UID):$(GID)" \
+		-v "$(PWD)/testdata/fxconfig-docker.yaml:/testdata/fxconfig-docker.yaml:ro,Z" \
+		-v "$(PWD)/testdata/crypto:/testdata/crypto:ro,Z" \
+		docker.io/hyperledger/fabric-x-tools:latest \
+		fxconfig namespace create basic --policy="OR('Org1MSP.member')" \
+		--endorse --submit --wait --config=/testdata/fxconfig-docker.yaml
+	@$(COMPOSE) up -d --build gateway
 
 .PHONY: start
-start: blockscout.env
-	@if nc -z localhost 7050 2>/dev/null; then echo "Error: port 7050 is already in use — stop any running Fabric orderer before starting."; exit 1; fi
-	@if [ ! -f testdata/crypto/sc-genesis-block.proto.bin ]; then echo "Please run 'make init-x' first."; exit 1; fi
-	@docker compose --profile explorer --env-file blockscout.env up -d --build
+start: start-node blockscout.env
+	@$(COMPOSE) --env-file blockscout.env up -d --build
 	@echo "Visit the block explorer at http://localhost:8000/ (might take a minute to load)"
 
 .PHONY: stop
-stop: blockscout.env
-	@docker compose --profile explorer --env-file blockscout.env down -v
+stop:
+	@$(COMPOSE) down -v
+	@$(COMPOSE) -f compose.fabric-x.yml down
 
 blockscout.env:
 	@echo "Generating $@..."

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ You can now use the system as any other EVM-style chain! Backed by Fabric-X.
 > minute or two. Subsequent starts are fast. To run without the block explorer,
 > use `make start-node` instead.
 
+> [!NOTE]
+> **Rootless Podman**: pass `DOCKER=podman COMPOSE="podman compose"` to any
+> `make` target that starts or stops containers:
+> ```shell
+> make start DOCKER=podman COMPOSE="podman compose"
+> ```
+
 ### Deploy a token and interact via MetaMask
 
 You'll need:
@@ -71,13 +78,13 @@ open the extension → your account → Add Wallet → Private Key, and enter
 Deploy an ERC-20 token by choosing a name and symbol:
 
 ```shell
-make demo-deploy NAME="Digital Euro" SYMBOL=DEUR
+make demo-deploy NAME="Digital Euro" SYMBOL=EURX
 ```
 
 The explorer URL is printed immediately:
 
 ```
-Deployed Digital Euro (DEUR): http://localhost:8000/address/0x...
+Deployed Digital Euro (EURX): http://localhost:8000/address/0x...
 ```
 
 Open the URL. Scroll to the bottom and click **"Add Fabric-X EVM"** 

--- a/compose.fabric-x.yml
+++ b/compose.fabric-x.yml
@@ -1,0 +1,52 @@
+name: fabric-x-evm
+
+# Fabric-X infrastructure layer: the test committer node.
+# Both make start-node and make start bring this up first.
+# EVM namespace init is run separately by the Makefile once the committer is healthy.
+
+services:
+  # For local development, we use the Fabric-X test committer.
+  # For a real deployment, see:
+  # https://github.com/LF-Decentralized-Trust-labs/fabric-x-ansible-collection
+  test-committer:
+    image: docker.io/hyperledger/fabric-x-committer-test-node:0.1.9
+    pull_policy: missing
+    restart: unless-stopped
+    container_name: test-committer
+    command: run db orderer committer
+    ports:
+      - "4001:4001"
+      - "2110:2110"
+      - "2114:2114"
+      - "2117:2117"
+      - "7001:7001"
+      - "7050:7050"
+      - "5433:5433"
+    volumes:
+      - ./testdata/crypto:/root/config/crypto:ro,Z
+      - ./testdata/crypto/sc-genesis-block.proto.bin:/root/config/sc-genesis-block.proto.bin:ro,Z
+      - ./testdata/crypto/sc-genesis-block.proto.bin:/root/artifacts/config-block.pb.bin:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/server-certs/public-key.pem:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/server-certs/private-key.pem:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/server-certs/ca-certificate.pem:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/client-certs/public-key.pem:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/client-certs/private-key.pem:ro,Z
+      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/client-certs/ca-certificate.pem:ro,Z
+    environment:
+      SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR: /root/config/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/msp
+      SC_SIDECAR_ORDERER_IDENTITY_MSP_ID: Org1MSP
+      SC_SIDECAR_ORDERER_CHANNEL_ID: mychannel
+      SC_SIDECAR_ORDERER_SIGNED_ENVELOPES: "true"
+      SC_QUERY_SERVICE_SERVER_ENDPOINT: ":7001"
+      SC_ORDERER_BLOCK_SIZE: "1"
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 7001" ]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+    networks:
+      default:
+        aliases:
+          - committer # matches the TLS certificate SAN
+

--- a/compose.yml
+++ b/compose.yml
@@ -1,85 +1,20 @@
 name: fabric-x-evm
 
-# Local Fabric-X EVM stack.
+# Gateway and Blockscout block explorer.
 #
-# Core (fabric-x node + namespace init):
+# Fabric-X infrastructure (test-committer + namespace init) is in
+# compose.fabric-x.yml and is started first by the Makefile targets.
+#
+# Core only (gateway on :8545):
 #   make start-node
 #
-# With block explorer (adds Blockscout at http://localhost:8000):
+# With block explorer (Blockscout on :8000):
 #   make start
 #
 # Stop and remove volumes:
 #   make stop
 
 services:
-  # for local development, we use the Fabric-X test committer. For a real deployment, consider
-  # https://github.com/LF-Decentralized-Trust-labs/fabric-x-ansible-collection
-  test-committer:
-    image: docker.io/hyperledger/fabric-x-committer-test-node:0.1.9
-    pull_policy: missing
-    restart: unless-stopped
-    container_name: test-committer
-    command: run db orderer committer
-    ports:
-      - "4001:4001"
-      - "2110:2110"
-      - "2114:2114"
-      - "2117:2117"
-      - "7001:7001"
-      - "7050:7050"
-      - "5433:5433"
-    volumes:
-      - ./testdata/crypto:/root/config/crypto
-      - ./testdata/crypto/sc-genesis-block.proto.bin:/root/config/sc-genesis-block.proto.bin
-      - ./testdata/crypto/sc-genesis-block.proto.bin:/root/artifacts/config-block.pb.bin
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/server-certs/public-key.pem
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/server-certs/private-key.pem
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/server-certs/ca-certificate.pem
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.crt:/client-certs/public-key.pem
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/server.key:/client-certs/private-key.pem
-      - ./testdata/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/tls/ca.crt:/client-certs/ca-certificate.pem
-    environment:
-      SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR: /root/config/crypto/peerOrganizations/Org1/peers/committer.org1.example.com/msp
-      SC_SIDECAR_ORDERER_IDENTITY_MSP_ID: Org1MSP
-      SC_SIDECAR_ORDERER_CHANNEL_ID: mychannel
-      SC_SIDECAR_ORDERER_SIGNED_ENVELOPES: "true"
-      SC_QUERY_SERVICE_SERVER_ENDPOINT: ":7001"
-      SC_ORDERER_BLOCK_SIZE: "1"
-    healthcheck:
-      test: [ "CMD-SHELL", "nc -z localhost 7001" ]
-      interval: 2s
-      timeout: 3s
-      retries: 30
-      start_period: 10s
-    networks:
-      default:
-        aliases:
-          - committer # matches the TLS certificate SAN
-
-  # Creates the EVM namespace.
-  fxconfig-init:
-    image: docker.io/hyperledger/fabric-x-tools:latest
-    pull_policy: missing
-    container_name: fxconfig-init
-    user: "${UID:-1000}:${GID:-1000}"
-    entrypoint:
-      - fxconfig
-      - namespace
-      - create
-      - basic
-      - --policy=OR('Org1MSP.member')
-      - --endorse
-      - --submit
-      - --wait
-      - --config=/testdata/fxconfig-docker.yaml
-    volumes:
-      - ./testdata/fxconfig-docker.yaml:/testdata/fxconfig-docker.yaml:ro,Z
-      - ./testdata/crypto:/testdata/crypto:ro,Z
-    depends_on:
-      test-committer:
-        condition: service_healthy
-    restart: "no"
-
   gateway:
     build: .
     pull_policy: build
@@ -92,9 +27,6 @@ services:
     volumes:
       - ./testdata/crypto/peerOrganizations/Org1:/crypto:ro,Z
       - ./sampleconfig/fabx-docker.yaml:/sampleconfig/fabx-docker.yaml:ro,Z
-    depends_on:
-      fxconfig-init:
-        condition: service_completed_successfully
     healthcheck:
       test: [ "CMD", "fxevm", "healthcheck" ]
       interval: 2s
@@ -103,12 +35,11 @@ services:
       start_period: 10s
 
   # ---------------------------------------------------------------------------
-  # Blockscout block explorer — started with `make start` (profile: explorer)
+  # Blockscout block explorer — started with `make start`
   # ---------------------------------------------------------------------------
 
   db:
-    profiles: [ explorer ]
-    image: postgres:17
+    image: docker.io/library/postgres:17
     shm_size: 256m
     restart: unless-stopped
     container_name: db
@@ -128,14 +59,12 @@ services:
       start_period: 10s
 
   redis-db:
-    profiles: [ explorer ]
-    image: redis:alpine
+    image: docker.io/library/redis:alpine
     container_name: redis-db
     command: redis-server
     restart: unless-stopped
 
   backend:
-    profiles: [ explorer ]
     image: ghcr.io/blockscout/blockscout:9.0.2
     pull_policy: missing
     restart: unless-stopped
@@ -184,7 +113,6 @@ services:
       start_period: 120s
 
   sig-provider:
-    profiles: [ explorer ]
     image: ghcr.io/blockscout/sig-provider:v1.1.1
     platform: linux/amd64
     pull_policy: missing
@@ -192,7 +120,6 @@ services:
     container_name: sig-provider
 
   frontend:
-    profiles: [ explorer ]
     image: ghcr.io/blockscout/frontend:v2.3.5
     pull_policy: missing
     restart: unless-stopped
@@ -240,8 +167,7 @@ services:
       NEXT_PUBLIC_VIEWS_BLOCK_HIDDEN_FIELDS: "[\"burnt_fees\",\"total_reward\"]"
 
   proxy:
-    profiles: [ explorer ]
-    image: docker.io/nginx:1.29.8
+    image: docker.io/library/nginx:1.29.8
     pull_policy: missing
     container_name: proxy
     restart: unless-stopped


### PR DESCRIPTION
Stacked on top of https://github.com/hyperledger/fabric-x-evm/pull/178.

This makes it possible to run the application and blockscout with rootless podman.