### PR TITLE
fix(gateway): map eth_call out-of-gas to -32000 instead of -32603

### DIFF
--- a/common/proposal.go
+++ b/common/proposal.go
@@ -20,6 +20,13 @@ const (
 	ProposalTypeState
 )
 
+const (
+	StatusOK             int32 = 200
+	StatusEVMRevert      int32 = 201
+	StatusEVMExecFailure int32 = 400
+	StatusError          int32 = 500
+)
+
 // StateQuery defines what to query from the ledger state, and at which snapshot.
 type StateQuery struct {
 	Account     common.Address

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -133,9 +133,11 @@ func response(res []byte, err error) *peer.ProposalResponse {
 	if err != nil {
 		// 201 marks an EVM revert: success-range so protoutil cuts a tx, but
 		// distinguishable from 200 so the gateway and committer can tell.
-		status := int32(500)
+		status := common.StatusError
 		if errors.Is(err, vm.ErrExecutionReverted) {
-			status = 201
+			status = common.StatusEVMRevert
+		} else if isEVMExecutionFailure(err) {
+			status = common.StatusEVMExecFailure
 		}
 		return &peer.ProposalResponse{
 			Version: 1,
@@ -150,11 +152,25 @@ func response(res []byte, err error) *peer.ProposalResponse {
 	return &peer.ProposalResponse{
 		Version: 1,
 		Response: &peer.Response{
-			Status:  200,
+			Status:  common.StatusOK,
 			Message: "OK",
 			Payload: res,
 		},
 	}
+}
+
+func isEVMExecutionFailure(err error) bool {
+	if err == nil || errors.Is(err, vm.ErrExecutionReverted) {
+		return false
+	}
+	return errors.Is(err, vm.ErrOutOfGas) ||
+		errors.Is(err, vm.ErrCodeStoreOutOfGas) ||
+		errors.Is(err, vm.ErrMaxCodeSizeExceeded) ||
+		errors.Is(err, vm.ErrInvalidJump) ||
+		errors.Is(err, vm.ErrWriteProtection) ||
+		errors.Is(err, vm.ErrReturnDataOutOfBounds) ||
+		errors.Is(err, vm.ErrGasUintOverflow) ||
+		errors.Is(err, vm.ErrInvalidCode)
 }
 
 // isPreExecutionError checks if an error is a pre-execution validation error

--- a/endorser/endorser_test.go
+++ b/endorser/endorser_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package endorser
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/hyperledger/fabric-x-evm/common"
+)
+
+func TestResponseStatusOK(t *testing.T) {
+	resp := response([]byte{0xde, 0xad}, nil)
+
+	if resp.Response.Status != common.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusOK)
+	}
+}
+
+func TestResponseStatusEVMRevert(t *testing.T) {
+	resp := response(nil, vm.ErrExecutionReverted)
+
+	if resp.Response.Status != common.StatusEVMRevert {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusEVMRevert)
+	}
+}
+
+func TestResponseStatusEVMExecFailure(t *testing.T) {
+	resp := response(nil, vm.ErrOutOfGas)
+
+	if resp.Response.Status != common.StatusEVMExecFailure {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusEVMExecFailure)
+	}
+}
+
+func TestResponseStatusError(t *testing.T) {
+	resp := response(nil, errors.New("backend unavailable"))
+
+	if resp.Response.Status != common.StatusError {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusError)
+	}
+}

--- a/gateway/api/rpcerr/rpcerr.go
+++ b/gateway/api/rpcerr/rpcerr.go
@@ -87,3 +87,8 @@ func ExecutionReverted(reason string, data string) error {
 		Data:    data,
 	}
 }
+
+// ExecutionError returns -32000 for a non-revert EVM execution failure (e.g. out of gas), without data.
+func ExecutionError(msg string) error {
+	return &Error{Code: CodeExecutionReverted, Message: msg}
+}

--- a/gateway/api/rpcerrors.go
+++ b/gateway/api/rpcerrors.go
@@ -27,10 +27,9 @@ func classifyValidationError(err error) error {
 	return rpcerr.TxRejected(err)
 }
 
