### PR TITLE
feat: add mock Fabric-X perf backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ COMPOSE ?= docker compose
 build:
 	go build -o bin/fxevm ./cmd/fxevm
 
+.PHONY: build-mock-fabric-x
+build-mock-fabric-x:
+	go build -o bin/mock-fabric-x ./cmd/mock-fabric-x
+
+.PHONY: start-mock-x
+start-mock-x: build-mock-fabric-x
+	./bin/mock-fabric-x
+
 .PHONY: build-release
 build-release:
 	@for arch in $(RELEASE_ARCHS); do \

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ make stop-x
 
 The container does not keep state.
 
+### Mock Fabric-X for perf/loadgen
+
+To run the existing perf replay loadgen against an in-memory mock instead of real Fabric-X, see [`docs/mock-fabric-x.md`](docs/mock-fabric-x.md).
+
 ### Fablo
 
 Start the network, run the integration tests, and stop it again:

--- a/cmd/mock-fabric-x/main.go
+++ b/cmd/mock-fabric-x/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/hyperledger/fabric-x-evm/mockfabricx"
+	"google.golang.org/grpc/grpclog"
+)
+
+func main() {
+	// silence GRPC logging
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr))
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg := mockfabricx.DefaultConfig()
+	cfg.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	server, err := mockfabricx.NewServer(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "mock-fabric-x listening orderer=%s committer=%s tls=%s\n", cfg.OrdererListen, cfg.CommitterListen, cfg.TLSMode)
+	if err := server.Run(ctx); err != nil && ctx.Err() == nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/mock-fabric-x.md
+++ b/docs/mock-fabric-x.md
@@ -1,0 +1,161 @@
+# Mock Fabric-X for Performance Tests
+
+`mock-fabric-x` is a local in-memory Fabric-X orderer and committer-sidecar replacement for `fabric-x-evm` performance testing.
+
+Use it when you want the existing gateway loadgen/tests to run against a mock Fabric-X backend instead of the real Fabric-X orderer and committer stack.
+
+## What it replaces
+
+`mock-fabric-x` listens on the same endpoints used by `integration/fabx.yaml`:
+
+- Fabric `orderer.AtomicBroadcast.Broadcast`: `127.0.0.1:7050`
+- Fabric-X committer replay path on `127.0.0.1:4001`:
+  - `BlockQueryService.GetBlockchainInfo`
+  - Fabric peer `Deliver`
+  - `Notifier.StreamAllTransactions`
+
+This mock is intentionally narrow. It targets the replay/perf harness and does not implement Fabric-X query RPCs such as `GetBlockByNumber`, `GetBlockByTxID`, `GetTxByID`, or `GetTransactionStatus`.
+
+When using this mock, do **not** run `make start-x`. The mock owns the Fabric-X ports that the gateway loadgen already targets.
+
+## Non-goals
+
+This mock does not implement consensus, MVCC validation, persistence, namespace policy validation, or real committer database behavior. Use metrics from this backend as mock-backend/gateway-loadgen capacity only, not real Fabric-X orderer or committer capacity.
+
+## One-time setup
+
+Generate TLS material and config files used by `integration/fabx.yaml`:
+
+```bash
+make init-x
+```
+
+On Docker Desktop or bind mounts where container UID `501` cannot write to the mounted `testdata` directory, use container root for generation:
+
+```bash
+make init-x UID=0 GID=0
+```
+
+## Build
+
+```bash
+make build-mock-fabric-x
+```
+
+## Start mock Fabric-X
+
+Run the mock from the repository root. The default TLS paths are relative to that directory and match the `../testdata/...` paths used when Go runs `integration/fabx.yaml` tests from `integration/`.
+
+```bash
+./bin/mock-fabric-x \
+  --max-tx-per-block=500 \
+  --block-timeout=10ms
+```
+
+Leave it running in one terminal. In another terminal, run the gateway/loadgen tests from the repository root.
+
+## Run existing perf replay loadgen
+
+The perf replay test uses `integration/fabx.yaml`, so no test-code changes are needed.
+
+```bash
+PERF_REPLAY_WINDOW_SIZE=100 \
+PERF_REPLAY_WRAP_COUNT=1 \
+PERF_SUBMITTING_WORKERS=16 \
+PERF_PROCESSING_WORKERS=8 \
+go test -v -count=1 -tags=perf -run '^TestReplayJSONDataset$' -timeout 5m ./integration/perf
+```
+
+Expected successful smoke output resembles:
+
+```text
+Loaded 100 transfers from dataset
+Replay complete: 100 successful, 0 failed, 0 skipped out of 100 total transfers
+gw stats: 101 0 0
+--- PASS: TestReplayJSONDataset
+```
+
+## Dataset prerequisites
+
+`TestReplayJSONDataset` needs local perf data files:
+
+- `integration/perf/testdata/USDC_contract.json`
+- `integration/perf/testdata/USDC_dataset.json.gz`
+
+These large/generated files are not committed. To create real USDC replay data, follow:
+
+```text
+integration/perf/USDC_testing.md
+```
+
+For a quick local smoke, you can generate a small synthetic TSV and then use the existing perf generator. The successful smoke run used a generated 100-transfer dataset, not the full Harvard dataset.
+
+## Insecure local run
+
+Use `--tls-mode none` only with configs that disable TLS.
+
+```bash
+./bin/mock-fabric-x --tls-mode none --orderer-listen 127.0.0.1:17050 --committer-listen 127.0.0.1:14001
+```
+
+## Useful flags
+
+```text
+--orderer-listen      orderer AtomicBroadcast listen address
+--committer-listen    committer sidecar listen address
+--tls-mode            mtls or none
+--max-tx-per-block    maximum transactions per mock block
+--block-timeout       maximum time before cutting a partial block
+--queue-size          accepted envelope queue size
+```
+
+Examples:
+
+```bash
+# Larger blocks
+./bin/mock-fabric-x --max-tx-per-block=1000 --block-timeout=20ms
+
+# Immediate one-transaction blocks
+./bin/mock-fabric-x --max-tx-per-block=1 --block-timeout=0
+```
+
+## Troubleshooting
+
+### Port already in use
+
+Stop real Fabric-X before starting the mock:
+
+```bash
+make stop-x
+```
+
+Then start `mock-fabric-x` again.
+
+### TLS cert path errors
+
+Run `mock-fabric-x` from the repository root. The default orderer router certs live under the `party1` directory:
+
+```text
+testdata/crypto/ordererOrganizations/orderer-org-1/orderers/party1/router.orderer-org-1/tls/server.crt
+testdata/crypto/ordererOrganizations/orderer-org-1/orderers/party1/router.orderer-org-1/tls/server.key
+```
+
+If you run from another directory, either `cd` back to the repository root or pass absolute `--orderer-cert`, `--orderer-key`, `--committer-cert`, `--committer-key`, and client CA paths.
+
+### Missing perf files
+
+If the test fails with missing `USDC_contract.json` or `USDC_dataset.json.gz`, generate them first using `integration/perf/USDC_testing.md`.
+
+### Inspect mock logs
+
+Run mock with log capture:
+
+```bash
+./bin/mock-fabric-x ... > /tmp/mock-fabric-x.log 2>&1
+```
+
+Then inspect:
+
+```bash
+tail -100 /tmp/mock-fabric-x.log
+```

