### PR TITLE
Add rate limiter to batch submitter

### DIFF
--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -113,7 +113,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 	}
 
 	// Gateway owns the BatchSubmitter and will handle its lifecycle
-	gateway, err := BuildGateway(ctx, endorsers, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, nil)
+	gateway, err := BuildGateway(ctx, endorsers, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, nil, cfg.Gateway.EndorsementChanSize, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/app/wiring.go
+++ b/gateway/app/wiring.go
@@ -9,6 +9,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
@@ -34,9 +35,9 @@ func NewNetworkSubmitters(ctx context.Context, protocol string, orderers []netwo
 		var err error
 		switch protocol {
 		case "fabric":
-			submitters[i], err = nfab.NewSubmitter(ctx, orderers, gwSigner, 0, logger)
+			submitters[i], err = nfab.NewSubmitter(ctx, orderers, gwSigner, time.Duration(0), logger)
 		case "fabric-x", "":
-			submitters[i], err = nfabx.NewSubmitter(ctx, orderers, gwSigner, 0, logger)
+			submitters[i], err = nfabx.NewSubmitter(ctx, orderers, time.Duration(0), logger)
 		default:
 			return nil, fmt.Errorf("unsupported protocol: %q", protocol)
 		}
@@ -70,14 +71,17 @@ func NewGatewaySynchronizer(protocol string, db network.BlockHeightReader, chann
 // responsible for creating the chain store (so they can register its cleanup independently
 // of the rest of this wiring) and for creating and starting the synchronizer(s) that feed
 // committed blocks to chain/gateway/endorsers.
-func BuildGateway(ctx context.Context, endorsers []eapi.Service, gwSigner sdk.Signer, netCfg common.Network, chain core.Store, submitters []core.Submitter, submitterCount int, workerCount int, txQueue core.TxQueueInterface) (*core.Gateway, error) {
+func BuildGateway(ctx context.Context, endorsers []eapi.Service, gwSigner sdk.Signer, netCfg common.Network, chain core.Store, submitters []core.Submitter, submitterCount int, workerCount int, txQueue core.TxQueueInterface, endorsementChanSize int, txPerSec int) (*core.Gateway, error) {
 	ec, err := core.NewEndorsementClient(endorsers, gwSigner, netCfg.Channel, netCfg.Namespace, netCfg.NsVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endorsement client: %w", err)
 	}
 
-	endorsementChan := make(chan sdk.Endorsement, 1000)
-	batchSubmitter := core.NewBatchSubmitter(submitters, endorsementChan, submitterCount)
+	if endorsementChanSize <= 0 {
+		endorsementChanSize = 1000
+	}
+	endorsementChan := make(chan sdk.Endorsement, endorsementChanSize)
+	batchSubmitter := core.NewBatchSubmitter(submitters, endorsementChan, submitterCount, txPerSec)
 	batchSubmitter.Start(ctx)
 
 	gw, err := core.New(ec, batchSubmitter, chain, netCfg.ChainID, workerCount, txQueue, endorsementChan)

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -57,8 +57,9 @@ type Gateway struct {
 	TestAccountsPath string `mapstructure:"test-accounts-path" yaml:"test-accounts-path"` // Path to JSON file with test accounts for eth_accounts RPC
 	EnableTestRPC    bool   `mapstructure:"enable-test-rpc"    yaml:"enable-test-rpc"`    // Enable test-only RPC methods (eth_accounts, eth_sendTransaction) - UNSAFE for production
 
-	WorkerCount    int `mapstructure:"worker-count"    yaml:"worker-count"`    // number of worker goroutines; defaults to 1 if not set
-	SubmitterCount int `mapstructure:"submitter-count" yaml:"submitter-count"` // number of batch submitter worker goroutines; defaults to 16 if not set
+	WorkerCount         int `mapstructure:"worker-count"          yaml:"worker-count"`          // number of worker goroutines; defaults to 1 if not set
+	SubmitterCount      int `mapstructure:"submitter-count"       yaml:"submitter-count"`       // number of batch submitter worker goroutines; defaults to 16 if not set
+	EndorsementChanSize int `mapstructure:"endorsement-chan-size" yaml:"endorsement-chan-size"` // capacity of the endorsement channel; defaults to 1000 if not set
 }
 
 // DB holds the database paths for the gateway.

--- a/gateway/core/batch_submitter.go
+++ b/gateway/core/batch_submitter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	sdk "github.com/hyperledger/fabric-x-sdk"
+	"golang.org/x/time/rate"
 )
 
 var batchLogger = flogging.MustGetLogger("gateway.core.batch_submitter")
@@ -37,24 +38,29 @@ var SetBatchSubmitterQueueSizeMetric func(size int)
 // originating Ethereum transaction.
 // Multiple worker goroutines read from inputChan and submit in parallel.
 // Each worker has its own submitter instance for better performance.
+// Rate limiting is optionally applied across all workers to ensure aggregate submission rate
+// does not exceed the configured limit.
 type BatchSubmitter struct {
-	submitters []Submitter // One submitter per worker for parallel submission
-	inputChan  chan sdk.Endorsement
-	stopChan   chan struct{}
-	doneChan   chan struct{}
-	numWorkers int
+	submitters  []Submitter // One submitter per worker for parallel submission
+	inputChan   chan sdk.Endorsement
+	stopChan    chan struct{}
+	doneChan    chan struct{}
+	numWorkers  int
+	rateLimiter *rate.Limiter // Shared rate limiter across all workers (nil if disabled)
 }
 
 const DefaultNumWorkers = 16
 
 // NewBatchSubmitter creates a new BatchSubmitter.
-// If cache is non-nil, EthTxBytes are stored per-transaction before submission.
 // numWorkers specifies the number of parallel submission goroutines (default: 16).
 // Creates one submitter instance per worker for optimal parallel performance.
+// txPerSec sets the aggregate submission rate limit across all workers; when zero,
+// rate limiting is disabled.
 func NewBatchSubmitter(
 	submitters []Submitter,
 	inputChan chan sdk.Endorsement,
 	numWorkers int,
+	txPerSec int,
 ) *BatchSubmitter {
 	if numWorkers <= 0 {
 		numWorkers = DefaultNumWorkers
@@ -65,12 +71,19 @@ func NewBatchSubmitter(
 		panic(fmt.Sprintf("Only %d submitters provided for %d workers.", len(submitters), numWorkers))
 	}
 
+	var rateLimiter *rate.Limiter
+	if txPerSec > 0 {
+		rateLimiter = rate.NewLimiter(rate.Limit(txPerSec), txPerSec)
+		batchLogger.Infof("Rate limiting enabled: %d tx/s", txPerSec)
+	}
+
 	return &BatchSubmitter{
-		submitters: submitters,
-		inputChan:  inputChan,
-		stopChan:   make(chan struct{}),
-		doneChan:   make(chan struct{}),
-		numWorkers: numWorkers,
+		submitters:  submitters,
+		inputChan:   inputChan,
+		stopChan:    make(chan struct{}),
+		doneChan:    make(chan struct{}),
+		numWorkers:  numWorkers,
+		rateLimiter: rateLimiter,
 	}
 }
 
@@ -142,6 +155,13 @@ func (bs *BatchSubmitter) worker(ctx context.Context, workerID int, wg *sync.Wai
 }
 
 func (bs *BatchSubmitter) submitOne(ctx context.Context, workerID int, end sdk.Endorsement) error {
+	// Wait for rate limiter to allow this submission (if enabled)
+	if bs.rateLimiter != nil {
+		if err := bs.rateLimiter.Wait(ctx); err != nil {
+			return fmt.Errorf("rate limiter wait failed: %w", err)
+		}
+	}
+
 	var txid string
 	t0 := time.Now()
 	err := bs.submitters[workerID].Submit(ctx, end)

--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,13 @@ require (
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260607181445-fc4b05c5d38f
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
 	github.com/hyperledger/fabric-x-common v0.2.6
-	github.com/hyperledger/fabric-x-sdk v0.0.0-20260616145749-cbf8346ea95b
+	github.com/hyperledger/fabric-x-sdk v0.0.0-20260708130638-9e7b178c2405
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.50.1
@@ -161,7 +162,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260511170946-3700d4141b60 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/hyperledger/fabric-x-committer v1.0.3 h1:mHcSuhI4d114fVvZdA91TkCgGn10
 github.com/hyperledger/fabric-x-committer v1.0.3/go.mod h1:KGaflXpltyIh4qgeY1xUpuY9H+b5W/HVvdZAGXW55KY=
 github.com/hyperledger/fabric-x-common v0.2.6 h1:nmrWvLC9oM91Xff1s5ae0hjWjX7fnAW4p3GLD/wkXZY=
 github.com/hyperledger/fabric-x-common v0.2.6/go.mod h1:xkAVXn2qEb/JMFOI8MrCMJC+rg0u8ip4tZz/2cAEXAk=
-github.com/hyperledger/fabric-x-sdk v0.0.0-20260616145749-cbf8346ea95b h1:2jMmVUipMUMCVGnuiEtvZ8KLJDZ0O0YGIL42dz3KfrU=
-github.com/hyperledger/fabric-x-sdk v0.0.0-20260616145749-cbf8346ea95b/go.mod h1:dMjMiWAJTlATFY/DQdzdyFj2qOZIkuoBcr0LONC9CnM=
+github.com/hyperledger/fabric-x-sdk v0.0.0-20260708130638-9e7b178c2405 h1:oyCHrb7F6jE1/82fwMQOcJE1WuwipdOXG3JmCX/zzA4=
+github.com/hyperledger/fabric-x-sdk v0.0.0-20260708130638-9e7b178c2405/go.mod h1:dMjMiWAJTlATFY/DQdzdyFj2qOZIkuoBcr0LONC9CnM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -28,7 +28,7 @@ import (
 	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/hyperledger/fabric-x-sdk/endorsement"
-	"github.com/hyperledger/fabric-x-sdk/network"
+	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
 )
 
 type KVSSnapshotter interface {
@@ -232,11 +232,10 @@ func (sp *StatePrimer) Commit(ctx context.Context, wait bool) error {
 	}
 
 	// Create a proposal for the priming transaction
-	prop, err := network.NewSignedProposal(
+	prop, err := nfab.NewSignedProposal(
 		sp.signer,
 		sp.channel,
 		sp.namespace,
-		sp.nsVersion,
 		[][]byte{{byte(lc.ProposalTypeEVMTx)}, ethTxBytes},
 	)
 	if err != nil {

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -344,7 +344,7 @@ func (sp *StatePrimer) commitAndWait(end sdk.Endorsement, tx *types.Transaction,
 	}
 
 	if wait {
-		waitForCommit(context.Background(), ec, tx)
+		return waitForCommit(context.Background(), ec, tx)
 	}
 
 	return nil

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-evm/common"
@@ -51,6 +52,7 @@ import (
 	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
 	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
 	"github.com/hyperledger/fabric-x-sdk/notification"
+	"google.golang.org/protobuf/proto"
 )
 
 // GetERC20BalanceSlot computes the storage slot for a balance in an ERC-20 mapping(address => uint256).
@@ -71,7 +73,7 @@ func (localSigner) Sign(msg []byte) ([]byte, error) {
 }
 
 func (localSigner) Serialize() ([]byte, error) {
-	return []byte("serialised identity"), nil
+	return proto.Marshal(&msp.SerializedIdentity{Mspid: "test-msp", IdBytes: []byte("serialised identity")})
 }
 
 // NewStatePrimer returns a reset StatePrimer ready for a new batch of state operations.
@@ -765,6 +767,9 @@ func waitForCommitT(t *testing.T, ec *ethclient.Client, tx *types.Transaction) {
 }
 
 func waitForCommit(ctx context.Context, ec *ethclient.Client, tx *types.Transaction) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	var err error
 
 	backoff := time.Duration(0)
@@ -775,7 +780,7 @@ func waitForCommit(ctx context.Context, ec *ethclient.Client, tx *types.Transact
 		_, pending, err = ec.TransactionByHash(ctx, tx.Hash())
 		if err != nil {
 			if !strings.Contains(err.Error(), "not found") {
-				return err
+				return fmt.Errorf("waiting for tx %s to commit: %w", tx.Hash(), err)
 			}
 			pending = true
 		}

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -184,7 +184,12 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 
 	// Create gateway before synchronizer so we can register it as a handler
 	// Gateway owns the BatchSubmitter and will handle its lifecycle
-	gw, err := app.BuildGateway(t.Context(), ends, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, txQueue)
+	// Enable rate limiting only for "synthetic" namespace (10 000 tx/s)
+	txPerSec := 0
+	if cfg.Network.Namespace == "synthetic" {
+		txPerSec = 10000
+	}
+	gw, err := app.BuildGateway(t.Context(), ends, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, txQueue, cfg.Gateway.EndorsementChanSize, txPerSec)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/testdata/shared_config.yaml
+++ b/testdata/shared_config.yaml
@@ -132,12 +132,12 @@ Consensus:
 
 Batching:
   BatchTimeouts:
-    BatchCreationTimeout: 20ms
+    BatchCreationTimeout: 10ms
     FirstStrikeThreshold: 10s
     SecondStrikeThreshold: 10s
     AutoRemoveTimeout: 10s
   BatchSize:
-    MaxMessageCount: 1000
+    MaxMessageCount: 10000
     AbsoluteMaxBytes: 10485760
     PreferredMaxBytes: 2097152
   RequestMaxBytes: 1048576


### PR DESCRIPTION
Introduce an optional per-second rate limit on transaction submission, shared across all BatchSubmitter workers. Wire a configurable endorsement channel size through BuildGateway so both the production path and test harness respect it. Bump fabric-x-sdk to pick up the nfabx.NewSubmitter signature change and promote golang.org/x/time to a direct dependency.