-// classifyCallError maps a Backend.CallContract error to a typed JSON-RPC
-// error. EVM reverts (*domain.RevertError) surface as -32000 with the raw
-// revert payload as ErrorData (geth eth_call contract); everything else is
-// an unexpected backend failure (-32603).
+// classifyCallError maps a Backend.CallContract error to a typed JSON-RPC error:
+// reverts (*domain.RevertError, with payload) and non-revert execution failures
+// (*domain.ExecutionError) surface as -32000; everything else is -32603.
 func classifyCallError(err error) error {
 	if err == nil {
 		return nil
@@ -38,6 +37,10 @@ func classifyCallError(err error) error {
 	var revert *domain.RevertError
 	if errors.As(err, &revert) {
 		return rpcerr.ExecutionReverted(revert.Reason, hexutil.Encode(revert.Data))
+	}
+	var exec *domain.ExecutionError
+	if errors.As(err, &exec) {
+		return rpcerr.ExecutionError(exec.Message)
 	}
 	return rpcerr.Internal(err)
 }

--- a/gateway/api/rpcerrors_test.go
+++ b/gateway/api/rpcerrors_test.go
@@ -132,3 +132,22 @@ func TestClassifyCallError_NonRevertIsInternal(t *testing.T) {
 		t.Errorf("code = %d, want %d (Internal)", rpcErr.ErrorCode(), rpcerr.CodeInternal)
 	}
 }
+
+func TestClassifyCallError_ExecutionErrorMapsToMinus32000(t *testing.T) {
+	got := classifyCallError(&domain.ExecutionError{Message: "out of gas"})
+
+	var rpcErr rpc.Error
+	if !errors.As(got, &rpcErr) {
+		t.Fatalf("output must satisfy rpc.Error, got %T", got)
+	}
+	if rpcErr.ErrorCode() != rpcerr.CodeExecutionReverted {
+		t.Errorf("code = %d, want %d (-32000)", rpcErr.ErrorCode(), rpcerr.CodeExecutionReverted)
+	}
+	if rpcErr.Error() != "out of gas" {
+		t.Errorf("message = %q, want %q", rpcErr.Error(), "out of gas")
+	}
+	var dataErr rpc.DataError
+	if errors.As(got, &dataErr) {
+		t.Errorf("execution error must not carry revert data")
+	}
+}

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -122,8 +122,11 @@ func (e *EndorsementClient) CallContract(ctx context.Context, args ethereum.Call
 	if err != nil {
 		return nil, fmt.Errorf("process call: %w", err)
 	}
-	if res.Response.Status == 201 {
+	if res.Response.Status == common.StatusEVMRevert {
 		return nil, &domain.RevertError{Reason: res.Response.Message, Data: res.Response.Payload}
+	}
+	if res.Response.Status == common.StatusEVMExecFailure {
+		return nil, &domain.ExecutionError{Message: res.Response.Message}
 	}
 	if res.Response.Status < 200 || res.Response.Status >= 400 {
 		return nil, fmt.Errorf("query response was not successful, error code %d, msg %s", res.Response.Status, res.Response.Message)

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -44,7 +44,7 @@ func TestCallContract_Status201ReturnsRevertError(t *testing.T) {
 	payload := []byte{0x08, 0xc3, 0x79, 0xa0, 0xde, 0xad, 0xbe, 0xef}
 	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
 		Response: &peer.Response{
-			Status:  201,
+			Status:  common.StatusEVMRevert,
 			Message: "execution reverted: out of stock",
 			Payload: payload,
 		},
@@ -69,7 +69,7 @@ func TestCallContract_Status201ReturnsRevertError(t *testing.T) {
 
 func TestCallContract_Status500IsGenericError(t *testing.T) {
 	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
-		Response: &peer.Response{Status: 500, Message: "endorser dead"},
+		Response: &peer.Response{Status: common.StatusError, Message: "endorser dead"},
 	}})
 
 	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
@@ -81,12 +81,32 @@ func TestCallContract_Status500IsGenericError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	var exec *domain.ExecutionError
+	if errors.As(err, &exec) {
+		t.Errorf("backend fault must not be *ExecutionError, got %v", exec)
+	}
+}
+
+func TestCallContract_Status400ReturnsExecutionError(t *testing.T) {
+	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
+		Response: &peer.Response{Status: common.StatusEVMExecFailure, Message: "out of gas"},
+	}})
+
+	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
+
+	var exec *domain.ExecutionError
+	if !errors.As(err, &exec) {
+		t.Fatalf("expected *ExecutionError, got %T (%v)", err, err)
+	}
+	if exec.Message != "out of gas" {
+		t.Errorf("Message = %q, want %q", exec.Message, "out of gas")
+	}
 }
 
 func TestCallContract_Status200ReturnsPayload(t *testing.T) {
 	want := []byte{0xde, 0xad}
 	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
-		Response: &peer.Response{Status: 200, Payload: want},
+		Response: &peer.Response{Status: common.StatusOK, Payload: want},
 	}})
 
 	got, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)

--- a/gateway/domain/errors.go
+++ b/gateway/domain/errors.go
@@ -35,3 +35,12 @@ func (e *RevertError) Error() string {
 func (e *RevertError) Is(target error) bool {
 	return target == ErrExecutionReverted
 }
+
+// ExecutionError carries a non-revert EVM execution failure (e.g. out of gas), mapped to -32000.
+type ExecutionError struct {
+	Message string
+}
+
+func (e *ExecutionError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
## Addressed issue
Closes #208

## Summary
- `CallContract` recognises go-ethereum EVM execution errors (out of gas, code-store OOG, max-code-size, invalid jump, write-protection, ...) and returns a typed `domain.ExecutionError` instead of a generic wrapped error.
- `classifyCallError` maps it to `-32000` (new `rpcerr.ExecutionError`) with a clean message and no revert data, mirroring the existing `domain.RevertError` handling. Detection is anchored to go-ethereum's `vm.Err*` sentinels.
- Out of scope (follow-up): pre-execution gas checks (`intrinsic gas too low` / floor-data-gas) still return `-32603`.

## Validation done
- `make checks` + `make unit-tests` pass; added unit tests for the API mapping and the `CallContract` classification (incl. a generic fault still -> `-32603`).
- End-to-end on a local Fabric-X network: out-of-gas `eth_call` now returns `-32000: out of gas` (was `-32603 ... error code 500`); a normal call still works.