--- a/integration/perf/replay_config_test.go
+++ b/integration/perf/replay_config_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import "testing"
+
+func TestLoadReplayWorkerConfigFromEnv(t *testing.T) {
+	t.Setenv("PERF_PROCESSING_WORKERS", "16")
+	t.Setenv("PERF_SUBMITTING_WORKERS", "16")
+
+	processingWorkers, submittingWorkers := loadReplayWorkerConfigFromEnv(t)
+
+	if processingWorkers != 16 {
+		t.Fatalf("processingWorkers = %d, want 16", processingWorkers)
+	}
+	if submittingWorkers != 16 {
+		t.Fatalf("submittingWorkers = %d, want 16", submittingWorkers)
+	}
+}
+
+func TestLoadReplayWorkerConfigFromEnvDefaultsToOne(t *testing.T) {
+	processingWorkers, submittingWorkers := loadReplayWorkerConfigFromEnv(t)
+
+	if processingWorkers != 1 {
+		t.Fatalf("processingWorkers = %d, want 1", processingWorkers)
+	}
+	if submittingWorkers != 1 {
+		t.Fatalf("submittingWorkers = %d, want 1", submittingWorkers)
+	}
+}

--- a/integration/perf/replay_json_dataset_test.go
+++ b/integration/perf/replay_json_dataset_test.go
@@ -114,6 +114,24 @@ func loadReplayConfigFromEnv(t *testing.T) replayConfig {
 	return cfg
 }
 
