### PR TITLE
fix(gateway): populate blockTimestamp on eth_getLogs results

### DIFF
--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -478,14 +478,15 @@ func domainLogToTypesLog(l domain.Log) *types.Log {
 	}
 
 	return &types.Log{
-		Address:     common.BytesToAddress(l.Address),
-		Topics:      topics,
-		Data:        l.Data,
-		BlockNumber: l.BlockNumber,
-		BlockHash:   common.BytesToHash(l.BlockHash),
-		TxHash:      common.BytesToHash(l.TxHash),
-		TxIndex:     uint(l.TxIndex),
-		Index:       uint(l.LogIndex),
+		Address:        common.BytesToAddress(l.Address),
+		Topics:         topics,
+		Data:           l.Data,
+		BlockNumber:    l.BlockNumber,
+		BlockHash:      common.BytesToHash(l.BlockHash),
+		BlockTimestamp: uint64(l.Timestamp),
+		TxHash:         common.BytesToHash(l.TxHash),
+		TxIndex:        uint(l.TxIndex),
+		Index:          uint(l.LogIndex),
 	}
 }
 

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -421,3 +421,15 @@ func TestCall_NonRevertBackendErrorIsInternal(t *testing.T) {
 		t.Errorf("code = %d, want -32603 (Internal)", rpcErr.ErrorCode())
 	}
 }
+
+func TestDomainLogToTypesLog_SetsBlockTimestamp(t *testing.T) {
+	got := domainLogToTypesLog(domain.Log{
+		Timestamp: 1234,
+		BlockHash: make([]byte, 32),
+		TxHash:    make([]byte, 32),
+		Address:   make([]byte, 20),
+	})
+	if got.BlockTimestamp != 1234 {
+		t.Errorf("BlockTimestamp = %d, want 1234", got.BlockTimestamp)
+	}
+}

--- a/gateway/domain/models.go
+++ b/gateway/domain/models.go
@@ -68,6 +68,7 @@ type Log struct {
 	Address     []byte
 	Topics      [][]byte
 	Data        []byte
+	Timestamp   int64
 }
 
 // LogFilter contains options for filtering logs.

--- a/gateway/storage/store.go
+++ b/gateway/storage/store.go
@@ -356,19 +356,19 @@ func (s *Store) GetLogs(ctx context.Context, filter domain.LogFilter) ([]domain.
 	var query strings.Builder
 	var args []any
 
-	query.WriteString(`SELECT block_number, block_hash, tx_hash, tx_index, log_index, address, topic0, topic1, topic2, topic3, data FROM logs WHERE 1=1`)
+	query.WriteString(`SELECT l.block_number, l.block_hash, l.tx_hash, l.tx_index, l.log_index, l.address, l.topic0, l.topic1, l.topic2, l.topic3, l.data, b.timestamp FROM logs l JOIN blocks b ON l.block_number = b.block_number WHERE 1=1`)
 
 	// Block filtering: either by hash or by range (mutually exclusive)
 	if filter.BlockHash != nil {
-		query.WriteString(` AND block_number = (SELECT block_number FROM blocks WHERE block_hash = ?)`)
+		query.WriteString(` AND l.block_number = (SELECT block_number FROM blocks WHERE block_hash = ?)`)
 		args = append(args, *filter.BlockHash)
 	} else {
 		if filter.FromBlock != nil {
-			query.WriteString(` AND block_number >= ?`)
+			query.WriteString(` AND l.block_number >= ?`)
 			args = append(args, *filter.FromBlock)
 		}
 		if filter.ToBlock != nil {
-			query.WriteString(` AND block_number <= ?`)
+			query.WriteString(` AND l.block_number <= ?`)
 			args = append(args, *filter.ToBlock)
 		}
 	}
@@ -416,7 +416,7 @@ func (s *Store) GetLogs(ctx context.Context, filter domain.LogFilter) ([]domain.
 		}
 	}
 
-	query.WriteString(` ORDER BY block_number, tx_index, log_index`)
+	query.WriteString(` ORDER BY l.block_number, l.tx_index, l.log_index`)
 
 	rows, err := s.DB.QueryContext(ctx, query.String(), args...)
 	if err != nil {
@@ -427,6 +427,7 @@ func (s *Store) GetLogs(ctx context.Context, filter domain.LogFilter) ([]domain.
 	var logs []domain.Log
 	for rows.Next() {
 		var l Log
+		var timestamp int64
 		if err := rows.Scan(
 			&l.BlockNumber,
 			&l.BlockHash,
@@ -439,10 +440,13 @@ func (s *Store) GetLogs(ctx context.Context, filter domain.LogFilter) ([]domain.
 			&l.Topic2,
 			&l.Topic3,
 			&l.Data,
+			&timestamp,
 		); err != nil {
 			return nil, err
 		}
-		logs = append(logs, toDomainLog(l))
+		dl := toDomainLog(l)
+		dl.Timestamp = timestamp
+		logs = append(logs, dl)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/gateway/storage/store_test.go
+++ b/gateway/storage/store_test.go
@@ -116,6 +116,31 @@ func TestGetLogs_BlockRange(t *testing.T) {
 	}
 }
 
+func TestGetLogs_PopulatesBlockTimestamp(t *testing.T) {
+	store := setupTestDB(t)
+
+	blockHash := make([]byte, 32)
+	blockHash[0] = 1
+	insertTestBlock(t, store, 1, blockHash) // inserts with Timestamp 1000
+
+	txHash := make([]byte, 32)
+	txHash[0] = 1
+	addr := make([]byte, 20)
+	addr[0] = 1
+	insertTestLog(t, store, 1, txHash, addr, 0, nil)
+
+	logs, err := store.GetLogs(t.Context(), domain.LogFilter{})
+	if err != nil {
+		t.Fatalf("GetLogs error: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("got %d logs, want 1", len(logs))
+	}
+	if logs[0].Timestamp != 1000 {
+		t.Errorf("Timestamp = %d, want 1000", logs[0].Timestamp)
+	}
+}
+
 func TestGetLogs_BlockHash(t *testing.T) {
 	store := setupTestDB(t)
 


### PR DESCRIPTION
## Addressed issue
Closes #210

## Summary
- The `blocks` table already stores each block's timestamp, but `GetLogs` never read it. `GetLogs` now joins `logs`↔`blocks` and carries the value on `domain.Log.Timestamp`.
- `domainLogToTypesLog` sets `types.Log.BlockTimestamp` from it, so `eth_getLogs` agrees with `eth_getBlockByNumber`.

## Validation done
- `make checks` + `make unit-tests` pass; added unit tests (storage: `GetLogs` populates the timestamp; api: `domainLogToTypesLog` sets `BlockTimestamp`).
- End-to-end on a local Fabric-X network: a log's `blockTimestamp` now returns the block's real timestamp (`0x6a3c611c`, matching `eth_getBlockByNumber`); was `0x0`.
