### PR TITLE
Standalone testnode for Hardhat tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
   quick-tests:
     name: Quick Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,6 +33,9 @@ jobs:
 
       - name: Unit tests
         run: make unit-tests
+
+      - name: Hardhat integration tests
+        run: make hardhat-tests
 
   integration-tests:
     name: Integration Tests
@@ -63,9 +66,6 @@ jobs:
 
       - name: Fabric integration tests
         run: make integration-tests
-
-      - name: Hardhat integration tests
-        run: make hardhat-tests        
 
   optional-tests:
     name: Optional Tests

--- a/cmd/fxevm/main.go
+++ b/cmd/fxevm/main.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -84,37 +83,78 @@ func runStart(ctx context.Context, configPath string) error {
 
 // newTestNodeCmd returns the command to start a test node with test RPC enabled.
 // This is a test-only mode that should NEVER be used in production.
+//
+// With no --config, it's fully self-contained: an in-process fabrictest network,
+// ephemeral identities, embedded test accounts — no file, no docker/Fablo backend.
+// With --config, it behaves as before: test RPC bolted onto a real ordering backend.
 func newTestNodeCmd() *cobra.Command {
 	var configPath string
 	var testAccountsPath string
+	var listen string
+	var chainID int64
+	var protocol string
 
 	cmd := &cobra.Command{
 		Use:   "testnode",
 		Short: "Start a test node with test RPC enabled (UNSAFE - for testing only)",
 		Long: `Start a test node with test RPC methods enabled.
-		
+
 		WARNING: This mode enables server-side transaction signing and other
 		test-only features that are UNSAFE for production use. Only use this
 		for development and testing with Hardhat, OpenZeppelin tests, etc.
-		
+
 		This mode automatically:
 		- Enables test RPC methods (eth_accounts, eth_sendTransaction)
 		- Returns test-friendly gas estimates
-		
+
 		NEVER use this in production environments.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTestNode(cmd.Context(), configPath, testAccountsPath)
+			if configPath == "" {
+				return runSelfContainedTestNode(cmd.Context(), listen, chainID, protocol, testAccountsPath)
+			}
+			return runTestNodeWithConfig(cmd.Context(), configPath, testAccountsPath)
 		},
 	}
 
-	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the YAML configuration file")
-	cmd.Flags().StringVar(&testAccountsPath, "test-accounts-path", filepath.Join("testdata", "test_accounts.json"),
-		"Path to JSON file containing test accounts with private keys")
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to a YAML config for a real ordering backend (omit for a self-contained in-process node)")
+	cmd.Flags().StringVar(&testAccountsPath, "test-accounts-path", "", "Path to JSON file containing test accounts with private keys (default: embedded Hardhat accounts)")
+	cmd.Flags().StringVar(&listen, "listen", ":8545", "HTTP listen address (self-contained mode only)")
+	cmd.Flags().Int64Var(&chainID, "chain-id", 31337, "Ethereum chain ID (self-contained mode only)")
+	cmd.Flags().StringVar(&protocol, "protocol", "fabric-x", "Network protocol: fabric or fabric-x (self-contained mode only)")
 
 	return cmd
 }
 
-func runTestNode(ctx context.Context, configPath, testAccountsPath string) error {
+func printTestNodeWarning() {
+	fmt.Println("========================================")
+	fmt.Println("WARNING: Test node mode enabled")
+	fmt.Println("WARNING: Test RPC methods enabled")
+	fmt.Println("WARNING: Server-side signing is UNSAFE")
+	fmt.Println("WARNING: Using in-memory trie DB")
+	fmt.Println("WARNING: NEVER use in production")
+	fmt.Println("========================================")
+}
+
+// runSelfContainedTestNode starts a testnode with no external dependencies: an
+// in-process fabrictest network, ephemeral local identities, in-memory storage.
+func runSelfContainedTestNode(ctx context.Context, listen string, chainID int64, protocol, testAccountsPath string) error {
+	printTestNodeWarning()
+
+	application, err := app.NewTestNode(ctx, app.TestNodeConfig{
+		Listen:           listen,
+		ChainID:          chainID,
+		Protocol:         protocol,
+		TestAccountsPath: testAccountsPath,
+	})
+	if err != nil {
+		return err
+	}
+	return application.Run(ctx)
+}
+
+// runTestNodeWithConfig starts a testnode against a real ordering backend
+// (Fablo/fabric-x) described by a config file, with test RPC forced on.
+func runTestNodeWithConfig(ctx context.Context, configPath, testAccountsPath string) error {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return err
@@ -125,18 +165,11 @@ func runTestNode(ctx context.Context, configPath, testAccountsPath string) error
 
 	cfg.Gateway.EnableTestRPC = true
 
-	// Override test accounts path if specified
 	if testAccountsPath != "" {
 		cfg.Gateway.TestAccountsPath = testAccountsPath
 	}
 
-	fmt.Println("========================================")
-	fmt.Println("WARNING: Test node mode enabled")
-	fmt.Println("WARNING: Test RPC methods enabled")
-	fmt.Println("WARNING: Server-side signing is UNSAFE")
-	fmt.Println("WARNING: Using in-memory trie DB")
-	fmt.Println("WARNING: NEVER use in production")
-	fmt.Println("========================================")
+	printTestNodeWarning()
 
 	application, err := app.New(ctx, cfg)
 	if err != nil {

--- a/cmd/fxevm/main.go
+++ b/cmd/fxevm/main.go
@@ -122,24 +122,18 @@ func newTestNodeCmd() *cobra.Command {
 	cmd.Flags().Int64Var(&chainID, "chain-id", 31337, "Ethereum chain ID (self-contained mode only)")
 	cmd.Flags().StringVar(&protocol, "protocol", "fabric-x", "Network protocol: fabric or fabric-x (self-contained mode only)")
 
-	return cmd
-}
+	// --listen/--chain-id/--protocol only apply to the self-contained path; reject them
+	// alongside --config instead of silently ignoring them.
+	cmd.MarkFlagsMutuallyExclusive("config", "listen")
+	cmd.MarkFlagsMutuallyExclusive("config", "chain-id")
+	cmd.MarkFlagsMutuallyExclusive("config", "protocol")
 
-func printTestNodeWarning() {
-	fmt.Println("========================================")
-	fmt.Println("WARNING: Test node mode enabled")
-	fmt.Println("WARNING: Test RPC methods enabled")
-	fmt.Println("WARNING: Server-side signing is UNSAFE")
-	fmt.Println("WARNING: Using in-memory trie DB")
-	fmt.Println("WARNING: NEVER use in production")
-	fmt.Println("========================================")
+	return cmd
 }
 
 // runSelfContainedTestNode starts a testnode with no external dependencies: an
 // in-process fabrictest network, ephemeral local identities, in-memory storage.
 func runSelfContainedTestNode(ctx context.Context, listen string, chainID int64, protocol, testAccountsPath string) error {
-	printTestNodeWarning()
-
 	application, err := app.NewTestNode(ctx, app.TestNodeConfig{
 		Listen:           listen,
 		ChainID:          chainID,
@@ -163,15 +157,7 @@ func runTestNodeWithConfig(ctx context.Context, configPath, testAccountsPath str
 		return fmt.Errorf("invalid config %q: %w", configPath, err)
 	}
 
-	cfg.Gateway.EnableTestRPC = true
-
-	if testAccountsPath != "" {
-		cfg.Gateway.TestAccountsPath = testAccountsPath
-	}
-
-	printTestNodeWarning()
-
-	application, err := app.New(ctx, cfg)
+	application, err := app.NewTestNodeWithConfig(ctx, cfg, testAccountsPath)
 	if err != nil {
 		return err
 	}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -49,7 +49,7 @@ type App struct {
 func (a *App) Gateway() *core.Gateway { return a.gateway }
 
 // New creates a new gateway application from the provided configuration.
-// It loads the gateway signer from the MSP directory configured in cfg.
+// It loads the gateway signer from the MSP directory configured in cfg. Test RPC is never enabled.
 func New(ctx context.Context, cfg config.Config) (*App, error) {
 	gwSigner, err := identity.SignerFromMSP(cfg.Gateway.Identity.MSPDir, cfg.Gateway.Identity.MspID)
 	if err != nil {
@@ -61,6 +61,20 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 // NewWithSigner builds the gateway application with the provided signer.
 // Useful for callers that manage identity externally, such as integration tests.
 func NewWithSigner(ctx context.Context, cfg config.Config, gwSigner sdk.Signer) (*App, error) {
+	return newApp(ctx, cfg, gwSigner, false, "")
+}
+
+// NewTestNodeWithConfig builds a gateway against a real ordering backend described by cfg,
+// with test RPC forced on.
+func NewTestNodeWithConfig(ctx context.Context, cfg config.Config, testAccountsPath string) (*App, error) {
+	gwSigner, err := identity.SignerFromMSP(cfg.Gateway.Identity.MSPDir, cfg.Gateway.Identity.MspID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gateway signer: %w", err)
+	}
+	return newApp(ctx, cfg, gwSigner, true, testAccountsPath)
+}
+
+func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableTestRPC bool, testAccountsPath string) (*App, error) {
 	logger := sdk.NewStdLogger("gateway")
 
 	// Create endorsers and their synchronizers.
@@ -69,7 +83,7 @@ func NewWithSigner(ctx context.Context, cfg config.Config, gwSigner sdk.Signer) 
 	var firstKVS estorage.KVS // Keep first endorser's KVS for test server
 	for i, ecfg := range cfg.Endorsers {
 		// Set history size: always 128 for test RPC (snapshot/revert), else default to 2 if not set
-		if cfg.Gateway.EnableTestRPC {
+		if enableTestRPC {
 			ecfg.Database.HistorySize = 128
 		} else if ecfg.Database.HistorySize == 0 {
 			ecfg.Database.HistorySize = 2
@@ -80,7 +94,7 @@ func NewWithSigner(ctx context.Context, cfg config.Config, gwSigner sdk.Signer) 
 			return nil, fmt.Errorf("failed to create signer: %w", err)
 		}
 
-		end, sync, kvs, err := eapp.NewEndorser(ecfg, cfg.Network, eSigner, logger, cfg.Gateway.EnableTestRPC)
+		end, sync, kvs, err := eapp.NewEndorser(ecfg, cfg.Network, eSigner, logger, enableTestRPC)
 		if err != nil {
 			return nil, fmt.Errorf("endorser %d (%s): %w", i, ecfg.Name, err)
 		}
@@ -91,13 +105,12 @@ func NewWithSigner(ctx context.Context, cfg config.Config, gwSigner sdk.Signer) 
 		}
 	}
 
-	return buildApp(ctx, cfg, gwSigner, logger, endorsers, endorserSyncs, firstKVS)
+	return buildApp(ctx, cfg, gwSigner, logger, endorsers, endorserSyncs, firstKVS, enableTestRPC, testAccountsPath)
 }
 
-// buildApp wires up the gateway from pre-built endorsers. Used by NewWithSigner
-// and directly by integration tests that manage their own endorsers.
+// buildApp wires up the gateway from pre-built endorsers.
 // extraHandlers are prepended to the synchronizer handler list, ahead of chain/gateway.
-func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []*network.Synchronizer, lightKVS estorage.KVS, extraHandlers ...blocks.BlockHandler) (*App, error) {
+func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []*network.Synchronizer, lightKVS estorage.KVS, enableTestRPC bool, testAccountsPath string, extraHandlers ...blocks.BlockHandler) (*App, error) {
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
 		orderers[i] = o.ToOrdererConf()
@@ -121,7 +134,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 	}
 
 	// Chain must be called before gateway, to persist blocks before marking transactions complete.
-	handlers := append(append([]blocks.BlockHandler{}, extraHandlers...), chain, gateway)
+	handlers := append(extraHandlers, chain, gateway)
 	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gateway synchronizer: %w", err)
@@ -129,12 +142,12 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 
 	// Create RPC server - use test server if explicitly enabled
 	var rpcServer *rpc.Server
-	if cfg.Gateway.EnableTestRPC {
+	if enableTestRPC {
 		// UNSAFE: Test RPC methods enabled - load test accounts
 		appLogger.Warn("Test RPC methods enabled (eth_accounts, eth_sendTransaction)")
 		appLogger.Warn("Server-side signing is unsafe and should never be used in production")
 
-		testAccountMgr, err := testimpl.LoadTestAccounts(cfg.Gateway.TestAccountsPath)
+		testAccountMgr, err := testimpl.LoadTestAccounts(testAccountsPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load test accounts: %w", err)
 		}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/hyperledger/fabric-x-sdk/identity"
 	"github.com/hyperledger/fabric-x-sdk/network"
 	"golang.org/x/sync/errgroup"
@@ -95,7 +96,8 @@ func NewWithSigner(ctx context.Context, cfg config.Config, gwSigner sdk.Signer) 
 
 // buildApp wires up the gateway from pre-built endorsers. Used by NewWithSigner
 // and directly by integration tests that manage their own endorsers.
-func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []*network.Synchronizer, lightKVS estorage.KVS) (*App, error) {
+// extraHandlers are prepended to the synchronizer handler list, ahead of chain/gateway.
+func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []*network.Synchronizer, lightKVS estorage.KVS, extraHandlers ...blocks.BlockHandler) (*App, error) {
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
 		orderers[i] = o.ToOrdererConf()
@@ -118,9 +120,9 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 		return nil, err
 	}
 
-	// Create synchronizer with both chain and gateway as handlers
-	// Chain must be called first to persist blocks, then gateway to mark transactions complete
-	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, chain, gateway)
+	// Chain must be called before gateway, to persist blocks before marking transactions complete.
+	handlers := append(append([]blocks.BlockHandler{}, extraHandlers...), chain, gateway)
+	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gateway synchronizer: %w", err)
 	}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -48,6 +48,11 @@ type App struct {
 // Gateway returns the inner gateway, e.g. for use in tests.
 func (a *App) Gateway() *core.Gateway { return a.gateway }
 
+// EnsureGenesisBlock inserts an empty block 0 if the chain has no blocks yet.
+func (a *App) EnsureGenesisBlock(ctx context.Context) error {
+	return a.chain.EnsureGenesisBlock(ctx)
+}
+
 // New creates a new gateway application from the provided configuration.
 // It loads the gateway signer from the MSP directory configured in cfg. Test RPC is never enabled.
 func New(ctx context.Context, cfg config.Config) (*App, error) {

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -93,5 +93,12 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 		},
 	}
 
-	return buildApp(ctx, cfg, signer, logger, []eapi.Service{endorser}, nil, endorserKVS, true, tcfg.TestAccountsPath, endorserKVS)
+	application, err := buildApp(ctx, cfg, signer, logger, []eapi.Service{endorser}, nil, endorserKVS, true, tcfg.TestAccountsPath, endorserKVS)
+	if err != nil {
+		return nil, err
+	}
+	if err := application.EnsureGenesisBlock(ctx); err != nil {
+		return nil, fmt.Errorf("failed to create genesis block: %w", err)
+	}
+	return application, nil
 }

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -1,0 +1,99 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/fabrictest"
+
+	"github.com/hyperledger/fabric-x-evm/common"
+	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
+	eapp "github.com/hyperledger/fabric-x-evm/endorser/app"
+	econfig "github.com/hyperledger/fabric-x-evm/endorser/config"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
+	"github.com/hyperledger/fabric-x-evm/gateway/config"
+)
+
+// localSigner is a no-MSP signer: fabrictest doesn't validate real certificates.
+type localSigner struct{}
+
+func (localSigner) Sign(msg []byte) ([]byte, error) { return []byte("signature"), nil }
+func (localSigner) Serialize() ([]byte, error)      { return []byte("serialised identity"), nil }
+
+// TestNodeConfig carries the flags exposed by `fxevm testnode`'s self-contained
+// (no --config) path.
+type TestNodeConfig struct {
+	Listen           string
+	ChainID          int64
+	Protocol         string
+	TestAccountsPath string
+}
+
+const (
+	testNodeChannel   = "mychannel"
+	testNodeNamespace = "basic"
+	testNodeNsVersion = "1.0"
+)
+
+// NewTestNode builds a fully self-contained App: an in-process fabrictest network,
+// ephemeral local identities, in-memory storage, and the test RPC surface enabled —
+// no config file, no generated crypto, no docker/Fablo backend. It replicates the
+// single-synchronizer topology proven by integration/test_helpers.go's local harness:
+// one gateway-level synchronizer feeds the endorser's KVS before chain/gateway, so the
+// test RPC's synchronous eth_sendRawTransaction always has read-your-writes.
+func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
+	logger := sdk.NewStdLogger("testnode")
+	signer := localSigner{}
+
+	protocol := tcfg.Protocol
+	if protocol == "" {
+		protocol = "fabric-x"
+	}
+
+	evmConfig := execution.EVMConfig{
+		ChainConfig: common.BuildChainConfig(tcfg.ChainID),
+	}
+
+	// HistorySize=128 gives evm_snapshot/evm_revert enough history to rewind through.
+	endorserDB := econfig.DB{Database: "memory", HistorySize: 128}
+	endorser, endorserKVS, _, err := eapp.NewEndorserCore(endorserDB, testNodeChannel, testNodeNamespace, protocol, signer, evmConfig, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endorser: %w", err)
+	}
+
+	// db1 makes fabrictest's MVCC validation read the same DB the endorser reads.
+	nw, err := fabrictest.Start(ctx, testNodeNamespace, protocol, fabrictest.Config{}, endorserKVS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start in-process network: %w", err)
+	}
+
+	orderer := &common.Endpoint{Host: "127.0.0.1", Port: nw.OrdererPort}
+	peer := &common.Endpoint{Host: "127.0.0.1", Port: nw.PeerPort}
+
+	cfg := config.Config{
+		Network: common.Network{
+			Protocol:  protocol,
+			Channel:   testNodeChannel,
+			Namespace: testNodeNamespace,
+			NsVersion: testNodeNsVersion,
+			ChainID:   tcfg.ChainID,
+		},
+		Gateway: config.Gateway{
+			Listen:           tcfg.Listen,
+			Database:         config.DB{ConnString: ":memory:"},
+			Orderers:         []common.ClientConfig{{Endpoint: orderer}},
+			Committer:        common.ClientConfig{Endpoint: peer},
+			EnableTestRPC:    true,
+			TestAccountsPath: tcfg.TestAccountsPath,
+		},
+	}
+
+	return buildApp(ctx, cfg, signer, logger, []eapi.Service{endorser}, nil, endorserKVS, endorserKVS)
+}

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/fabrictest"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-evm/common"
 	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
@@ -22,10 +24,14 @@ import (
 )
 
 // localSigner is a no-MSP signer: fabrictest doesn't validate real certificates.
+// Serialize still must produce a real msp.SerializedIdentity — the packager
+// unmarshals it as protobuf, so a plain byte string fails wire-format parsing.
 type localSigner struct{}
 
 func (localSigner) Sign(msg []byte) ([]byte, error) { return []byte("signature"), nil }
-func (localSigner) Serialize() ([]byte, error)      { return []byte("serialised identity"), nil }
+func (localSigner) Serialize() ([]byte, error) {
+	return proto.Marshal(&msp.SerializedIdentity{Mspid: "test-msp", IdBytes: []byte("serialised identity")})
+}
 
 // TestNodeConfig carries the flags exposed by `fxevm testnode`'s self-contained
 // (no --config) path.

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -86,14 +86,12 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 			ChainID:   tcfg.ChainID,
 		},
 		Gateway: config.Gateway{
-			Listen:           tcfg.Listen,
-			Database:         config.DB{ConnString: ":memory:"},
-			Orderers:         []common.ClientConfig{{Endpoint: orderer}},
-			Committer:        common.ClientConfig{Endpoint: peer},
-			EnableTestRPC:    true,
-			TestAccountsPath: tcfg.TestAccountsPath,
+			Listen:    tcfg.Listen,
+			Database:  config.DB{ConnString: ":memory:"},
+			Orderers:  []common.ClientConfig{{Endpoint: orderer}},
+			Committer: common.ClientConfig{Endpoint: peer},
 		},
 	}
 
-	return buildApp(ctx, cfg, signer, logger, []eapi.Service{endorser}, nil, endorserKVS, endorserKVS)
+	return buildApp(ctx, cfg, signer, logger, []eapi.Service{endorser}, nil, endorserKVS, true, tcfg.TestAccountsPath, endorserKVS)
 }

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -68,7 +68,7 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 		return nil, fmt.Errorf("failed to create endorser: %w", err)
 	}
 
-	// db1 makes fabrictest's MVCC validation read the same DB the endorser reads.
+	// endorserKVS makes fabrictest's MVCC validation read the same DB the endorser reads.
 	nw, err := fabrictest.Start(ctx, testNodeNamespace, protocol, fabrictest.Config{}, endorserKVS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start in-process network: %w", err)

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -54,9 +54,6 @@ type Gateway struct {
 
 	SyncTimeout time.Duration `mapstructure:"sync-timeout" yaml:"sync-timeout"`
 
-	TestAccountsPath string `mapstructure:"test-accounts-path" yaml:"test-accounts-path"` // Path to JSON file with test accounts for eth_accounts RPC
-	EnableTestRPC    bool   `mapstructure:"enable-test-rpc"    yaml:"enable-test-rpc"`    // Enable test-only RPC methods (eth_accounts, eth_sendTransaction) - UNSAFE for production
-
 	WorkerCount         int `mapstructure:"worker-count"          yaml:"worker-count"`          // number of worker goroutines; defaults to 1 if not set
 	SubmitterCount      int `mapstructure:"submitter-count"       yaml:"submitter-count"`       // number of batch submitter worker goroutines; defaults to 16 if not set
 	EndorsementChanSize int `mapstructure:"endorsement-chan-size" yaml:"endorsement-chan-size"` // capacity of the endorsement channel; defaults to 1000 if not set

--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -93,6 +93,32 @@ func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 	return nil
 }
 
+// EnsureGenesisBlock inserts an empty block 0 if the store has no blocks yet, so
+// eth_getBlockByNumber("latest") is never null before the first transaction commits.
+// Real Fabric/fabric-x channels always deliver a genesis block already; this is only
+// for backends (like fabrictest) that don't.
+func (c *Chain) EnsureGenesisBlock(ctx context.Context) error {
+	latest, err := c.Store.LatestBlock(ctx, false)
+	if err != nil {
+		return err
+	}
+	if latest != nil {
+		return nil
+	}
+
+	genesisHash := crypto.Keccak256([]byte("fxevm-testnode-genesis"))
+	if err := c.Store.InsertBlock(ctx, domain.Block{
+		BlockNumber: 0,
+		BlockHash:   genesisHash,
+		ParentHash:  make([]byte, common.HashLength),
+		StateRoot:   types.EmptyRootHash[:],
+	}); err != nil {
+		return err
+	}
+	c.prevHash = common.BytesToHash(genesisHash)
+	return nil
+}
+
 // Close releases the trie and database resources.
 func (c *Chain) Close() error {
 	if c.ts != nil {

--- a/gateway/testimpl/accounts.go
+++ b/gateway/testimpl/accounts.go
@@ -11,6 +11,7 @@ package testimpl
 
 import (
 	"crypto/ecdsa"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -19,6 +20,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+//go:embed test_accounts.json
+var embeddedTestAccounts []byte
 
 // TestAccount represents a test account with address and private key
 type TestAccount struct {
@@ -37,21 +41,26 @@ type TestAccountManager struct {
 	PrivateKeys map[common.Address]*ecdsa.PrivateKey
 }
 
-// LoadTestAccounts loads test accounts from a JSON file and pre-converts private keys
+// DefaultTestAccounts returns the embedded default Hardhat test accounts.
+func DefaultTestAccounts() (*TestAccountManager, error) {
+	return parseTestAccounts(embeddedTestAccounts)
+}
+
+// LoadTestAccounts loads test accounts from a JSON file and pre-converts private keys.
+// An empty path returns DefaultTestAccounts().
 func LoadTestAccounts(path string) (*TestAccountManager, error) {
 	if path == "" {
-		// Return empty manager if no path configured
-		return &TestAccountManager{
-			Addresses:   []common.Address{},
-			PrivateKeys: make(map[common.Address]*ecdsa.PrivateKey),
-		}, nil
+		return DefaultTestAccounts()
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read test accounts file: %w", err)
 	}
+	return parseTestAccounts(data)
+}
 
+func parseTestAccounts(data []byte) (*TestAccountManager, error) {
 	var accountsFile TestAccountsFile
 	if err := json.Unmarshal(data, &accountsFile); err != nil {
 		return nil, fmt.Errorf("failed to parse test accounts JSON: %w", err)

--- a/gateway/testimpl/test_accounts.json
+++ b/gateway/testimpl/test_accounts.json
@@ -1,0 +1,48 @@
+{
+  "accounts": [
+    {
+      "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "privateKey": "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+    },
+    {
+      "address": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "privateKey": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    },
+    {
+      "address": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+      "privateKey": "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+    },
+    {
+      "address": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+      "privateKey": "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+    },
+    {
+      "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+      "privateKey": "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
+    },
+    {
+      "address": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+      "privateKey": "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+    },
+    {
+      "address": "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+      "privateKey": "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"
+    },
+    {
+      "address": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+      "privateKey": "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+    },
+    {
+      "address": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+      "privateKey": "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
+    },
+    {
+      "address": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
+      "privateKey": "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+    },
+    {
+      "address": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+      "privateKey": "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897"
+    }
+  ]
+}

--- a/scripts/run_hardhat_test.sh
+++ b/scripts/run_hardhat_test.sh
@@ -4,236 +4,116 @@
 
 set -euo pipefail
 
-# Source shared functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/fabric_test_common.sh"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OZ_DIR="${PROJECT_ROOT}/testdata/openzeppelin-contracts"
+WRAPPER_CONFIG="${PROJECT_ROOT}/testdata/hardhat.wrapper.config.js"
 
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Configuration
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-OZ_DIR="${PROJECT_ROOT}/testdata/openzeppelin-contracts"
-HARDHAT_FABLO_CONFIG="./testdata/fablo/fablo-config.hardhat-test.json"
-GATEWAY_PID=""
-
-# Export FABLO_CONFIG to use hardhat-specific config (single org, single endorsement)
-export FABLO_CONFIG="${HARDHAT_FABLO_CONFIG}"
-
-# Default test path
 TEST_PATH="${1:-test/token/ERC20/ERC20.test.js}"
+TESTNODE_PID=""
 
-# Enhanced cleanup function
 cleanup() {
-    echo -e "\n${YELLOW}Cleaning up...${NC}"
-    
-    # Kill gateway if running
-    if [ -n "${GATEWAY_PID}" ] && kill -0 ${GATEWAY_PID} 2>/dev/null; then
-        echo "Stopping gateway (PID: ${GATEWAY_PID})"
-        kill ${GATEWAY_PID} 2>/dev/null || true
-        wait ${GATEWAY_PID} 2>/dev/null || true
+    if [ -n "${TESTNODE_PID}" ] && kill -0 "${TESTNODE_PID}" 2>/dev/null; then
+        echo -e "\n${YELLOW}Stopping testnode (PID: ${TESTNODE_PID})${NC}"
+        kill "${TESTNODE_PID}" 2>/dev/null || true
+        wait "${TESTNODE_PID}" 2>/dev/null || true
     fi
-    
-    # Clean up triedb to avoid lock issues
-    if [ -d "${PROJECT_ROOT}/testdata/triedb" ]; then
-        echo "Removing triedb directory..."
-        rm -rf "${PROJECT_ROOT}/testdata/triedb"
-    fi
-    
-    # Call shared cleanup for Fabric network
-    cleanup_network
-    
-    echo -e "${GREEN}Cleanup complete${NC}"
 }
-
-# Set up trap for cleanup
 trap cleanup EXIT INT TERM
 
-# Check prerequisites
 check_prerequisites() {
-    echo -e "${YELLOW}Checking prerequisites...${NC}"
-    
-    # Check for required commands
-    for cmd in node npx go docker; do
-        if ! command -v $cmd &> /dev/null; then
+    for cmd in node npx go; do
+        if ! command -v "$cmd" &> /dev/null; then
             echo -e "${RED}Error: $cmd is not installed${NC}"
             exit 1
         fi
     done
-    
-    echo -e "${GREEN}Prerequisites OK${NC}"
 }
 
-# Initialize OpenZeppelin contracts
 init_openzeppelin() {
-    echo -e "${YELLOW}Initializing OpenZeppelin contracts...${NC}"
-    
     if [ ! -d "${OZ_DIR}" ]; then
         echo -e "${RED}Error: OpenZeppelin contracts not found at ${OZ_DIR}${NC}"
         echo "Please initialize the submodule: git submodule update --init --recursive"
         exit 1
     fi
-    
+
     cd "${OZ_DIR}"
-    
-    # Install dependencies if needed
     if [ ! -d "node_modules" ]; then
-        echo "Installing dependencies..."
+        echo -e "${YELLOW}Installing OpenZeppelin dependencies...${NC}"
         npm install
-    else
-        echo "Dependencies already installed"
     fi
-    
-    echo -e "${GREEN}OpenZeppelin contracts ready${NC}"
 }
 
-# Start gateway (fresh instance, similar to integration tests)
-start_gateway() {
-    echo -e "${YELLOW}Starting fabric-evm gateway with test RPC enabled...${NC}"
-    
+start_testnode() {
+    echo -e "${YELLOW}Starting self-contained fxevm testnode...${NC}"
     cd "${PROJECT_ROOT}"
-    
-    # Kill any existing gateway processes on port 8545
-    echo "Checking for existing gateway processes..."
+
     EXISTING_PID=$(lsof -ti :8545 || true)
     if [ -n "${EXISTING_PID}" ]; then
         echo "Killing existing process on port 8545 (PID: ${EXISTING_PID})"
-        kill ${EXISTING_PID} 2>/dev/null || true
+        kill "${EXISTING_PID}" 2>/dev/null || true
         sleep 2
     fi
-    
-    # Clean up any existing triedb to ensure fresh start
-    if [ -d "testdata/triedb" ]; then
-        echo "Removing existing triedb directory..."
-        rm -rf testdata/triedb
-    fi
-    
-    # Start gateway in test node mode with hardhat-specific config
-    echo "Starting test node (logs: /tmp/gateway_$$.log)..."
-    cd integration && go run ../cmd/fxevm testnode --config fablo.hardhat.yaml \
-        --test-accounts-path ../testdata/test_accounts.json \
-        > /tmp/gateway_$$.log 2>&1 &
-    cd ..
 
-    GATEWAY_PID=$!
-    echo "Gateway PID: ${GATEWAY_PID}"
-    
-    # Wait for gateway to be ready and verify test RPC
-    echo "Waiting for gateway to be ready..."
+    echo "Starting testnode (logs: /tmp/testnode_$$.log)..."
+    go run ./cmd/fxevm testnode > "/tmp/testnode_$$.log" 2>&1 &
+    TESTNODE_PID=$!
+
+    echo "Waiting for testnode to be ready..."
     MAX_RETRIES=30
     RETRY_COUNT=0
-    
     while [ ${RETRY_COUNT} -lt ${MAX_RETRIES} ]; do
-        # Test both chainId and accounts to verify test RPC is working
         if curl -s -X POST -H "Content-Type: application/json" \
-            --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
-            http://127.0.0.1:8545 2>/dev/null | grep -q "result" && \
-           curl -s -X POST -H "Content-Type: application/json" \
             --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' \
             http://127.0.0.1:8545 2>/dev/null | grep -q "result"; then
-            echo -e "${GREEN}Gateway is ready with test RPC enabled!${NC}"
-            
-            # Display test account count for verification
-            ACCOUNTS=$(curl -s -X POST -H "Content-Type: application/json" \
-                --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' \
-                http://127.0.0.1:8545 2>/dev/null | grep -o '"0x[^"]*"' | wc -l)
-            echo "Test accounts available: ${ACCOUNTS}"
-            
-            if [ "${ACCOUNTS}" -eq "0" ]; then
-                echo -e "${RED}Warning: No test accounts returned!${NC}"
-            fi
-            
-            # Export gateway URL for Hardhat wrapper config
+            echo -e "${GREEN}Testnode is ready!${NC}"
             export FABRIC_EVM_URL="http://127.0.0.1:8545"
-            echo "Fabric-EVM URL: ${FABRIC_EVM_URL}"
-            
             return 0
         fi
-        
-        # Check if gateway process is still running
-        if ! kill -0 ${GATEWAY_PID} 2>/dev/null; then
-            echo -e "\n${RED}Error: Gateway process died${NC}"
-            echo "Last 50 lines of gateway log:"
-            tail -50 /tmp/gateway_$$.log
+
+        if ! kill -0 "${TESTNODE_PID}" 2>/dev/null; then
+            echo -e "\n${RED}Error: testnode process died${NC}"
+            echo "Last 50 lines of testnode log:"
+            tail -50 "/tmp/testnode_$$.log"
             exit 1
         fi
-        
+
         RETRY_COUNT=$((RETRY_COUNT + 1))
         echo -n "."
         sleep 1
     done
-    
-    echo -e "\n${RED}Error: Gateway failed to start or test RPC not responding${NC}"
-    echo "Last 50 lines of gateway log:"
-    tail -50 /tmp/gateway_$$.log
+
+    echo -e "\n${RED}Error: testnode failed to start${NC}"
+    echo "Last 50 lines of testnode log:"
+    tail -50 "/tmp/testnode_$$.log"
     exit 1
 }
 
-# Run Hardhat tests
 run_tests() {
     echo -e "${YELLOW}Running Hardhat tests...${NC}"
     echo "Test path: ${GREEN}${TEST_PATH}${NC}"
-    
-    # Copy wrapper config into OZ directory for Hardhat to use
-    echo "Copying wrapper config to OpenZeppelin directory..."
-    cp "${PROJECT_ROOT}/testdata/hardhat.wrapper.config.js" "${OZ_DIR}/hardhat.config.fabricevm.js"
-    
-    # Must run from OZ directory for Hardhat to find node_modules
+
     cd "${OZ_DIR}"
-    
-    # Use wrapper config in OZ directory (relative path)
-    echo "Executing: npx hardhat test ${TEST_PATH} --config hardhat.config.fabricevm.js --network fabricevm --bail"
-    npx hardhat test "${TEST_PATH}" --config hardhat.config.fabricevm.js --network fabricevm --bail
+    echo "Executing: npx hardhat test ${TEST_PATH} --config ${WRAPPER_CONFIG} --network fabricevm --bail"
+    npx hardhat test "${TEST_PATH}" --config "${WRAPPER_CONFIG}" --network fabricevm --bail
 }
 
-# Main execution
 main() {
     echo -e "${GREEN}========================================${NC}"
     echo -e "${GREEN}Fabric-EVM Hardhat Integration Test${NC}"
     echo -e "${GREEN}========================================${NC}"
     echo ""
-    
-    # Ensure we're in project root for all operations
-    cd "${PROJECT_ROOT}"
-    
-    # Parse arguments and validate environment
-    check_project_root "run_hardhat_test.sh"
-    ensure_testdata_dir
-    
-    # Clean up any existing network from previous runs
-    echo -e "${YELLOW}Cleaning up any existing Fabric network...${NC}"
-    cd "$FABLO_DIR" 2>/dev/null && ./fablo down 2>/dev/null || true
-    cd - > /dev/null || true
-    
-    # Check prerequisites
-    check_prerequisites
 
-    # Use the hardhat-specific Fablo topology for this script only
-    export FABLO_CONFIG="${HARDHAT_FABLO_CONFIG}"
-    
-    # Initialize OpenZeppelin
-    init_openzeppelin
-    
-    # Start Fabric network (must be in project root)
     cd "${PROJECT_ROOT}"
-    echo -e "${YELLOW}Starting Fabric network...${NC}"
-    start_network_and_deploy_chaincode
-    echo "Waiting for network to fully stabilize..."
-    sleep 10
-    echo -e "${GREEN}Fabric network started${NC}"
-    
-    # Start gateway (fresh instance for this test run)
-    start_gateway
-    
-    # Run tests
+    check_prerequisites
+    init_openzeppelin
+    start_testnode
     run_tests
-    
-    # Cleanup happens automatically via trap
 }
 
-# Run main function
 main

--- a/testdata/hardhat.wrapper.config.js
+++ b/testdata/hardhat.wrapper.config.js
@@ -1,14 +1,23 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Wrapper config for Fabric-EVM integration testing
-// Extends OpenZeppelin's config with fabricevm network
-// This file gets copied into the OpenZeppelin directory at runtime
+// Wrapper config for Fabric-EVM integration testing.
+// Extends OpenZeppelin's own hardhat.config.js with a fabricevm network. Loaded via
+// `--config <path-to-this-file>` with cwd set to the OpenZeppelin checkout, so
+// ozConfig resolves to that checkout's own config without copying this file into it.
 
-const ozConfig = require('./hardhat.config.js');
+const path = require('path');
+const ozConfig = require(path.join(process.cwd(), 'hardhat.config.js'));
 
 module.exports = {
   ...ozConfig,
+
+  // Hardhat defaults paths.root to this file's own directory; since this file lives
+  // outside the OpenZeppelin checkout, pin it back to cwd (the checkout) explicitly.
+  paths: {
+    ...ozConfig.paths,
+    root: process.cwd(),
+  },
 
   networks: {
     ...ozConfig.networks,


### PR DESCRIPTION
This PR makes the testnode fully standalone, requiring no config file or certificates. It does this by embedding the json with the default testaccounts, and using hardcoded config with `fabrictest` as backend. 

The script that runs the OpenZeppelin tests now uses the fxevm testnode instead of a full gateway talking to Fablo. This makes them very fast to run: 7 seconds to start the node *and* run all the ERC-20 tests. Because of that, this PR also enables the Hardhat tests to run in the CI for every PR instead of only when labeled to request the full suite.