+func loadReplayWorkerConfigFromEnv(t *testing.T) (int, int) {
+	processingWorkers := 1
+	if processingWorkersStr := os.Getenv("PERF_PROCESSING_WORKERS"); processingWorkersStr != "" {
+		_, err := fmt.Sscanf(processingWorkersStr, "%d", &processingWorkers)
+		assert.NoError(t, err, "PERF_PROCESSING_WORKERS must be a valid integer")
+		assert.True(t, processingWorkers >= 1, "PERF_PROCESSING_WORKERS must be >= 1")
+	}
+
+	submittingWorkers := 1
+	if submittingWorkersStr := os.Getenv("PERF_SUBMITTING_WORKERS"); submittingWorkersStr != "" {
+		_, err := fmt.Sscanf(submittingWorkersStr, "%d", &submittingWorkers)
+		assert.NoError(t, err, "PERF_SUBMITTING_WORKERS must be a valid integer")
+		assert.True(t, submittingWorkers >= 1, "PERF_SUBMITTING_WORKERS must be >= 1")
+	}
+
+	return processingWorkers, submittingWorkers
+}
+
 //lint:ignore U1000 kept for future tests / debugging
 func logMem(tag string) {
 	var m runtime.MemStats
@@ -408,8 +426,10 @@ func TestReplayJSONDataset(t *testing.T) {
 	}
 	// flogging.ActivateSpec("gateway.core.txqueue_v2=debug")
 
-	// Run the test with single worker configuration
-	_, _, _ = runReplayTest(t, 1, 1, loadReplayConfigFromEnv(t))
+	processingWorkers, submittingWorkers := loadReplayWorkerConfigFromEnv(t)
+	t.Logf("Running replay with processingWorkers=%d, submittingWorkers=%d", processingWorkers, submittingWorkers)
+
+	_, _, _ = runReplayTest(t, processingWorkers, submittingWorkers, loadReplayConfigFromEnv(t))
 }
 
 type performanceResult struct {

--- a/mockfabricx/committer_service.go
+++ b/mockfabricx/committer_service.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// RegisterCommitterServices registers replay-minimal committer and peer services.
+func RegisterCommitterServices(s grpc.ServiceRegistrar, ledger *Ledger) {
+	svc := &committerService{ledger: ledger}
+	committerpb.RegisterBlockQueryServiceServer(s, svc)
+	committerpb.RegisterQueryServiceServer(s, svc)
+	committerpb.RegisterNotifierServer(s, svc)
+	peer.RegisterDeliverServer(s, svc)
+}
+
+type committerService struct {
+	committerpb.UnimplementedBlockQueryServiceServer
+	committerpb.UnimplementedQueryServiceServer
+	committerpb.UnimplementedNotifierServer
+	peer.UnimplementedDeliverServer
+
+	ledger *Ledger
+}
+
+func (s *committerService) GetBlockchainInfo(context.Context, *emptypb.Empty) (*common.BlockchainInfo, error) {
+	return &common.BlockchainInfo{Height: s.ledger.Height()}, nil
+}
+
+func (s *committerService) Deliver(stream peer.Deliver_DeliverServer) error {
+	env, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	startBlockNumber := seekStartBlockNumber(env)
+	existingBlocks, chForNewBlocks, cancel := s.ledger.SubscribeBlocksFrom(startBlockNumber)
+	defer cancel()
+
+	for _, block := range existingBlocks {
+		if err := stream.Send(&peer.DeliverResponse{Type: &peer.DeliverResponse_Block{Block: block}}); err != nil {
+			return err
+		}
+	}
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case block, ok := <-chForNewBlocks:
+			if !ok {
+				return nil
+			}
+
+			if block.GetHeader().GetNumber() < startBlockNumber {
+				continue
+			}
+
+			if err := stream.Send(&peer.DeliverResponse{Type: &peer.DeliverResponse_Block{Block: block}}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func seekStartBlockNumber(env *common.Envelope) uint64 {
+	payload := &common.Payload{}
+	if proto.Unmarshal(env.GetPayload(), payload) != nil {
+		return 1
+	}
+
+	seek := &orderer.SeekInfo{}
+	if proto.Unmarshal(payload.GetData(), seek) != nil {
+		return 1
+	}
+
+	specified := seek.GetStart().GetSpecified()
+	if specified == nil || specified.Number == 0 {
+		return 1
+	}
+	return specified.Number
+}
+
+func (s *committerService) StreamAllTransactions(req *committerpb.StreamAllRequest, stream committerpb.Notifier_StreamAllTransactionsServer) error {
+	existingBatches, chForNewBatches, cancel := s.ledger.SubscribeEventBatches()
+	defer cancel()
+
+	for _, batch := range existingBatches {
+		filtered := filterBatch(batch, req)
+		if len(filtered.Events) == 0 {
+			continue
+		}
+		if err := stream.Send(filtered); err != nil {
+			return err
+		}
+	}
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case batch, ok := <-chForNewBatches:
+			if !ok {
+				return nil
+			}
+			filtered := filterBatch(batch, req)
+			if len(filtered.Events) == 0 {
+				continue
+			}
+			if err := stream.Send(filtered); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func filterBatch(batch *committerpb.TxEventBatch, req *committerpb.StreamAllRequest) *committerpb.TxEventBatch {
+	if req == nil {
+		req = &committerpb.StreamAllRequest{}
+	}
+	out := &committerpb.TxEventBatch{BlockNumber: batch.GetBlockNumber()}
+	for _, event := range batch.GetEvents() {
+		if !matchesStatus(event.GetStatus(), req.GetFilterStatus()) {
+			continue
+		}
+		namespaces := filterNamespaces(event.GetNamespaces(), req.GetFilterNamespaces())
+		if len(req.GetFilterNamespaces()) > 0 && len(namespaces) == 0 {
+			continue
+		}
+		copied := &committerpb.TxEvent{Status: event.GetStatus()}
+		if event.GetRef() != nil {
+			copied.Ref = proto.Clone(event.GetRef()).(*committerpb.TxRef)
+		}
+		if req.GetIncludeReadWriteSets() {
+			copied.Namespaces = namespaces
+		}
+		if req.GetIncludeEndorsements() {
+			copied.Endorsements = append([]*applicationpb.Endorsements(nil), event.GetEndorsements()...)
+		}
+		out.Events = append(out.Events, copied)
+	}
+	return out
+}
+
+func matchesStatus(status committerpb.Status, allowed []committerpb.Status) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, candidate := range allowed {
+		if candidate == status {
+			return true
+		}
+	}
+	return false
+}
+
+func filterNamespaces(namespaces []*applicationpb.TxNamespace, allowed []string) []*applicationpb.TxNamespace {
+	if len(allowed) == 0 {
+		return append([]*applicationpb.TxNamespace(nil), namespaces...)
+	}
+	allow := map[string]any{}
+	for _, nsID := range allowed {
+		allow[nsID] = nil
+	}
+	out := []*applicationpb.TxNamespace{}
+	for _, ns := range namespaces {
+		if _, ok := allow[ns.GetNsId()]; ok {
+			out = append(out, ns)
+		}
+	}
+	return out
+}

--- a/mockfabricx/committer_service_test.go
+++ b/mockfabricx/committer_service_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"context"
+	"math"
+	"net"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestPeerDeliverStreamsBlocksFromStart(t *testing.T) {
+	fixture := newInsecureServiceFixture(t)
+	defer fixture.close()
+	fixture.ledger.Commit([]*common.Envelope{newTxEnvelope(t, "tx-1")})
+
+	client := peer.NewDeliverClient(fixture.conn)
+	stream, err := client.Deliver(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(newSeekEnvelope(t, 1)))
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	blockResp := resp.GetBlock()
+	require.NotNil(t, blockResp)
+	require.Equal(t, uint64(1), blockResp.Header.Number)
+}
+
+func TestStreamAllTransactionsStreamsExistingAndFutureEvents(t *testing.T) {
+	fixture := newInsecureServiceFixture(t)
+	defer fixture.close()
+	fixture.ledger.Commit([]*common.Envelope{newTxEnvelope(t, "tx-1")})
+
+	client := committerpb.NewNotifierClient(fixture.conn)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{IncludeReadWriteSets: true})
+	require.NoError(t, err)
+
+	first, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), first.BlockNumber)
+	require.Equal(t, "tx-1", first.Events[0].Ref.TxId)
+	require.NotEmpty(t, first.Events[0].Namespaces)
+
+	fixture.ledger.Commit([]*common.Envelope{newTxEnvelope(t, "tx-2")})
+	second, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "tx-2", second.Events[0].Ref.TxId)
+}
+
+func TestGetBlockchainInfoReturnsHeight(t *testing.T) {
+	fixture := newInsecureServiceFixture(t)
+	defer fixture.close()
+	fixture.ledger.Commit([]*common.Envelope{newTxEnvelope(t, "tx-1")})
+
+	client := committerpb.NewBlockQueryServiceClient(fixture.conn)
+	info, err := client.GetBlockchainInfo(t.Context(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), info.Height)
+}
+
+type serviceFixture struct {
+	ledger *Ledger
+	server *grpc.Server
+	conn   *grpc.ClientConn
+}
+
+func newInsecureServiceFixture(t *testing.T) serviceFixture {
+	t.Helper()
+	ledger := NewLedger()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	RegisterCommitterServices(srv, ledger)
+	go func() { _ = srv.Serve(lis) }()
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	return serviceFixture{ledger: ledger, server: srv, conn: conn}
+}
+
+func (f serviceFixture) close() {
+	_ = f.conn.Close()
+	f.server.Stop()
+}
+
+func newSeekEnvelope(t *testing.T, start uint64) *common.Envelope {
+	t.Helper()
+	seekInfo := mustMarshal(t, &orderer.SeekInfo{
+		Start:    &orderer.SeekPosition{Type: &orderer.SeekPosition_Specified{Specified: &orderer.SeekSpecified{Number: start}}},
+		Stop:     &orderer.SeekPosition{Type: &orderer.SeekPosition_Specified{Specified: &orderer.SeekSpecified{Number: math.MaxUint64}}},
+		Behavior: orderer.SeekInfo_BLOCK_UNTIL_READY,
+	})
+	payload := mustMarshal(t, &common.Payload{
+		Header: &common.Header{ChannelHeader: mustMarshal(t, &common.ChannelHeader{Type: int32(common.HeaderType_DELIVER_SEEK_INFO), ChannelId: "mychannel"})},
+		Data:   seekInfo,
+	})
+	return &common.Envelope{Payload: payload}
+}

