### PR TITLE
fix(make): retry namespace setup in start-x to tolerate cold-start delays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,18 +111,26 @@ start-x:
 	@$(COMPOSE) -f compose.fabric-x.yml up -d
 	@echo "Waiting for test committer to be ready..."
 	@while ! nc -z localhost 7001 2>/dev/null; do sleep 1; done
-	@$(DOCKER) run --rm --network $(NETWORK) \
-		--user "$(UID):$(GID)" \
-		--env "FX_NS=$(NS)" \
-		--env "FX_POLICY=$(POLICY)" \
-		-v "$(PWD)/testdata/fxconfig.yaml:/config/fxconfig.yaml:ro,Z" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/peers/fxconfig.org1.example.com/tls:/tls:ro,Z" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/users/channel_admin@org1.example.com/msp:/msp:ro,Z" \
-		-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z" \
-		-v "$(PWD)/testdata/crypto/ordererOrganizations/orderer-org-1/msp/tlscacerts/tlsca.orderer-org-1-cert.pem:/orderer-tls-ca.pem:ro,Z" \
-		$(TOOLS_IMAGE) \
-		sh -c 'fxconfig namespace list --config=/config/fxconfig.yaml 2>/dev/null | grep -q ") $$FX_NS:" || \
-		fxconfig namespace create "$$FX_NS" --policy="$$FX_POLICY" --endorse --submit --wait --config=/config/fxconfig.yaml'
+	@echo "Creating namespace (retrying until the committer is ready)..."
+	@ok=0; for attempt in 1 2 3 4 5; do \
+		if $(DOCKER) run --rm --network $(NETWORK) \
+			--user "$(UID):$(GID)" \
+			--env "FX_NS=$(NS)" \
+			--env "FX_POLICY=$(POLICY)" \
+			-v "$(PWD)/testdata/fxconfig.yaml:/config/fxconfig.yaml:ro,Z" \
+			-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/peers/fxconfig.org1.example.com/tls:/tls:ro,Z" \
+			-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/users/channel_admin@org1.example.com/msp:/msp:ro,Z" \
+			-v "$(PWD)/testdata/crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z" \
+			-v "$(PWD)/testdata/crypto/ordererOrganizations/orderer-org-1/msp/tlscacerts/tlsca.orderer-org-1-cert.pem:/orderer-tls-ca.pem:ro,Z" \
+			$(TOOLS_IMAGE) \
+			sh -c 'fxconfig namespace list --config=/config/fxconfig.yaml 2>/dev/null | grep -q ") $$FX_NS:" || \
+			fxconfig namespace create "$$FX_NS" --policy="$$FX_POLICY" --endorse --submit --wait --config=/config/fxconfig.yaml'; then \
+			ok=1; break; \
+		fi; \
+		echo "namespace setup attempt $$attempt failed; retrying in 3s..."; \
+		sleep 3; \
+	done; \
+	[ "$$ok" = 1 ] || { echo "Error: namespace setup failed after 5 attempts"; exit 1; }
 
 .PHONY: test-x
 test-x:


### PR DESCRIPTION
## Addressed issue
Closes #213

## Summary
- `start-x` gated only on `nc -z localhost 7001`, but Docker publishes that port the moment the container starts — before the committer/orderer pipeline is actually ready. On a cold start the immediate `fxconfig namespace create --wait` could therefore time out (`context deadline exceeded`) and abort startup.
- Wrap the namespace `list-or-create` step in a bounded retry loop (5 attempts, 3s apart). The namespace command itself is unchanged (idempotent `namespace list | grep || namespace create`); the loop just retries on the cold-start timeout and fails loudly (`exit 1`) if all attempts fail, so it never silently succeeds without the namespace.
- No change to the readiness probe or the `start-full` target.

## Validation done
- Makefile-only change; `make -n start-x` parses cleanly and `make checks` passes.
- The namespace list/create invocation (image, env, volumes, flags) is identical to the current target — the change only wraps it in a retry-on-failure loop, leaving the success path unchanged.
- Caveat: the cold-start timeout is timing-dependent and doesn't reproduce reliably on a warm machine, so this is a best-effort robustness change without a before/after reproduction.
