### PR TITLE
simplify endorser error handling

### DIFF
--- a/common/proposal.go
+++ b/common/proposal.go
@@ -21,10 +21,11 @@ const (
 )
 
 const (
-	StatusOK             int32 = 200
-	StatusEVMRevert      int32 = 201
-	StatusEVMExecFailure int32 = 400
-	StatusError          int32 = 500
+	StatusOK          int32 = 200
+	StatusEVMRevert   int32 = 201
+	StatusTxRejected  int32 = 400 // invalid tx, rejected before execution (nonce, funds, intrinsic gas, ...)
+	StatusExecFailure int32 = 460 // valid tx whose EVM execution failed (out of gas, invalid opcode, ...); should be mined (not yet)
+	StatusServerError int32 = 500
 )
 
 // StateQuery defines what to query from the ledger state, and at which snapshot.

--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -83,7 +83,6 @@ func NewEndorser(
 	end, err := endorser.New(
 		endorser.NewEVMEngine(network.Namespace, kvs, evmConfig, monotonicVersions),
 		builder,
-		network.ChainID,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create endorser: %w", err)

--- a/endorser/endorser.go
+++ b/endorser/endorser.go
@@ -11,11 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"regexp"
 
 	"github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
@@ -35,9 +33,8 @@ type PeerConf struct {
 
 // Endorser implements the ProcessProposal API to simulate the execution of ethereum transaction
 type Endorser struct {
-	Engine    EVMEngineInterface // Exported to allow injection of wrappers
-	builder   endorsement.Builder
-	ethSigner types.Signer
+	Engine  EVMEngineInterface // Exported to allow injection of wrappers
+	builder endorsement.Builder
 }
 
 // EVMEngineInterface defines the interface for EVM execution engines.
@@ -56,41 +53,30 @@ type EVMEngineInterface interface {
 // Arguments:
 //   - `engine`:  Manages EVM execution and state reads.
 //   - `builder`: Creates the signed ProposalResponse.
-//   - `chainID`: Ethereum chain ID used to validate transaction signatures.
-func New(engine *EVMEngine, builder endorsement.Builder, chainID int64) (*Endorser, error) {
+func New(engine *EVMEngine, builder endorsement.Builder) (*Endorser, error) {
 	return &Endorser{
-		Engine:    engine,
-		builder:   builder,
-		ethSigner: types.LatestSignerForChainID(big.NewInt(chainID)),
+		Engine:  engine,
+		builder: builder,
 	}, nil
 }
 
 // ProcessEVMTransaction processes an Ethereum transaction and returns a signed proposal response.
-// Reverts are endorsed and submitted (so the receipt records status=0); pre-execution
-// failures (nonce, gas, signer, EIP-3860, etc.) are rejected before any envelope is cut.
+// Reverts are endorsed and submitted (so the receipt records status=0); client-caused failures
+// (invalid tx or failed execution) surface as a non-2xx status that CreateSignedTx won't submit.
 func (f *Endorser) ProcessEVMTransaction(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction) (*peer.ProposalResponse, error) {
-	// Validate the ethereum transaction signature
-	if _, err := types.Sender(f.ethSigner, ethTx); err != nil {
-		return nil, fmt.Errorf("invalid ethereum signature: %w", err)
-	}
-
-	// Execute the transaction
+	// Signature and nonce are validated inside the engine during execution.
 	res, err := f.Engine.Execute(ctx, ethTx)
 	if err != nil {
-		// Distinguish between pre-execution validation errors and execution errors.
-		// Pre-execution errors (from ApplyMessage) indicate the transaction is invalid
-		// and should be rejected. Execution errors (from result.Err) indicate the
-		// transaction executed but failed, and should be included in the response.
-		if isPreExecutionError(err) {
-			// Pre-execution validation error: reject the transaction
-			return nil, err
-		}
-		// Execution error: include in response with error status
 		return response(nil, err), nil
 	}
 
-	// Build and sign the endorsement
-	return f.builder.Endorse(inv, res)
+	// Build and sign the endorsement. A signing failure is a server fault, so it
+	// rides in the response (500) like every other outcome, not as a Go error.
+	resp, err := f.builder.Endorse(inv, res)
+	if err != nil {
+		return response(nil, fmt.Errorf("endorse: %w", err)), nil
+	}
+	return resp, nil
 }
 
 // ProcessCall processes an Ethereum call (query) and returns a proposal response
@@ -131,13 +117,16 @@ func (f *Endorser) ProcessStateQuery(ctx context.Context, query common.StateQuer
 
 func response(res []byte, err error) *peer.ProposalResponse {
 	if err != nil {
-		// 201 marks an EVM revert: success-range so protoutil cuts a tx, but
-		// distinguishable from 200 so the gateway and committer can tell.
-		status := common.StatusError
+		// A revert is a committed outcome; an *execFailure is a valid tx whose EVM
+		// execution failed; a *txRejected is an invalid client tx; anything else is
+		// a server-side fault.
+		status := common.StatusServerError
 		if errors.Is(err, vm.ErrExecutionReverted) {
 			status = common.StatusEVMRevert
-		} else if isEVMExecutionFailure(err) {
-			status = common.StatusEVMExecFailure
+		} else if _, ok := errors.AsType[*execFailure](err); ok {
+			status = common.StatusExecFailure
+		} else if _, ok := errors.AsType[*txRejected](err); ok {
+			status = common.StatusTxRejected
 		}
 		return &peer.ProposalResponse{
 			Version: 1,
@@ -157,67 +146,4 @@ func response(res []byte, err error) *peer.ProposalResponse {
 			Payload: res,
 		},
 	}
-}
-
-func isEVMExecutionFailure(err error) bool {
-	if err == nil || errors.Is(err, vm.ErrExecutionReverted) {
-		return false
-	}
-	return errors.Is(err, vm.ErrOutOfGas) ||
-		errors.Is(err, vm.ErrCodeStoreOutOfGas) ||
-		errors.Is(err, vm.ErrMaxCodeSizeExceeded) ||
-		errors.Is(err, vm.ErrInvalidJump) ||
-		errors.Is(err, vm.ErrWriteProtection) ||
-		errors.Is(err, vm.ErrReturnDataOutOfBounds) ||
-		errors.Is(err, vm.ErrGasUintOverflow) ||
-		errors.Is(err, vm.ErrInvalidCode)
-}
-
-// isPreExecutionError checks if an error is a pre-execution validation error
-// that should reject the transaction, as opposed to an execution error that
-// should be included in the transaction result.
-//
-// According to go-ethereum's ApplyMessage documentation:
-// "An error always indicates a core error meaning that the message would always
-// fail for that particular state and would never be accepted within a block."
-//
-// Pre-execution errors include:
-// - Nonce errors (too low, too high)
-// - Insufficient funds
-// - Gas limit errors
-// - Init code size exceeded (EIP-3860)
-//
-// Execution errors (NOT pre-execution) include:
-// - Out of gas during execution
-// - Execution reverted
-// - Invalid opcode
-func isPreExecutionError(err error) bool {
-	// Check for pre-execution validation errors from core package
-	if errors.Is(err, core.ErrNonceTooLow) ||
-		errors.Is(err, core.ErrNonceTooHigh) ||
-		errors.Is(err, core.ErrNonceMax) ||
-		errors.Is(err, core.ErrGasLimitReached) ||
-		errors.Is(err, core.ErrInsufficientFundsForTransfer) ||
-		errors.Is(err, vm.ErrMaxInitCodeSizeExceeded) ||
-		errors.Is(err, core.ErrInsufficientFunds) ||
-		errors.Is(err, core.ErrGasUintOverflow) ||
-		errors.Is(err, core.ErrIntrinsicGas) ||
-		errors.Is(err, core.ErrTxTypeNotSupported) ||
-		errors.Is(err, core.ErrTipAboveFeeCap) ||
-		errors.Is(err, core.ErrTipVeryHigh) ||
-		errors.Is(err, core.ErrFeeCapVeryHigh) ||
-		errors.Is(err, core.ErrFeeCapTooLow) ||
-		errors.Is(err, core.ErrSenderNoEOA) ||
-		errors.Is(err, core.ErrBlobFeeCapTooLow) ||
-		errors.Is(err, core.ErrMissingBlobHashes) ||
-		errors.Is(err, core.ErrTooManyBlobs) ||
-		errors.Is(err, core.ErrBlobTxCreate) {
-		return true
-	}
-
-	// Check for blob validation errors that are created with fmt.Errorf
-	// Pattern: "blob <number> has invalid hash version"
-	errMsg := err.Error()
-	matched, _ := regexp.MatchString(`^blob \d+ has invalid hash version$`, errMsg)
-	return matched
 }

--- a/endorser/endorser_test.go
+++ b/endorser/endorser_test.go
@@ -7,11 +7,19 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package endorser
 
 import (
+	"context"
 	"errors"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
 )
 
 func TestResponseStatusOK(t *testing.T) {
@@ -30,18 +38,93 @@ func TestResponseStatusEVMRevert(t *testing.T) {
 	}
 }
 
-func TestResponseStatusEVMExecFailure(t *testing.T) {
-	resp := response(nil, vm.ErrOutOfGas)
+func TestResponseStatusExecFailure(t *testing.T) {
+	// A valid tx whose execution failed is tagged *execFailure.
+	resp := response(nil, &execFailure{err: vm.ErrOutOfGas})
 
-	if resp.Response.Status != common.StatusEVMExecFailure {
-		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusEVMExecFailure)
+	if resp.Response.Status != common.StatusExecFailure {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusExecFailure)
 	}
 }
 
-func TestResponseStatusError(t *testing.T) {
+func TestResponseStatusTxRejected(t *testing.T) {
+	// An invalid tx rejected before execution is tagged *txRejected.
+	resp := response(nil, &txRejected{err: core.ErrNonceTooLow})
+
+	if resp.Response.Status != common.StatusTxRejected {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusTxRejected)
+	}
+}
+
+func TestResponseStatusServerError(t *testing.T) {
 	resp := response(nil, errors.New("backend unavailable"))
 
-	if resp.Response.Status != common.StatusError {
-		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusError)
+	if resp.Response.Status != common.StatusServerError {
+		t.Fatalf("status = %d, want %d", resp.Response.Status, common.StatusServerError)
+	}
+}
+
+// stubEngine is an EVMEngineInterface whose Execute returns a fixed error, so we
+// can drive ProcessEVMTransaction's failure classification.
+type stubEngine struct {
+	execErr error
+}
+
+func (s *stubEngine) Execute(context.Context, *types.Transaction) (endorsement.ExecutionResult, error) {
+	return endorsement.ExecutionResult{}, s.execErr
+}
+func (s *stubEngine) Call(ethereum.CallMsg, *big.Int) ([]byte, error) { return nil, nil }
+func (s *stubEngine) BalanceAt(context.Context, ethcommon.Address, *big.Int) (*big.Int, error) {
+	return nil, nil
+}
+func (s *stubEngine) StorageAt(context.Context, ethcommon.Address, ethcommon.Hash, *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubEngine) CodeAt(context.Context, ethcommon.Address, *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubEngine) NonceAt(context.Context, ethcommon.Address, *big.Int) (uint64, error) {
+	return 0, nil
+}
+
+func processEVMTxWithEngineErr(t *testing.T, execErr error) *peer.ProposalResponse {
+	t.Helper()
+
+	// The stub engine ignores the tx, so it need not be signed.
+	f := &Endorser{Engine: &stubEngine{execErr: execErr}}
+	tx := types.NewTx(&types.LegacyTx{Gas: 21000, GasPrice: big.NewInt(0)})
+
+	resp, err := f.ProcessEVMTransaction(context.Background(), endorsement.Invocation{}, tx)
+	if err != nil {
+		t.Fatalf("ProcessEVMTransaction must encode the failure in the response, got Go error: %v", err)
+	}
+	return resp
+}
+
+// A valid tx whose execution failed surfaces as StatusExecFailure (endorsable).
+func TestProcessEVMTransaction_ExecFailure(t *testing.T) {
+	resp := processEVMTxWithEngineErr(t, &execFailure{err: vm.ErrOutOfGas})
+
+	if resp.Response.Status != common.StatusExecFailure {
+		t.Fatalf("status = %d, want %d (StatusExecFailure)", resp.Response.Status, common.StatusExecFailure)
+	}
+}
+
+// An invalid tx surfaces as StatusTxRejected so the caller is told to fix it.
+func TestProcessEVMTransaction_TxRejected(t *testing.T) {
+	resp := processEVMTxWithEngineErr(t, &txRejected{err: core.ErrNonceTooLow})
+
+	if resp.Response.Status != common.StatusTxRejected {
+		t.Fatalf("status = %d, want %d (StatusTxRejected)", resp.Response.Status, common.StatusTxRejected)
+	}
+}
+
+// An untagged error is an infrastructure failure on our side and must surface as
+// StatusServerError (500); CreateSignedTx then refuses to package it.
+func TestProcessEVMTransaction_InfraErrorIs500(t *testing.T) {
+	resp := processEVMTxWithEngineErr(t, errors.New("open snapshot: db unavailable"))
+
+	if resp.Response.Status != common.StatusServerError {
+		t.Fatalf("status = %d, want %d (StatusServerError)", resp.Response.Status, common.StatusServerError)
 	}
 }

--- a/endorser/executor.go
+++ b/endorser/executor.go
@@ -85,10 +85,11 @@ func (e *EVMEngine) Execute(ctx context.Context, tx *types.Transaction) (endorse
 	defer ex.Close()
 
 	ret, err := ex.Send(tx)
-	if err != nil && !errors.Is(err, vm.ErrExecutionReverted) {
-		return endorsement.ExecutionResult{}, err
-	}
-	if errors.Is(err, vm.ErrExecutionReverted) {
+	if err != nil {
+		if !errors.Is(err, vm.ErrExecutionReverted) {
+			return endorsement.ExecutionResult{}, err
+		}
+		// Revert: a committed outcome, endorsed as Status 201 with a revert event.
 		event, mErr := fxcommon.MarshalRevert(ret, "", tx.Hash().Hex())
 		if mErr != nil {
 			return endorsement.ExecutionResult{}, fmt.Errorf("marshal revert event: %w", mErr)
@@ -106,7 +107,7 @@ func (e *EVMEngine) Execute(ctx context.Context, tx *types.Transaction) (endorse
 	if l := ex.state.Logs(); len(l) > 0 {
 		logs, err = json.Marshal(l)
 		if err != nil {
-			return endorsement.ExecutionResult{}, errors.New("error marshaling logs")
+			return endorsement.ExecutionResult{}, fmt.Errorf("marshal logs: %w", err)
 		}
 	}
 
@@ -186,7 +187,13 @@ func (e *EVMEngine) newExecutor(blockNumber *big.Int) (*Executor, error) {
 	if e.evmConfig.DebugLogs {
 		state = NewStateDBLogger(stateDB)
 	}
-	return NewExecutor(state, reader, blockNumber, e.evmConfig)
+
+	ex, err := NewExecutor(state, reader, blockNumber, e.evmConfig)
+	if err != nil {
+		reader.Close()
+		return nil, err
+	}
+	return ex, nil
 }
 
 // newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height (0 = latest).
@@ -274,11 +281,11 @@ func (h *Executor) Close() error {
 	return nil
 }
 
-// CallMsgToMessage converts an ethereum.CallMsg into a core.Message.
+// callMsgToMessage converts an ethereum.CallMsg into a core.Message.
 // The baseFee parameter is used to calculate the effective gas price for EIP-1559 transactions.
 // If baseFee is nil, legacy gas pricing is used.
 // skipNonceCheck and skipTxCheck control whether nonce and EOA checks should be skipped.
-func CallMsgToMessage(msg ethereum.CallMsg, baseFee *big.Int, skipNonceCheck, skipTxCheck bool) *core.Message {
+func callMsgToMessage(msg ethereum.CallMsg, baseFee *big.Int, skipNonceCheck, skipTxCheck bool) *core.Message {
 	var (
 		gasPrice  *big.Int
 		gasFeeCap *big.Int
@@ -356,16 +363,17 @@ func CallMsgToMessage(msg ethereum.CallMsg, baseFee *big.Int, skipNonceCheck, sk
 // Call executes a read-only call (eth_call semantics).
 // An empty revert is treated as a non-error: many Ethereum tools probe contracts this way.
 func (h *Executor) Call(msg ethereum.CallMsg) ([]byte, error) {
-	ret, err := h.Execute(CallMsgToMessage(msg, h.BlockCtx.BaseFee, true, true))
+	ret, err := h.execute(callMsgToMessage(msg, h.BlockCtx.BaseFee, true, true))
 	if errors.Is(err, vm.ErrExecutionReverted) && len(ret) == 0 {
 		return nil, nil // empty revert on a call is not an error
 	}
-	return ret, formatRevert(ret, err)
+	return ret, err
 }
 
-// PrepareMessage validates the sender nonce and converts tx to a core.Message.
-// Exported for use by testimpl wrappers that need to build a message without
-// applying the production free-gas defaults.
+// PrepareMessage is the transaction gate: it recovers the sender (validating the
+// signature), checks the nonce against ledger state, and converts tx to a
+// core.Message. Exported for testimpl wrappers that build a message without the
+// production free-gas defaults.
 func (h *Executor) PrepareMessage(tx *types.Transaction) (*core.Message, error) {
 	signer := types.MakeSigner(h.ChainCfg, h.BlockCtx.BlockNumber, h.BlockCtx.Time)
 
@@ -390,21 +398,19 @@ func (h *Executor) PrepareMessage(tx *types.Transaction) (*core.Message, error) 
 func (h *Executor) Send(tx *types.Transaction) ([]byte, error) {
 	msg, err := h.PrepareMessage(tx)
 	if err != nil {
-		return nil, err
+		// Invalid transaction rejected before execution (bad signature, nonce, ...).
+		return nil, &txRejected{err: err}
 	}
 
-	ret, err := h.Execute(msg)
-	if err != nil {
-		return nil, formatRevert(ret, err)
-	}
-
-	return ret, nil
+	// Return the raw EVM result: on a revert that ret is the revert data (used to
+	// build the revert event); on other faults geth leaves it empty.
+	return h.execute(msg)
 }
 
-// Execute applies production defaults then runs the EVM via ApplyMessage.
+// execute applies production defaults then runs the EVM via ApplyMessage.
 // Gas prices are always zeroed (free gas) so buyGas never requires ETH balance.
 // If MaxTxGas is set, msg.GasLimit is capped before execution.
-func (h *Executor) Execute(msg *core.Message) ([]byte, error) {
+func (h *Executor) execute(msg *core.Message) ([]byte, error) {
 	if msg.GasLimit == 0 {
 		msg.GasLimit = 5_000_000
 	}
@@ -438,30 +444,43 @@ func (h *Executor) ApplyMessage(msg *core.Message) ([]byte, error) {
 	// Use ApplyMessage to execute the transaction
 	result, err := core.ApplyMessage(evm, msg, gp)
 	if err != nil {
-		// Revert to the snapshot on error from ApplyMessage
-		// This mimicks geth's approach and permits tests to pass
+		// Pre-execution rejection: the message can't be applied to this state
+		// (nonce, funds, intrinsic gas, ...) and would never be accepted in a block.
+		// Snapshot revert mirrors geth.
 		h.state.RevertToSnapshot(snapshot)
-		return nil, err
+		return nil, &txRejected{err: err}
 	}
 
-	// Return the result data and any execution error
-	// Note: result.Err contains execution errors (e.g., revert, out of gas, code size exceeded)
-	// These are not fatal errors - the transaction is included but failed
 	if result.Err != nil {
-		return result.ReturnData, result.Err
+		// The transaction is valid but its EVM execution failed. A revert is a
+		// committed outcome carrying a reason; other faults (out of gas, invalid
+		// opcode, ...) are execFailures. Both are distinct from a pre-execution
+		// rejection.
+		if errors.Is(result.Err, vm.ErrExecutionReverted) {
+			if reason, uErr := abi.UnpackRevert(result.ReturnData); uErr == nil {
+				return result.ReturnData, fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
+			}
+			return result.ReturnData, result.Err
+		}
+		return result.ReturnData, &execFailure{err: result.Err}
 	}
 	return result.ReturnData, nil
 }
 
-// formatRevert enriches a revert error with the ABI-decoded reason string.
-// If the data cannot be unpacked, the original error is returned unchanged.
-func formatRevert(ret []byte, err error) error {
-	if !errors.Is(err, vm.ErrExecutionReverted) {
-		return err
-	}
-	reason, errUnpack := abi.UnpackRevert(ret)
-	if errUnpack != nil {
-		return err
-	}
-	return fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
-}
+// txRejected tags an invalid transaction rejected before execution (nonce, funds,
+// intrinsic gas, signature, ...): it can never be included in a block, so the
+// caller sees an error rather than an endorsement.
+type txRejected struct{ err error }
+
+func (e *txRejected) Error() string { return e.err.Error() }
+func (e *txRejected) Unwrap() error { return e.err }
+
+// execFailure tags a valid transaction whose EVM execution faulted (out of gas,
+// invalid opcode, ...) — in Ethereum it is mined with a failed receipt, distinct
+// from a revert (which carries a reason) and from a pre-execution rejection. Both
+// wrap the original go-ethereum error so errors.Is/errors.As still match the
+// underlying value (e.g. vm.ErrOutOfGas).
+type execFailure struct{ err error }
+
+func (e *execFailure) Error() string { return e.err.Error() }
+func (e *execFailure) Unwrap() error { return e.err }

--- a/endorser/executor_test.go
+++ b/endorser/executor_test.go
@@ -76,21 +76,21 @@ func TestExecute_MaxTxGas(t *testing.T) {
 	// MaxTxGas below intrinsic gas (21000 for a simple transfer) → must fail
 	ex := newExecutor(1_000)
 	defer ex.Close()
-	if _, err := ex.Execute(msg()); err == nil {
+	if _, err := ex.execute(msg()); err == nil {
 		t.Fatal("expected error when MaxTxGas < intrinsic gas, got nil")
 	}
 
 	// MaxTxGas at exactly intrinsic gas → simple transfer must succeed
 	ex2 := newExecutor(21_000)
 	defer ex2.Close()
-	if _, err := ex2.Execute(msg()); err != nil {
+	if _, err := ex2.execute(msg()); err != nil {
 		t.Fatalf("expected success when MaxTxGas == intrinsic gas, got: %v", err)
 	}
 
 	// MaxTxGas = 0 (unlimited) → declared gas used as-is, must succeed
 	ex3 := newExecutor(0)
 	defer ex3.Close()
-	if _, err := ex3.Execute(msg()); err != nil {
+	if _, err := ex3.execute(msg()); err != nil {
 		t.Fatalf("expected success when MaxTxGas == 0 (unlimited), got: %v", err)
 	}
 }

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -26,7 +26,10 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
 )
 
-// Endorser interface defines the contract for endorsement providers.
+// Endorser processes proposals into a ProposalResponse whose Status carries the
+// outcome (OK, revert, client error, server error). The error return is reserved
+// for transport/delivery failures — over gRPC it is the call status; the
+// in-process implementation always returns nil and reports faults via the Status.
 // This allows different implementations (e.g., local, gRPC client, mock).
 type Endorser interface {
 	ProcessEVMTransaction(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction) (*peer.ProposalResponse, error)
@@ -81,11 +84,22 @@ func (e EndorsementClient) ExecuteTransaction(ctx context.Context, tx *types.Tra
 		processEndorsement := func(index int, endorser Endorser) {
 			pResp, err := endorser.ProcessEVMTransaction(ctx, inv, tx)
 			if err != nil {
-				errs[index] = fmt.Errorf("process EVM transaction: %w", err)
+				// A Go error is a transport/delivery failure (e.g. gRPC), not a tx outcome.
+				errs[index] = fmt.Errorf("call endorser: %w", err)
 				cancel() // signal other goroutines to stop early
 				return
 			}
-			res[index] = pResp
+			// Application outcomes ride in the status. A success and a revert are
+			// committed; a valid tx whose execution failed is endorsable here but
+			// not yet committed (a follow-up will mine it). An invalid (rejected) tx
+			// or a server fault is an error the caller must see.
+			switch pResp.Response.Status {
+			case common.StatusOK, common.StatusEVMRevert, common.StatusExecFailure:
+				res[index] = pResp
+			default:
+				errs[index] = fmt.Errorf("process EVM transaction: %s", pResp.Response.Message)
+				cancel()
+			}
 		}
 
 		if len(e.endorsers) > 1 {
@@ -125,7 +139,9 @@ func (e *EndorsementClient) CallContract(ctx context.Context, args ethereum.Call
 	if res.Response.Status == common.StatusEVMRevert {
 		return nil, &domain.RevertError{Reason: res.Response.Message, Data: res.Response.Payload}
 	}
-	if res.Response.Status == common.StatusEVMExecFailure {
+	// For a call, both a failed execution and a rejected tx are surfaced as an
+	// execution error (-32000); only the reverted case carries data.
+	if res.Response.Status == common.StatusExecFailure || res.Response.Status == common.StatusTxRejected {
 		return nil, &domain.ExecutionError{Message: res.Response.Message}
 	}
 	if res.Response.Status < 200 || res.Response.Status >= 400 {

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -69,7 +69,7 @@ func TestCallContract_Status201ReturnsRevertError(t *testing.T) {
 
 func TestCallContract_Status500IsGenericError(t *testing.T) {
 	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
-		Response: &peer.Response{Status: common.StatusError, Message: "endorser dead"},
+		Response: &peer.Response{Status: common.StatusServerError, Message: "endorser dead"},
 	}})
 
 	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)
@@ -89,7 +89,7 @@ func TestCallContract_Status500IsGenericError(t *testing.T) {
 
 func TestCallContract_Status400ReturnsExecutionError(t *testing.T) {
 	c := newClient(&stubEndorser{callResp: &peer.ProposalResponse{
-		Response: &peer.Response{Status: common.StatusEVMExecFailure, Message: "out of gas"},
+		Response: &peer.Response{Status: common.StatusExecFailure, Message: "out of gas"},
 	}})
 
 	_, err := c.CallContract(context.Background(), ethereum.CallMsg{}, nil)

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -623,7 +623,6 @@ func NewEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 	end, err := endorser.New(
 		endorser.NewEVMEngine(namespace, db, evmConfig, monotonicVersions),
 		builder,
-		evmConfig.ChainConfig.ChainID.Int64(),
 	)
 	if err != nil {
 		t.Fatalf("endorser.New: %v", err)


### PR DESCRIPTION
- Refactor endorser error handling: the executor tags client-caused failures as *txFailure at the ApplyMessage source, and callers classify on the tag. revert stays a distinct committed outcome, decoded at the source.
- Rename status constants: StatusEVMExecFailure -> StatusClientError, StatusError -> StatusServerError
- Fix reader/snapshot leak in newExecutor, wrap the logs-marshal error, collapse the duplicate revert check in EVMEngine.Execute
- Simplify: single signature+nonce gate (drop the redundant sig check and dead ethSigner/chainID), Send returns the EVM return data, unexport Executor.execute