--- a/mockfabricx/config.go
+++ b/mockfabricx/config.go
@@ -1,0 +1,85 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"time"
+)
+
+const (
+	// TLSModeNone disables TLS on mock gRPC listeners.
+	TLSModeNone = "none"
+	// TLSModeMTLS enables mutual TLS on mock gRPC listeners.
+	TLSModeMTLS = "mtls"
+)
+
+// Config defines listener, TLS, and batching settings for the mock backend.
+type Config struct {
+	OrdererListen     string
+	CommitterListen   string
+	TLSMode           string
+	OrdererCert       string
+	OrdererKey        string
+	OrdererClientCA   string
+	CommitterCert     string
+	CommitterKey      string
+	CommitterClientCA string
+	MaxTxPerBlock     int
+	BlockTimeout      time.Duration
+	QueueSize         int
+}
+
+// DefaultConfig returns settings matching the integration Fabric-X defaults.
+func DefaultConfig() Config {
+	return Config{
+		OrdererListen:     "127.0.0.1:7050",
+		CommitterListen:   "127.0.0.1:4001",
+		TLSMode:           TLSModeMTLS,
+		OrdererCert:       "testdata/crypto/ordererOrganizations/orderer-org-1/orderers/party1/router.orderer-org-1/tls/server.crt",
+		OrdererKey:        "testdata/crypto/ordererOrganizations/orderer-org-1/orderers/party1/router.orderer-org-1/tls/server.key",
+		OrdererClientCA:   "testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem",
+		CommitterCert:     "testdata/crypto/peerOrganizations/org1.example.com/peers/committer-sidecar.org1.example.com/tls/server.crt",
+		CommitterKey:      "testdata/crypto/peerOrganizations/org1.example.com/peers/committer-sidecar.org1.example.com/tls/server.key",
+		CommitterClientCA: "testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem",
+		MaxTxPerBlock:     1,
+		BlockTimeout:      0,
+		QueueSize:         65536,
+	}
+}
+
+// Validate rejects unsupported TLS modes and invalid batching settings.
+func (c Config) Validate() error {
+	if c.MaxTxPerBlock <= 0 {
+		return errors.New("max-tx-per-block must be positive")
+	}
+	if c.QueueSize <= 0 {
+		return errors.New("queue-size must be positive")
+	}
+	if c.TLSMode != TLSModeNone && c.TLSMode != TLSModeMTLS {
+		return fmt.Errorf("tls-mode must be %q or %q", TLSModeNone, TLSModeMTLS)
+	}
+	return nil
+}
+
+// BindFlags binds command-line flags onto Config fields.
+func (c *Config) BindFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.OrdererListen, "orderer-listen", c.OrdererListen, "orderer AtomicBroadcast listen address")
+	fs.StringVar(&c.CommitterListen, "committer-listen", c.CommitterListen, "committer sidecar listen address")
+	fs.StringVar(&c.TLSMode, "tls-mode", c.TLSMode, "TLS mode: mtls or none")
+	fs.StringVar(&c.OrdererCert, "orderer-cert", c.OrdererCert, "orderer server TLS certificate path")
+	fs.StringVar(&c.OrdererKey, "orderer-key", c.OrdererKey, "orderer server TLS key path")
+	fs.StringVar(&c.OrdererClientCA, "orderer-client-ca", c.OrdererClientCA, "CA for orderer client certificates")
+	fs.StringVar(&c.CommitterCert, "committer-cert", c.CommitterCert, "committer server TLS certificate path")
+	fs.StringVar(&c.CommitterKey, "committer-key", c.CommitterKey, "committer server TLS key path")
+	fs.StringVar(&c.CommitterClientCA, "committer-client-ca", c.CommitterClientCA, "CA for committer client certificates")
+	fs.IntVar(&c.MaxTxPerBlock, "max-tx-per-block", c.MaxTxPerBlock, "maximum transactions per mock block")
+	fs.DurationVar(&c.BlockTimeout, "block-timeout", c.BlockTimeout, "maximum time before cutting partial block")
+	fs.IntVar(&c.QueueSize, "queue-size", c.QueueSize, "accepted envelope queue size")
+}

--- a/mockfabricx/config_test.go
+++ b/mockfabricx/config_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfigMatchesFabXPortsAndBatchDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	require.Equal(t, "127.0.0.1:7050", cfg.OrdererListen)
+	require.Equal(t, "127.0.0.1:4001", cfg.CommitterListen)
+	require.Equal(t, TLSModeMTLS, cfg.TLSMode)
+	require.Equal(t, 1, cfg.MaxTxPerBlock)
+	require.Equal(t, time.Duration(0), cfg.BlockTimeout)
+	require.Equal(t, 65536, cfg.QueueSize)
+}
+
+func TestValidateRejectsBadConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxTxPerBlock = 0
+	require.ErrorContains(t, cfg.Validate(), "max-tx-per-block")
+
+	cfg = DefaultConfig()
+	cfg.TLSMode = "bogus"
+	require.ErrorContains(t, cfg.Validate(), "tls-mode")
+}

--- a/mockfabricx/ledger.go
+++ b/mockfabricx/ledger.go
@@ -1,0 +1,219 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"google.golang.org/protobuf/proto"
+)
+
+// Ledger stores mock blocks and transaction event batches in memory.
+type Ledger struct {
+	mu sync.RWMutex
+
+	nextBlockNum uint64
+	blocks       []*common.Block
+	eventBatches []*committerpb.TxEventBatch
+
+	blockSubs map[chan *common.Block]any
+	eventSubs map[chan *committerpb.TxEventBatch]any
+}
+
+// NewLedger returns an empty ledger with block numbering starting at 1.
+func NewLedger() *Ledger {
+	return &Ledger{
+		nextBlockNum: 1,
+		blockSubs:    map[chan *common.Block]any{},
+		eventSubs:    map[chan *committerpb.TxEventBatch]any{},
+	}
+}
+
+// Height returns the next block number, matching Fabric ledger height semantics.
+func (l *Ledger) Height() uint64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.nextBlockNum
+}
+
+// Commit appends envs as one mock block and returns its transaction event batch.
+func (l *Ledger) Commit(envs []*common.Envelope) *committerpb.TxEventBatch {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	blockNum := l.nextBlockNum
+	l.nextBlockNum++
+
+	block := &common.Block{
+		Header: &common.BlockHeader{Number: blockNum},
+		Data:   &common.BlockData{Data: make([][]byte, 0, len(envs))},
+		Metadata: &common.BlockMetadata{
+			Metadata: make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1),
+		},
+	}
+
+	parsed := make([]ParsedEnvelope, 0, len(envs))
+	txFilter := make([]byte, 0, len(envs))
+	for _, env := range envs {
+		bytes, _ := proto.Marshal(env)
+		block.Data.Data = append(block.Data.Data, bytes)
+		p := ParseEnvelope(env)
+		parsed = append(parsed, p)
+		txFilter = append(txFilter, byte(p.Status))
+	}
+	block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = txFilter
+
+	events := make([]*committerpb.TxEvent, 0, len(envs))
+	for txNum, p := range parsed {
+		if p.TxID == "" {
+			continue
+		}
+		ref := &committerpb.TxRef{TxId: p.TxID, BlockNum: blockNum, TxNum: uint32(txNum)}
+		if !p.SkipEvent {
+			events = append(events, &committerpb.TxEvent{
+				Ref:          ref,
+				Status:       p.Status,
+				Namespaces:   p.Namespaces,
+				Endorsements: p.Endorsements,
+			})
+		}
+	}
+
+	batch := &committerpb.TxEventBatch{BlockNumber: blockNum, Events: events}
+	l.blocks = append(l.blocks, block)
+	l.eventBatches = append(l.eventBatches, batch)
+	l.notifyLocked(block, batch)
+	return cloneEventBatch(batch)
+}
+
+// SubscribeBlocksFrom returns existing blocks from start plus a live block stream.
+func (l *Ledger) SubscribeBlocksFrom(start uint64) ([]*common.Block, <-chan *common.Block, func()) {
+	chForNewBlocks := make(chan *common.Block, 1024)
+
+	// Snapshot and subscribe under one lock so Deliver cannot miss a block
+	// committed between catch-up and live streaming.
+	l.mu.Lock()
+	existingBlocks := make([]*common.Block, 0, len(l.blocks))
+	for _, block := range l.blocks {
+		if block.GetHeader().GetNumber() >= start {
+			existingBlocks = append(existingBlocks, proto.Clone(block).(*common.Block))
+		}
+	}
+	l.blockSubs[chForNewBlocks] = nil
+	l.mu.Unlock()
+
+	cancel := func() {
+		l.mu.Lock()
+		delete(l.blockSubs, chForNewBlocks)
+		close(chForNewBlocks)
+		l.mu.Unlock()
+	}
+	return existingBlocks, chForNewBlocks, cancel
+}
+
+// SubscribeEventBatches returns existing transaction batches plus a live batch stream.
+func (l *Ledger) SubscribeEventBatches() ([]*committerpb.TxEventBatch, <-chan *committerpb.TxEventBatch, func()) {
+	chForNewBatches := make(chan *committerpb.TxEventBatch, 1024)
+
+	// Same atomic catch-up/live handoff as blocks; filtering belongs to the
+	// committer service because it is request-specific.
+	l.mu.Lock()
+	existingBatches := make([]*committerpb.TxEventBatch, 0, len(l.eventBatches))
+	for _, batch := range l.eventBatches {
+		existingBatches = append(existingBatches, cloneEventBatch(batch))
+	}
+	l.eventSubs[chForNewBatches] = nil
+	l.mu.Unlock()
+
+	cancel := func() {
+		l.mu.Lock()
+		delete(l.eventSubs, chForNewBatches)
+		close(chForNewBatches)
+		l.mu.Unlock()
+	}
+	return existingBatches, chForNewBatches, cancel
+}
+
+func cloneEventBatch(batch *committerpb.TxEventBatch) *committerpb.TxEventBatch {
+	if batch == nil {
+		return nil
+	}
+	return proto.Clone(batch).(*committerpb.TxEventBatch)
+}
+
+func (l *Ledger) notifyLocked(block *common.Block, batch *committerpb.TxEventBatch) {
+	for ch := range l.blockSubs {
+		select {
+		case ch <- proto.Clone(block).(*common.Block):
+		default:
+		}
+	}
+	for ch := range l.eventSubs {
+		select {
+		case ch <- cloneEventBatch(batch):
+		default:
+		}
+	}
+}
+
+// ParsedEnvelope captures fields extracted from an orderer envelope.
+type ParsedEnvelope struct {
+	TxID         string
+	Status       committerpb.Status
+	Namespaces   []*applicationpb.TxNamespace
+	Endorsements []*applicationpb.Endorsements
+	SkipEvent    bool
+	Err          error
+}
+
+// ParseEnvelope extracts transaction metadata and validation status from env.
+func ParseEnvelope(env *common.Envelope) ParsedEnvelope {
+	if env == nil {
+		return ParsedEnvelope{Status: committerpb.Status_MALFORMED_BAD_ENVELOPE, Err: fmt.Errorf("nil envelope")}
+	}
+
+	payload := &common.Payload{}
+	if err := proto.Unmarshal(env.Payload, payload); err != nil {
+		return ParsedEnvelope{Status: committerpb.Status_MALFORMED_BAD_ENVELOPE, Err: fmt.Errorf("payload: %w", err)}
+	}
+
+	if payload.Header == nil {
+		return ParsedEnvelope{Status: committerpb.Status_MALFORMED_MISSING_TX_ID, Err: fmt.Errorf("missing header")}
+	}
+
+	chdr := &common.ChannelHeader{}
+	if err := proto.Unmarshal(payload.Header.ChannelHeader, chdr); err != nil {
+		return ParsedEnvelope{Status: committerpb.Status_MALFORMED_MISSING_TX_ID, Err: fmt.Errorf("channel header: %w", err)}
+	}
+
+	result := ParsedEnvelope{TxID: chdr.TxId, Status: committerpb.Status_COMMITTED}
+	if result.TxID == "" {
+		result.Status = committerpb.Status_MALFORMED_MISSING_TX_ID
+		result.Err = fmt.Errorf("missing tx id")
+		return result
+	}
+
+	if chdr.Type != int32(common.HeaderType_MESSAGE) {
+		result.SkipEvent = true
+		return result
+	}
+
+	tx := &applicationpb.Tx{}
+	if err := proto.Unmarshal(payload.Data, tx); err != nil {
+		result.Status = committerpb.Status_MALFORMED_BAD_ENVELOPE_PAYLOAD
+		result.Err = fmt.Errorf("transaction: %w", err)
+		return result
+	}
+
+	result.Namespaces = tx.Namespaces
+	result.Endorsements = tx.Endorsements
+	return result
+}

--- a/mockfabricx/ledger_test.go
+++ b/mockfabricx/ledger_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestParseEnvelope(t *testing.T) {
+	t.Run("extracts tx id namespaces and endorsements", func(t *testing.T) {
+		env := newTestEnvelope(t, "tx-1", &applicationpb.Tx{
+			Namespaces:   []*applicationpb.TxNamespace{{NsId: "basic", NsVersion: 1}},
+			Endorsements: []*applicationpb.Endorsements{{}},
+		})
+
+		parsed := ParseEnvelope(env)
+
+		require.NoError(t, parsed.Err)
+		require.Equal(t, "tx-1", parsed.TxID)
+		require.Equal(t, committerpb.Status_COMMITTED, parsed.Status)
+		require.Len(t, parsed.Namespaces, 1)
+		require.Equal(t, "basic", parsed.Namespaces[0].NsId)
+		require.Len(t, parsed.Endorsements, 1)
+	})
+
+	t.Run("skips non-message envelope", func(t *testing.T) {
+		payloadBytes, err := proto.Marshal(&common.Payload{
+			Header: &common.Header{ChannelHeader: mustMarshal(t, &common.ChannelHeader{Type: int32(common.HeaderType_CONFIG), TxId: "config-tx"})},
+		})
+		require.NoError(t, err)
+
+		parsed := ParseEnvelope(&common.Envelope{Payload: payloadBytes})
+
+		require.NoError(t, parsed.Err)
+		require.Equal(t, "config-tx", parsed.TxID)
+		require.True(t, parsed.SkipEvent)
+		require.Equal(t, committerpb.Status_COMMITTED, parsed.Status)
+	})
+
+	t.Run("marks bad payload when tx id is known", func(t *testing.T) {
+		payloadBytes, err := proto.Marshal(&common.Payload{
+			Header: &common.Header{ChannelHeader: mustMarshal(t, &common.ChannelHeader{Type: int32(common.HeaderType_MESSAGE), TxId: "bad-tx"})},
+			Data:   []byte("not an applicationpb.Tx"),
+		})
+		require.NoError(t, err)
+
+		parsed := ParseEnvelope(&common.Envelope{Payload: payloadBytes})
+
+		require.Error(t, parsed.Err)
+		require.Equal(t, "bad-tx", parsed.TxID)
+		require.Equal(t, committerpb.Status_MALFORMED_BAD_ENVELOPE_PAYLOAD, parsed.Status)
+		require.Empty(t, parsed.Namespaces)
+	})
+
+	t.Run("omits when tx id unavailable", func(t *testing.T) {
+		parsed := ParseEnvelope(&common.Envelope{Payload: []byte("bad payload")})
+
+		require.Error(t, parsed.Err)
+		require.Empty(t, parsed.TxID)
+		require.Equal(t, committerpb.Status_MALFORMED_BAD_ENVELOPE, parsed.Status)
+	})
+}
+
+func TestLedgerCommitStoresBlockAndEvent(t *testing.T) {
+	ledger := NewLedger()
+	env := newTestEnvelope(t, "tx-1", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})
+
+	batch := ledger.Commit([]*common.Envelope{env})
+
+	require.Equal(t, uint64(1), batch.BlockNumber)
+	require.Len(t, batch.Events, 1)
+	require.Equal(t, "tx-1", batch.Events[0].Ref.TxId)
+	require.Equal(t, uint64(1), batch.Events[0].Ref.BlockNum)
+	require.Equal(t, uint32(0), batch.Events[0].Ref.TxNum)
+	require.Equal(t, committerpb.Status_COMMITTED, batch.Events[0].Status)
+	require.Equal(t, uint64(2), ledger.Height())
+}
+
+func TestSubscribeBlocksFromReturnsExistingAndFutureBlocks(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Commit([]*common.Envelope{newTestEnvelope(t, "tx-1", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})})
+
+	existingBlocks, chForNewBlocks, cancel := ledger.SubscribeBlocksFrom(1)
+	defer cancel()
+
+	require.Len(t, existingBlocks, 1)
+	require.Equal(t, uint64(1), existingBlocks[0].Header.Number)
+
+	ledger.Commit([]*common.Envelope{newTestEnvelope(t, "tx-2", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})})
+
+	select {
+	case newBlock := <-chForNewBlocks:
+		require.Equal(t, uint64(2), newBlock.Header.Number)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for new block")
+	}
+}
+
+func TestSubscribeEventBatchesReturnsExistingAndFutureBatches(t *testing.T) {
+	ledger := NewLedger()
+	env1 := newTestEnvelope(t, "tx-1", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})
+	env2 := newTestEnvelope(t, "tx-2", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "other"}}})
+	ledger.Commit([]*common.Envelope{env1, env2})
+
+	existingBatches, chForNewBatches, cancel := ledger.SubscribeEventBatches()
+	defer cancel()
+
+	require.Len(t, existingBatches, 1)
+	require.Len(t, existingBatches[0].Events, 2)
+	require.Equal(t, "tx-1", existingBatches[0].Events[0].Ref.TxId)
+	require.Equal(t, "tx-2", existingBatches[0].Events[1].Ref.TxId)
+
+	ledger.Commit([]*common.Envelope{newTestEnvelope(t, "tx-3", &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})})
+
+	select {
+	case newBatch := <-chForNewBatches:
+		require.Len(t, newBatch.Events, 1)
+		require.Equal(t, "tx-3", newBatch.Events[0].Ref.TxId)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for new event batch")
+	}
+}
+
+func newTestEnvelope(t *testing.T, txID string, tx *applicationpb.Tx) *common.Envelope {
+	t.Helper()
+	txBytes := mustMarshal(t, tx)
+	payloadBytes, err := proto.Marshal(&common.Payload{
+		Header: &common.Header{ChannelHeader: mustMarshal(t, &common.ChannelHeader{Type: int32(common.HeaderType_MESSAGE), TxId: txID, ChannelId: "mychannel"})},
+		Data:   txBytes,
+	})
+	require.NoError(t, err)
+	return &common.Envelope{Payload: payloadBytes}
+}
+
+func mustMarshal(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return data
+}

--- a/mockfabricx/orderer_service.go
+++ b/mockfabricx/orderer_service.go
@@ -1,0 +1,122 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"google.golang.org/grpc"
+)
+
+// ordererService owns block cutting because AtomicBroadcast is the only
+// producer in this mock backend.
+type ordererServiceConfig struct {
+	maxTxPerBlock int
+	blockTimeout  time.Duration
+	queueSize     int
+}
+
+type ordererService struct {
+	orderer.UnimplementedAtomicBroadcastServer
+
+	ledger        *Ledger
+	in            chan *common.Envelope
+	maxTxPerBlock int
+	blockTimeout  time.Duration
+}
+
+func newOrdererService(ledger *Ledger, cfg ordererServiceConfig) *ordererService {
+	if cfg.maxTxPerBlock <= 0 {
+		cfg.maxTxPerBlock = 1
+	}
+	if cfg.queueSize <= 0 {
+		cfg.queueSize = 65536
+	}
+	return &ordererService{
+		ledger:        ledger,
+		in:            make(chan *common.Envelope, cfg.queueSize),
+		maxTxPerBlock: cfg.maxTxPerBlock,
+		blockTimeout:  cfg.blockTimeout,
+	}
+}
+
+// RegisterOrdererServices registers the AtomicBroadcast service.
+func RegisterOrdererServices(s grpc.ServiceRegistrar, ordererServer orderer.AtomicBroadcastServer) {
+	orderer.RegisterAtomicBroadcastServer(s, ordererServer)
+}
+
+func (s *ordererService) Broadcast(stream orderer.AtomicBroadcast_BroadcastServer) error {
+	for {
+		env, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := s.submit(stream.Context(), env); err != nil {
+			return err
+		}
+
+		if err := stream.Send(&orderer.BroadcastResponse{Status: common.Status_SUCCESS}); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *ordererService) submit(ctx context.Context, env *common.Envelope) error {
+	select {
+	case s.in <- env:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *ordererService) run(ctx context.Context) error {
+	var pending []*common.Envelope
+	var tickerC <-chan time.Time
+
+	if s.blockTimeout > 0 {
+		ticker := time.NewTicker(s.blockTimeout)
+		defer ticker.Stop()
+		tickerC = ticker.C
+	}
+
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		s.ledger.Commit(pending)
+		pending = nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return nil
+		case env := <-s.in:
+			if env == nil {
+				return fmt.Errorf("nil envelope")
+			}
+			pending = append(pending, env)
+			if len(pending) >= s.maxTxPerBlock || s.blockTimeout == 0 {
+				flush()
+				continue
+			}
+		case <-tickerC:
+			flush()
+		}
+	}
+}

--- a/mockfabricx/orderer_service_test.go
+++ b/mockfabricx/orderer_service_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestOrdererServiceCutsBlocks(t *testing.T) {
+	tests := map[string]struct {
+		cfg   ordererServiceConfig
+		txIDs []string
+	}{
+		"by max tx per block": {
+			cfg:   ordererServiceConfig{maxTxPerBlock: 2, blockTimeout: time.Hour, queueSize: 4},
+			txIDs: []string{"tx-1", "tx-2"},
+		},
+		"by timeout": {
+			cfg:   ordererServiceConfig{maxTxPerBlock: 100, blockTimeout: 10 * time.Millisecond, queueSize: 4},
+			txIDs: []string{"tx-1"},
+		},
+		"immediate mode": {
+			cfg:   ordererServiceConfig{maxTxPerBlock: 1, blockTimeout: 0, queueSize: 4},
+			txIDs: []string{"tx-1"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ledger, svc, ctx := newRunningOrdererService(t, tt.cfg)
+
+			for _, txID := range tt.txIDs {
+				require.NoError(t, svc.submit(ctx, newTxEnvelope(t, txID)))
+			}
+
+			require.Eventually(t, func() bool { return ledger.Height() == 2 }, time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestAtomicBroadcastSubmitsToOrdererService(t *testing.T) {
+	ledger, svc, _ := newRunningOrdererService(t, ordererServiceConfig{maxTxPerBlock: 1, blockTimeout: 0, queueSize: 4})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	RegisterOrdererServices(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	stream, err := orderer.NewAtomicBroadcastClient(conn).Broadcast(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(newTxEnvelope(t, "tx-1")))
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, common.Status_SUCCESS, resp.Status)
+	require.Eventually(t, func() bool { return ledger.Height() == 2 }, time.Second, 10*time.Millisecond)
+}
+
+func newRunningOrdererService(t *testing.T, cfg ordererServiceConfig) (*Ledger, *ordererService, context.Context) {
+	t.Helper()
+
+	ledger := NewLedger()
+	svc := newOrdererService(ledger, cfg)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	go func() { _ = svc.run(ctx) }()
+
+	return ledger, svc, ctx
+}
+
+func newTxEnvelope(t *testing.T, txID string) *common.Envelope {
+	t.Helper()
+	return newTestEnvelope(t, txID, &applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{NsId: "basic"}}})
+}

--- a/mockfabricx/server.go
+++ b/mockfabricx/server.go
@@ -1,0 +1,118 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package mockfabricx
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// Server runs mock orderer and committer gRPC services against one ledger.
+type Server struct {
+	cfg     Config
+	ledger  *Ledger
+	orderer *ordererService
+}
+
+// NewServer validates cfg and constructs a mock Fabric-X server.
+func NewServer(cfg Config) (*Server, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	ledger := NewLedger()
+	return &Server{
+		cfg:    cfg,
+		ledger: ledger,
+		orderer: newOrdererService(ledger, ordererServiceConfig{
+			maxTxPerBlock: cfg.MaxTxPerBlock,
+			blockTimeout:  cfg.BlockTimeout,
+			queueSize:     cfg.QueueSize,
+		}),
+	}, nil
+}
+
+// Run serves orderer and committer endpoints until ctx is canceled or serving fails.
+func (s *Server) Run(ctx context.Context) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return s.orderer.run(ctx) })
+	g.Go(func() error { return s.serveOrderer(ctx) })
+	g.Go(func() error { return s.serveCommitter(ctx) })
+	err := g.Wait()
+	if errors.Is(err, grpc.ErrServerStopped) || (err == nil && ctx.Err() != nil) {
+		return nil
+	}
+	return err
+}
+
+func (s *Server) serveOrderer(ctx context.Context) error {
+	opts, err := serverOptions(s.cfg.TLSMode, s.cfg.OrdererCert, s.cfg.OrdererKey, s.cfg.OrdererClientCA)
+	if err != nil {
+		return err
+	}
+	return s.serve(ctx, s.cfg.OrdererListen, opts, func(grpcServer *grpc.Server) {
+		RegisterOrdererServices(grpcServer, s.orderer)
+	})
+}
+
+func (s *Server) serveCommitter(ctx context.Context) error {
+	opts, err := serverOptions(s.cfg.TLSMode, s.cfg.CommitterCert, s.cfg.CommitterKey, s.cfg.CommitterClientCA)
+	if err != nil {
+		return err
+	}
+	return s.serve(ctx, s.cfg.CommitterListen, opts, func(grpcServer *grpc.Server) {
+		RegisterCommitterServices(grpcServer, s.ledger)
+	})
+}
+
+func (s *Server) serve(ctx context.Context, listen string, opts []grpc.ServerOption, register func(*grpc.Server)) error {
+	lis, err := net.Listen("tcp", listen)
+	if err != nil {
+		return err
+	}
+	grpcServer := grpc.NewServer(opts...)
+	register(grpcServer)
+	go func() {
+		<-ctx.Done()
+		grpcServer.GracefulStop()
+	}()
+	return grpcServer.Serve(lis)
+}
+
+func serverOptions(mode, certPath, keyPath, clientCAPath string) ([]grpc.ServerOption, error) {
+	if mode == TLSModeNone {
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load server cert/key: %w", err)
+	}
+	caPEM, err := os.ReadFile(clientCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("read client CA %s: %w", clientCAPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parse client CA %s", clientCAPath)
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    pool,
+		MinVersion:   tls.VersionTLS12,
+	}
+	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(cfg))}, nil
+}


### PR DESCRIPTION
Add mock-fabric-x, a local in-memory Fabric-X orderer and committer-sidecar replacement for replay and gateway performance tests.

The mock serves the replay-minimal surface used by integration/perf:
- orderer AtomicBroadcast for transaction submission
- peer Deliver for block catch-up and live block streaming
- committer BlockchainInfo and StreamAllTransactions for replay notifications

Use this backend when measuring gateway load generation, replay behavior, SDK submit/notify flow, or local perf-test plumbing without running the full Fabric-X orderer and committer stack. Do not use it for real Fabric-X capacity numbers, consensus behavior, MVCC validation, persistence, policy validation, or committer database behavior.

Also allow TestReplayJSONDataset worker counts to be configured with PERF_PROCESSING_WORKERS and PERF_SUBMITTING_WORKERS, so local replay verification can exercise the same concurrent submit/notify paths as the mock backend smoke runs.

Document the intended workflow and default TLS paths for running the mock from the repository root with integration/fabx.yaml.