### PR TITLE
Baseline: a diff tool to measure our progress and regressions in compatibilty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ testdata/*
 !testdata/ethereum-tests
 !testdata/openzeppelin-contracts
 !testdata/hardhat.wrapper.config.js
+!testdata/mocha-spec-and-json-reporter.js
 !testdata/configtx.yaml
 !testdata/crypto-config.yaml
 !testdata/fxconfig.yaml

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -29,10 +29,14 @@ Currently supports Mocha's JSON reporter (`--format mocha-json`, the default).
 
 ```shell
 cd testdata/openzeppelin-contracts
-HARDHAT_REPORTER=json npx hardhat test test/token/ERC20/ERC20.test.js \
-  --config ../hardhat.wrapper.config.js --network fabricevm \
-  > /tmp/oz-results.json
+HARDHAT_JSON_OUTPUT=/tmp/oz-results.json npx hardhat test test/token/ERC20/ERC20.test.js \
+  --config ../hardhat.wrapper.config.js --network fabricevm
 ```
+
+`HARDHAT_JSON_OUTPUT` switches to the combined reporter
+([`testdata/mocha-spec-and-json-reporter.js`](../../testdata/mocha-spec-and-json-reporter.js)):
+the usual pass/fail console view still prints live, and the JSON lands at the given path —
+one run gives both, instead of picking one or the other.
 
 ## Check (the CI gate)
 
@@ -58,7 +62,7 @@ nothing is listed yet):
 $ go run ./cmd/baseline check --suite oz-hardhat --baseline /tmp/empty.json --results /tmp/permit-results.json
 # Baseline check: oz-hardhat
 
-2 passed, 4 failed, 0 skipped (6 total)
+2 passed, 4 failed, 0 skipped (6 total, 33.3% passing)
 
 ## Regressions (4)
 
@@ -72,21 +76,27 @@ $ echo $?
 ```
 
 Same run again after the baseline is seeded (see `update` below) — clean, with the histogram
-grouping the four by their shared cause:
+grouping the four by their shared, auto-tagged cause (see `inferCause` in `baseline.go`: a message
+naming its own missing RPC method, or matching one of our own known constants, gets tagged without a
+human needing to look):
 
 ```
 $ go run ./cmd/baseline check --suite oz-hardhat --baseline testdata/oz_known_failures.json --results /tmp/permit-results.json
 # Baseline check: oz-hardhat
 
-2 passed, 4 failed, 0 skipped (6 total)
+2 passed, 4 failed, 0 skipped (6 total, 33.3% passing)
 
 ## Expected failures by cause (4)
 
-- the method eth_signTypedData_v4 does not exist/is not available: 4
+- eth_signTypedData_v4: 4
 
 $ echo $?
 0
 ```
+
+A run spanning multiple suites (multiple `--results` files, or one glob matching several) adds a
+`## By suite` breakdown, sorted worst-first, so you can see at a glance where compatibility still
+needs the most work — and watch that shrink over time as fixes land.
 
 ## Update (seed or reconcile the baseline)
 
@@ -97,9 +107,10 @@ go run ./cmd/baseline update \
   --results /tmp/oz-results.json
 ```
 
-Rewrites the baseline file: drops stale entries, adds a blank-`cause` entry for every new failure.
-Safe to run any time — for the initial seed, or after a dependency bump shifts what fails. No
-hand-curation needed to land it; tag `cause` on entries later, opportunistically.
+Rewrites the baseline file: drops stale entries, adds an entry for every new failure — auto-tagging
+`cause` for the high-confidence signatures `inferCause` recognizes, leaving the rest blank for a
+human to tag opportunistically (or bulk-tag with `tag`, below). Safe to run any time — for the
+initial seed, or after a dependency bump shifts what fails. No hand-curation needed to land it.
 
 ```
 $ go run ./cmd/baseline update --suite oz-hardhat --baseline testdata/oz_known_failures.json --results /tmp/permit-results.json
@@ -108,16 +119,37 @@ testdata/oz_known_failures.json: 0 entries removed, 4 entries added, 4 total now
 $ cat testdata/oz_known_failures.json
 [
   {
-    "id": "ERC20Permit permit accepts owner signature"
+    "id": "ERC20Permit permit accepts owner signature",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Permit permit rejects expired permit"
+    "id": "ERC20Permit permit rejects expired permit",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Permit permit rejects other signature"
+    "id": "ERC20Permit permit rejects other signature",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Permit permit rejects reused signature"
+    "id": "ERC20Permit permit rejects reused signature",
+    "cause": "eth_signTypedData_v4"
   }
 ]
 ```
+
+## Tag (bulk-assign a cause)
+
+```shell
+go run ./cmd/baseline tag \
+  --baseline testdata/oz_known_failures.json \
+  --results '/tmp/oz-hardhat-results/*.json' \
+  --match "Packing" \
+  --cause "max-code-size"
+```
+
+Sets `cause` (and optionally `--note`) on every still-failing entry whose ID or current message
+contains `--match` — for a symptom that's too broad or too varied in wording for `inferCause` to
+recognize automatically, but that a human can look at once and confidently label in bulk (e.g. a
+whole describe block, or a message fragment shared across many tests). Entries that already have a
+cause are left alone unless `--force` is passed — a broad match shouldn't silently overwrite a more
+specific tag an earlier, more targeted pass already got right.

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -43,7 +43,7 @@ reconcile:
 
 One thing this tool *can't* see: whether the compatible-set **exclusions** themselves are still right
 (new test directories, files that now need the `hardhat-predeploy` plugin, etc.) — that's decided in
-`scripts/run_hardhat_test.sh` / `docs/OZ_COMPAT.md`, not here.
+`scripts/run_hardhat_test.sh`, not here.
 
 ## Generate results
 

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -1,0 +1,123 @@
+# cmd/baseline
+
+Diffs a compatibility suite's results against a checked-in list of known failures, so CI can gate on
+*new* regressions instead of the whole suite passing.
+
+## Why
+
+The OpenZeppelin Hardhat suite (`testdata/openzeppelin-contracts`, run via `fxevm testnode`) is cheap
+enough to run on every PR, but not every test in it passes today, and some never will because of
+design choices. Without a record of which specific tests are expected to fail, a CI gate on the full
+suite either stays permanently red or has no teeth at all.
+
+We're already skipping known-failing tests via hardcoded lists `testdata/eth_tests.skip`/`.slow`,
+with flat file-path lists checked directly in
+[`integration/ethereum_test.go`](../../integration/ethereum_test.go) - inspired by `go-ethereum`.
+`cmd/baseline` generalizes that same idiom to per-test granularity (not whole files) with an actual
+diff: new unlisted failure → regression; listed test that now passes → stale entry, remove it —
+instead of a list someone has to remember to prune by hand. It makes the approach consistent and
+measurable.
+
+**Currently wired up for OpenZeppelin only, not yet used anywhere in CI.** The `--format` flag
+exists so a `go test -json` adapter can be added later for `TestEthereumTests`, replacing
+`eth_tests.skip`/`.slow` with the same mechanism at per-subtest granularity — not built yet, but the
+reason the result model and CLI are format-agnostic rather than Mocha-specific.
+
+## Generate results
+
+Currently supports Mocha's JSON reporter (`--format mocha-json`, the default).
+
+```shell
+cd testdata/openzeppelin-contracts
+HARDHAT_REPORTER=json npx hardhat test test/token/ERC20/ERC20.test.js \
+  --config ../hardhat.wrapper.config.js --network fabricevm \
+  > /tmp/oz-results.json
+```
+
+## Check (the CI gate)
+
+```shell
+go run ./cmd/baseline check \
+  --suite oz-hardhat \
+  --baseline testdata/oz_known_failures.json \
+  --results /tmp/oz-results.json
+```
+
+Prints a summary and exits non-zero if anything regressed:
+- a failure that isn't in the baseline (a real regression), or
+- a baseline entry that's no longer failing (stale — remove it).
+
+`--results` accepts a glob (`--results '/tmp/oz-results/*.json'`) to merge several files — useful
+since a Mocha file that crashes at load time can zero out the whole report for that invocation, so
+running per-file/per-directory and merging is safer than one giant run.
+
+Sample output, an empty baseline against a real run of `ERC20Permit.test.js` (regressions, since
+nothing is listed yet):
+
+```
+$ go run ./cmd/baseline check --suite oz-hardhat --baseline /tmp/empty.json --results /tmp/permit-results.json
+# Baseline check: oz-hardhat
+
+2 passed, 4 failed, 0 skipped (6 total)
+
+## Regressions (4)
+
+- `ERC20Permit permit accepts owner signature`: the method eth_signTypedData_v4 does not exist/is not available
+- `ERC20Permit permit rejects reused signature`: the method eth_signTypedData_v4 does not exist/is not available
+- `ERC20Permit permit rejects other signature`: the method eth_signTypedData_v4 does not exist/is not available
+- `ERC20Permit permit rejects expired permit`: the method eth_signTypedData_v4 does not exist/is not available
+
+$ echo $?
+1
+```
+
+Same run again after the baseline is seeded (see `update` below) — clean, with the histogram
+grouping the four by their shared cause:
+
+```
+$ go run ./cmd/baseline check --suite oz-hardhat --baseline testdata/oz_known_failures.json --results /tmp/permit-results.json
+# Baseline check: oz-hardhat
+
+2 passed, 4 failed, 0 skipped (6 total)
+
+## Expected failures by cause (4)
+
+- the method eth_signTypedData_v4 does not exist/is not available: 4
+
+$ echo $?
+0
+```
+
+## Update (seed or reconcile the baseline)
+
+```shell
+go run ./cmd/baseline update \
+  --suite oz-hardhat \
+  --baseline testdata/oz_known_failures.json \
+  --results /tmp/oz-results.json
+```
+
+Rewrites the baseline file: drops stale entries, adds a blank-`cause` entry for every new failure.
+Safe to run any time — for the initial seed, or after a dependency bump shifts what fails. No
+hand-curation needed to land it; tag `cause` on entries later, opportunistically.
+
+```
+$ go run ./cmd/baseline update --suite oz-hardhat --baseline testdata/oz_known_failures.json --results /tmp/permit-results.json
+testdata/oz_known_failures.json: 0 entries removed, 4 entries added, 4 total now
+
+$ cat testdata/oz_known_failures.json
+[
+  {
+    "id": "ERC20Permit permit accepts owner signature"
+  },
+  {
+    "id": "ERC20Permit permit rejects expired permit"
+  },
+  {
+    "id": "ERC20Permit permit rejects other signature"
+  },
+  {
+    "id": "ERC20Permit permit rejects reused signature"
+  }
+]
+```

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -23,6 +23,28 @@ exists so a `go test -json` adapter can be added later for `TestEthereumTests`, 
 `eth_tests.skip`/`.slow` with the same mechanism at per-subtest granularity — not built yet, but the
 reason the result model and CLI are format-agnostic rather than Mocha-specific.
 
+## After bumping `testdata/openzeppelin-contracts`
+
+Not a special case — the same loop as any other run, just with more worth actually reading before you
+reconcile:
+
+1. **Regenerate results** against the new submodule commit — see [Generate results](#generate-results).
+2. **`check` first, before `update`.** Don't skip straight to reconciling:
+   - **Regressions** — failing tests not yet in the baseline. Could be a genuine new incompatibility,
+     or just upstream renaming/rewording an already-known-failing test under a new ID. Worth a skim,
+     especially if the count is large or unexpected.
+   - **Stale entries** — baseline entries no longer failing. Either the underlying issue got fixed for
+     real, or upstream renamed/removed the test. Either way, safe to drop.
+3. **`update`** to reconcile: drops the stale entries, adds the regressions (auto-tagged where the
+   message matches a known signature, blank otherwise).
+4. If the bump introduced a fresh batch of an already-understood symptom (e.g. more tests hitting an
+   RPC method we haven't implemented), bulk-tag them with `tag` instead of hand-editing dozens of
+   entries.
+
+One thing this tool *can't* see: whether the compatible-set **exclusions** themselves are still right
+(new test directories, files that now need the `hardhat-predeploy` plugin, etc.) — that's decided in
+`scripts/run_hardhat_test.sh` / `docs/OZ_COMPAT.md`, not here.
+
 ## Generate results
 
 Currently supports Mocha's JSON reporter (`--format mocha-json`, the default).

--- a/cmd/baseline/baseline.go
+++ b/cmd/baseline/baseline.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
+	"strings"
 )
 
 // Status is the outcome of a single test, normalized across runner formats.
@@ -25,16 +27,19 @@ const (
 
 // Result is one test's outcome, normalized from whatever runner produced it.
 // ID is the runner's own full test name, used verbatim (Mocha's fullTitle,
-// or go test's hierarchical subtest name) — never reformatted.
+// or go test's hierarchical subtest name) — never reformatted. File is the
+// source file the runner attributes the test to, if it reports one; used only
+// to group the report by suite, never persisted to a baseline Entry.
 type Result struct {
 	ID      string
 	Status  Status
 	Message string
+	File    string
 }
 
 // Entry is one checked-in baseline record: a test expected to fail today.
 // Cause and Note are optional human annotations, filled in opportunistically —
-// never required for an entry to be valid (see BASELINE_PLAN.md's "Two workflows").
+// never required for an entry to be valid.
 type Entry struct {
 	ID    string `json:"id"`
 	Cause string `json:"cause,omitempty"`
@@ -57,7 +62,7 @@ type DiffResult struct {
 
 // Regressed reports whether the diff should fail CI: any regression, or any stale
 // entry (a listed test that no longer fails is exactly as much "baseline doesn't
-// match reality" as a new failure — see BASELINE_PLAN.md's diff semantics).
+// match reality" as a new failure).
 func (d DiffResult) Regressed() bool {
 	return len(d.Regressions) > 0 || len(d.Stale) > 0
 }
@@ -67,6 +72,7 @@ func (d DiffResult) Regressed() bool {
 // shape; err is an empty object for a pass, or has Message set for a failure.
 type mochaTest struct {
 	FullTitle string   `json:"fullTitle"`
+	File      string   `json:"file"`
 	Err       mochaErr `json:"err"`
 }
 
@@ -102,7 +108,7 @@ func ParseMochaJSON(data []byte) ([]Result, error) {
 	seen := make(map[string]bool, len(report.Tests))
 	for _, t := range report.Tests {
 		seen[t.FullTitle] = true
-		r := Result{ID: t.FullTitle}
+		r := Result{ID: t.FullTitle, File: t.File}
 		switch {
 		case pending[t.FullTitle]:
 			r.Status = StatusSkip
@@ -122,7 +128,7 @@ func ParseMochaJSON(data []byte) ([]Result, error) {
 		if seen[f.FullTitle] {
 			continue
 		}
-		results = append(results, Result{ID: f.FullTitle, Status: StatusFail, Message: f.Err.Message})
+		results = append(results, Result{ID: f.FullTitle, Status: StatusFail, Message: f.Err.Message, File: f.File})
 	}
 	return results, nil
 }
@@ -163,8 +169,11 @@ func SaveBaseline(path string, entries []Entry) error {
 	return nil
 }
 
-// Diff compares current results against a baseline. See BASELINE_PLAN.md's "Diff
-// semantics" for the 4-way matrix this implements.
+// Diff compares current results against a baseline: failing-and-listed is
+// expected (the normal case), failing-and-unlisted is a regression, and
+// listed-but-not-failing (including a listed ID that no longer appears in
+// results at all — renamed or removed upstream) is stale and should be
+// removed from the baseline.
 func Diff(results []Result, baseline []Entry) DiffResult {
 	byID := make(map[string]Entry, len(baseline))
 	for _, e := range baseline {
@@ -198,30 +207,139 @@ func Diff(results []Result, baseline []Entry) DiffResult {
 	return out
 }
 
-// Reconcile computes the updated baseline for `update`: drop stale entries, add a
-// blank-cause entry for every regression. Existing entries (including their cause/
-// note tags) are left untouched.
+// causeSignature is a high-confidence, mechanical rule for deriving a cause from
+// a failure message: the message names its own cause (a missing RPC method) —
+// never a guess at what a generic assertion diff is actually about. Order
+// matters: first match wins.
+var causeSignatures = []struct {
+	pattern *regexp.Regexp
+	cause   func(match []string) string
+}{
+	{
+		pattern: regexp.MustCompile(`^the method (\S+) does not exist/is not available$`),
+		cause:   func(m []string) string { return m[1] },
+	},
+	{
+		pattern: regexp.MustCompile(`^insufficient funds for gas \* price \+ value`),
+		cause:   func(m []string) string { return "insufficient-funds" },
+	},
+}
+
+// inferCause returns the cause tag for a message matching a known signature
+// above, or "" if none match — left for a human to tag opportunistically.
+func inferCause(message string) string {
+	for _, sig := range causeSignatures {
+		if m := sig.pattern.FindStringSubmatch(message); m != nil {
+			return sig.cause(m)
+		}
+	}
+	return ""
+}
+
+// Reconcile computes the updated baseline for `update`: drop stale entries, add
+// an entry for every regression, and backfill `cause` (via inferCause) for any
+// entry — new or existing — that doesn't already have one. An existing cause,
+// however it was set, is never overwritten.
 func Reconcile(baseline []Entry, diff DiffResult) []Entry {
 	stale := make(map[string]bool, len(diff.Stale))
 	for _, e := range diff.Stale {
 		stale[e.ID] = true
 	}
+	messageByID := make(map[string]string, len(diff.Expected))
+	for _, exp := range diff.Expected {
+		messageByID[exp.Entry.ID] = exp.Result.Message
+	}
 
 	out := make([]Entry, 0, len(baseline)+len(diff.Regressions))
 	for _, e := range baseline {
-		if !stale[e.ID] {
-			out = append(out, e)
+		if stale[e.ID] {
+			continue
 		}
+		if e.Cause == "" {
+			e.Cause = inferCause(messageByID[e.ID])
+		}
+		out = append(out, e)
 	}
 	for _, r := range diff.Regressions {
-		out = append(out, Entry{ID: r.ID})
+		out = append(out, Entry{ID: r.ID, Cause: inferCause(r.Message)})
 	}
 	return out
 }
 
-// WriteReport prints a human-readable summary: headline counts, regressions, stale
-// entries, and a cause histogram of expected failures (grouped by the entry's Cause
-// tag, falling back to the raw failure message when Cause is blank).
+// passRate is the percentage of executed (non-skipped) results that passed.
+// Skipped results are excluded from the denominator — they're neither a pass
+// nor a fail, so including them would dilute the number in either direction.
+func passRate(pass, fail int) float64 {
+	if pass+fail == 0 {
+		return 0
+	}
+	return float64(pass) / float64(pass+fail) * 100
+}
+
+// suiteOf derives a coarse grouping label from a test's source file path — the
+// first path segment under "test/", e.g. ".../test/token/ERC20/ERC20.test.js"
+// -> "token". Falls back to the full file (or "" if the runner didn't report
+// one, e.g. go test has no per-test file) when the path doesn't have that shape.
+func suiteOf(file string) string {
+	const marker = "/test/"
+	idx := strings.LastIndex(file, marker)
+	if idx == -1 {
+		return file
+	}
+	rest := file[idx+len(marker):]
+	if slash := strings.Index(rest, "/"); slash != -1 {
+		return rest[:slash]
+	}
+	return rest
+}
+
+type suiteStats struct {
+	name             string
+	pass, fail, skip int
+}
+
+// bySuite buckets results by suiteOf(r.File), sorted by pass rate ascending
+// (the worst-performing suite first) — the same ROI-ranking idea as the cause
+// histogram, but for "where to look next" rather than "what to fix next".
+func bySuite(results []Result) []suiteStats {
+	stats := make(map[string]*suiteStats)
+	var order []string
+	for _, r := range results {
+		name := suiteOf(r.File)
+		s, ok := stats[name]
+		if !ok {
+			s = &suiteStats{name: name}
+			stats[name] = s
+			order = append(order, name)
+		}
+		switch r.Status {
+		case StatusPass:
+			s.pass++
+		case StatusFail:
+			s.fail++
+		case StatusSkip:
+			s.skip++
+		}
+	}
+
+	out := make([]suiteStats, 0, len(order))
+	for _, name := range order {
+		out = append(out, *stats[name])
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ri, rj := passRate(out[i].pass, out[i].fail), passRate(out[j].pass, out[j].fail)
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i].name < out[j].name
+	})
+	return out
+}
+
+// WriteReport prints a human-readable summary: headline counts and pass rate, a
+// per-suite breakdown (to see where compatibility is improving), regressions,
+// stale entries, and a cause histogram of expected failures (grouped by the
+// entry's Cause tag, falling back to the raw failure message when blank).
 func WriteReport(w io.Writer, suite string, results []Result, diff DiffResult) {
 	var pass, fail, skip int
 	for _, r := range results {
@@ -236,7 +354,16 @@ func WriteReport(w io.Writer, suite string, results []Result, diff DiffResult) {
 	}
 
 	fmt.Fprintf(w, "# Baseline check: %s\n\n", suite)
-	fmt.Fprintf(w, "%d passed, %d failed, %d skipped (%d total)\n\n", pass, fail, skip, len(results))
+	fmt.Fprintf(w, "%d passed, %d failed, %d skipped (%d total, %.1f%% passing)\n\n",
+		pass, fail, skip, len(results), passRate(pass, fail))
+
+	if suites := bySuite(results); len(suites) > 1 {
+		fmt.Fprintf(w, "## By suite\n\n")
+		for _, s := range suites {
+			fmt.Fprintf(w, "- %s: %d/%d passing (%.0f%%)\n", s.name, s.pass, s.pass+s.fail, passRate(s.pass, s.fail))
+		}
+		fmt.Fprintln(w)
+	}
 
 	if len(diff.Regressions) > 0 {
 		fmt.Fprintf(w, "## Regressions (%d)\n\n", len(diff.Regressions))

--- a/cmd/baseline/baseline.go
+++ b/cmd/baseline/baseline.go
@@ -1,0 +1,294 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+// Status is the outcome of a single test, normalized across runner formats.
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusFail Status = "fail"
+	StatusSkip Status = "skip"
+)
+
+// Result is one test's outcome, normalized from whatever runner produced it.
+// ID is the runner's own full test name, used verbatim (Mocha's fullTitle,
+// or go test's hierarchical subtest name) — never reformatted.
+type Result struct {
+	ID      string
+	Status  Status
+	Message string
+}
+
+// Entry is one checked-in baseline record: a test expected to fail today.
+// Cause and Note are optional human annotations, filled in opportunistically —
+// never required for an entry to be valid (see BASELINE_PLAN.md's "Two workflows").
+type Entry struct {
+	ID    string `json:"id"`
+	Cause string `json:"cause,omitempty"`
+	Note  string `json:"note,omitempty"`
+}
+
+// ExpectedFailure pairs a currently-failing result with the baseline entry that
+// expects it, so the report can show the entry's cause tag alongside the failure.
+type ExpectedFailure struct {
+	Result Result
+	Entry  Entry
+}
+
+// DiffResult is the outcome of comparing current results against a baseline.
+type DiffResult struct {
+	Regressions []Result          // failing, not in the baseline
+	Stale       []Entry           // in the baseline, but not failing (or missing) now
+	Expected    []ExpectedFailure // failing, in the baseline — the normal case
+}
+
+// Regressed reports whether the diff should fail CI: any regression, or any stale
+// entry (a listed test that no longer fails is exactly as much "baseline doesn't
+// match reality" as a new failure — see BASELINE_PLAN.md's diff semantics).
+func (d DiffResult) Regressed() bool {
+	return len(d.Regressions) > 0 || len(d.Stale) > 0
+}
+
+// mochaTest mirrors the fields we need from Mocha's built-in --reporter json output.
+// Every test (pass, fail, or pending) appears in mochaReport.Tests with the same
+// shape; err is an empty object for a pass, or has Message set for a failure.
+type mochaTest struct {
+	FullTitle string   `json:"fullTitle"`
+	Err       mochaErr `json:"err"`
+}
+
+type mochaErr struct {
+	Message string `json:"message"`
+}
+
+// mochaReport is the top-level shape of Mocha's --reporter json output.
+// Tests is the authoritative list of every test that ran; Pending duplicates the
+// subset that were skipped (Mocha gives them empty err too, so Pending is the only
+// way to tell a skip apart from a pass). Failures duplicates every failing test too,
+// but is also the *only* place a failing before/beforeEach hook shows up — a hook
+// isn't itself a test, so it never appears in Tests at all.
+type mochaReport struct {
+	Tests    []mochaTest `json:"tests"`
+	Pending  []mochaTest `json:"pending"`
+	Failures []mochaTest `json:"failures"`
+}
+
+// ParseMochaJSON converts Mocha's built-in --reporter json output into []Result.
+func ParseMochaJSON(data []byte) ([]Result, error) {
+	var report mochaReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse mocha json: %w", err)
+	}
+
+	pending := make(map[string]bool, len(report.Pending))
+	for _, t := range report.Pending {
+		pending[t.FullTitle] = true
+	}
+
+	results := make([]Result, 0, len(report.Tests))
+	seen := make(map[string]bool, len(report.Tests))
+	for _, t := range report.Tests {
+		seen[t.FullTitle] = true
+		r := Result{ID: t.FullTitle}
+		switch {
+		case pending[t.FullTitle]:
+			r.Status = StatusSkip
+		case t.Err.Message != "":
+			r.Status = StatusFail
+			r.Message = t.Err.Message
+		default:
+			r.Status = StatusPass
+		}
+		results = append(results, r)
+	}
+
+	// A hook failure (e.g. a beforeEach that throws) has its own descriptive
+	// fullTitle (Mocha's own ID for it) and is otherwise indistinguishable from a
+	// regular failure — surface it the same way, or it silently vanishes.
+	for _, f := range report.Failures {
+		if seen[f.FullTitle] {
+			continue
+		}
+		results = append(results, Result{ID: f.FullTitle, Status: StatusFail, Message: f.Err.Message})
+	}
+	return results, nil
+}
+
+// LoadBaseline reads a baseline file. A missing file is an empty baseline, not an
+// error, so `update` can create one from scratch (initial seeding).
+func LoadBaseline(path string) ([]Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read baseline: %w", err)
+	}
+
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse baseline %s: %w", path, err)
+	}
+	return entries, nil
+}
+
+// SaveBaseline writes a baseline file, sorted by ID for stable, reviewable diffs.
+func SaveBaseline(path string, entries []Entry) error {
+	sorted := make([]Entry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	data, err := json.MarshalIndent(sorted, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write baseline %s: %w", path, err)
+	}
+	return nil
+}
+
+// Diff compares current results against a baseline. See BASELINE_PLAN.md's "Diff
+// semantics" for the 4-way matrix this implements.
+func Diff(results []Result, baseline []Entry) DiffResult {
+	byID := make(map[string]Entry, len(baseline))
+	for _, e := range baseline {
+		byID[e.ID] = e
+	}
+	seen := make(map[string]bool, len(results))
+
+	var out DiffResult
+	for _, r := range results {
+		seen[r.ID] = true
+		entry, listed := byID[r.ID]
+
+		switch {
+		case r.Status == StatusFail && listed:
+			out.Expected = append(out.Expected, ExpectedFailure{Result: r, Entry: entry})
+		case r.Status == StatusFail && !listed:
+			out.Regressions = append(out.Regressions, r)
+		case r.Status != StatusFail && listed:
+			out.Stale = append(out.Stale, entry)
+		}
+	}
+
+	// Baseline entries whose ID never appeared in this run at all (upstream
+	// renamed/removed the test) are safe to remove, same as a passing test.
+	for _, e := range baseline {
+		if !seen[e.ID] {
+			out.Stale = append(out.Stale, e)
+		}
+	}
+
+	return out
+}
+
+// Reconcile computes the updated baseline for `update`: drop stale entries, add a
+// blank-cause entry for every regression. Existing entries (including their cause/
+// note tags) are left untouched.
+func Reconcile(baseline []Entry, diff DiffResult) []Entry {
+	stale := make(map[string]bool, len(diff.Stale))
+	for _, e := range diff.Stale {
+		stale[e.ID] = true
+	}
+
+	out := make([]Entry, 0, len(baseline)+len(diff.Regressions))
+	for _, e := range baseline {
+		if !stale[e.ID] {
+			out = append(out, e)
+		}
+	}
+	for _, r := range diff.Regressions {
+		out = append(out, Entry{ID: r.ID})
+	}
+	return out
+}
+
+// WriteReport prints a human-readable summary: headline counts, regressions, stale
+// entries, and a cause histogram of expected failures (grouped by the entry's Cause
+// tag, falling back to the raw failure message when Cause is blank).
+func WriteReport(w io.Writer, suite string, results []Result, diff DiffResult) {
+	var pass, fail, skip int
+	for _, r := range results {
+		switch r.Status {
+		case StatusPass:
+			pass++
+		case StatusFail:
+			fail++
+		case StatusSkip:
+			skip++
+		}
+	}
+
+	fmt.Fprintf(w, "# Baseline check: %s\n\n", suite)
+	fmt.Fprintf(w, "%d passed, %d failed, %d skipped (%d total)\n\n", pass, fail, skip, len(results))
+
+	if len(diff.Regressions) > 0 {
+		fmt.Fprintf(w, "## Regressions (%d)\n\n", len(diff.Regressions))
+		for _, r := range diff.Regressions {
+			fmt.Fprintf(w, "- `%s`: %s\n", r.ID, r.Message)
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(diff.Stale) > 0 {
+		fmt.Fprintf(w, "## Stale baseline entries (%d) — remove these\n\n", len(diff.Stale))
+		for _, e := range diff.Stale {
+			fmt.Fprintf(w, "- `%s`\n", e.ID)
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(diff.Expected) > 0 {
+		fmt.Fprintf(w, "## Expected failures by cause (%d)\n\n", len(diff.Expected))
+		for _, group := range groupExpected(diff.Expected) {
+			fmt.Fprintf(w, "- %s: %d\n", group.key, len(group.items))
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+type expectedGroup struct {
+	key   string
+	items []ExpectedFailure
+}
+
+// groupExpected buckets expected failures by cause (falling back to the raw
+// message when untagged), sorted by group size descending — the ROI ranking.
+func groupExpected(expected []ExpectedFailure) []expectedGroup {
+	groups := make(map[string][]ExpectedFailure)
+	for _, e := range expected {
+		key := e.Entry.Cause
+		if key == "" {
+			key = e.Result.Message
+		}
+		groups[key] = append(groups[key], e)
+	}
+
+	out := make([]expectedGroup, 0, len(groups))
+	for key, items := range groups {
+		out = append(out, expectedGroup{key: key, items: items})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if len(out[i].items) != len(out[j].items) {
+			return len(out[i].items) > len(out[j].items)
+		}
+		return out[i].key < out[j].key
+	})
+	return out
+}

--- a/cmd/baseline/baseline_test.go
+++ b/cmd/baseline/baseline_test.go
@@ -73,6 +73,39 @@ func TestParseMochaJSON_HookFailure(t *testing.T) {
 	}
 }
 
+func TestSuiteOf(t *testing.T) {
+	cases := []struct{ file, want string }{
+		{"/repo/testdata/openzeppelin-contracts/test/token/ERC20/ERC20.test.js", "token"},
+		{"/repo/testdata/openzeppelin-contracts/test/finance/VestingWallet.test.js", "finance"},
+		{"", ""},
+		{"no-test-dir-here.js", "no-test-dir-here.js"},
+	}
+	for _, c := range cases {
+		if got := suiteOf(c.file); got != c.want {
+			t.Errorf("suiteOf(%q) = %q, want %q", c.file, got, c.want)
+		}
+	}
+}
+
+func TestBySuite(t *testing.T) {
+	results := []Result{
+		{ID: "a", Status: StatusPass, File: "/x/test/token/A.test.js"},
+		{ID: "b", Status: StatusFail, File: "/x/test/token/B.test.js"},
+		{ID: "c", Status: StatusPass, File: "/x/test/utils/C.test.js"},
+		{ID: "d", Status: StatusPass, File: "/x/test/utils/D.test.js"},
+	}
+
+	stats := bySuite(results)
+
+	want := []suiteStats{
+		{name: "token", pass: 1, fail: 1}, // 50% — worse, sorts first
+		{name: "utils", pass: 2, fail: 0}, // 100%
+	}
+	if !reflect.DeepEqual(stats, want) {
+		t.Fatalf("got %+v, want %+v", stats, want)
+	}
+}
+
 func TestBaseline_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "known_failures.json")
 
@@ -152,6 +185,51 @@ func TestDiff_NothingWrong(t *testing.T) {
 	diff := Diff(results, baseline)
 	if diff.Regressed() {
 		t.Fatalf("expected clean diff, got regressions=%+v stale=%+v", diff.Regressions, diff.Stale)
+	}
+}
+
+func TestInferCause(t *testing.T) {
+	cases := []struct {
+		message string
+		want    string
+	}{
+		{"the method hardhat_mine does not exist/is not available", "hardhat_mine"},
+		{"the method eth_signTypedData_v4 does not exist/is not available", "eth_signTypedData_v4"},
+		{"insufficient funds for gas * price + value: address 0xabc have 0 want 100", "insufficient-funds"},
+		{"execution reverted", ""},
+		{"expected 3 to equal 4", ""},
+	}
+	for _, c := range cases {
+		if got := inferCause(c.message); got != c.want {
+			t.Errorf("inferCause(%q) = %q, want %q", c.message, got, c.want)
+		}
+	}
+}
+
+func TestReconcile_AutoTagsKnownCauses(t *testing.T) {
+	baseline := []Entry{
+		{ID: "still failing, untagged"},
+	}
+	diff := DiffResult{
+		Regressions: []Result{
+			{ID: "new hardhat_mine failure", Status: StatusFail, Message: "the method hardhat_mine does not exist/is not available"},
+		},
+		Expected: []ExpectedFailure{
+			{
+				Result: Result{ID: "still failing, untagged", Status: StatusFail, Message: "the method eth_signTypedData_v4 does not exist/is not available"},
+				Entry:  baseline[0],
+			},
+		},
+	}
+
+	got := Reconcile(baseline, diff)
+
+	want := []Entry{
+		{ID: "still failing, untagged", Cause: "eth_signTypedData_v4"},
+		{ID: "new hardhat_mine failure", Cause: "hardhat_mine"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
 	}
 }
 

--- a/cmd/baseline/baseline_test.go
+++ b/cmd/baseline/baseline_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func mustParseMocha(t *testing.T, path string) []Result {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	results, err := ParseMochaJSON(data)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return results
+}
+
+func TestParseMochaJSON_AllPass(t *testing.T) {
+	results := mustParseMocha(t, "testdata/allpass.json")
+	want := []Result{
+		{ID: "Foo bar test A", Status: StatusPass},
+		{ID: "Foo bar test B", Status: StatusPass},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseMochaJSON_AllFail(t *testing.T) {
+	results := mustParseMocha(t, "testdata/allfail.json")
+	want := []Result{
+		{ID: "Foo bar test A", Status: StatusFail, Message: "boom A"},
+		{ID: "Foo bar test B", Status: StatusFail, Message: "boom B"},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseMochaJSON_Mixed(t *testing.T) {
+	results := mustParseMocha(t, "testdata/mixed.json")
+	want := []Result{
+		{ID: "Foo bar test A", Status: StatusPass},
+		{ID: "Foo bar test B", Status: StatusFail, Message: "boom B"},
+		{ID: "Foo bar test C", Status: StatusSkip},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseMochaJSON_HookFailure(t *testing.T) {
+	// A failing before/beforeEach hook never appears in `tests` — only in
+	// `failures`, with its own descriptive fullTitle — but must still surface.
+	results := mustParseMocha(t, "testdata/hookfail.json")
+	want := []Result{
+		{ID: "Foo bar test A", Status: StatusPass},
+		{ID: `Foo "before each" hook for "bar test B"`, Status: StatusFail, Message: "boom hook"},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestBaseline_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_failures.json")
+
+	// A missing file is an empty baseline, not an error.
+	entries, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("LoadBaseline on missing file: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty baseline, got %+v", entries)
+	}
+
+	want := []Entry{
+		{ID: "Foo bar test B", Cause: "signTypedData_v4"},
+		{ID: "Foo bar test A"},
+	}
+	if err := SaveBaseline(path, want); err != nil {
+		t.Fatalf("SaveBaseline: %v", err)
+	}
+
+	got, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("LoadBaseline: %v", err)
+	}
+	// SaveBaseline sorts by ID.
+	wantSorted := []Entry{
+		{ID: "Foo bar test A"},
+		{ID: "Foo bar test B", Cause: "signTypedData_v4"},
+	}
+	if !reflect.DeepEqual(got, wantSorted) {
+		t.Fatalf("got %+v, want %+v", got, wantSorted)
+	}
+}
+
+func TestDiff(t *testing.T) {
+	results := []Result{
+		{ID: "regression", Status: StatusFail, Message: "new break"},
+		{ID: "expected-fail", Status: StatusFail, Message: "known issue"},
+		{ID: "now-passing", Status: StatusPass},
+		{ID: "unlisted-pass", Status: StatusPass},
+	}
+	baseline := []Entry{
+		{ID: "expected-fail", Cause: "some-cause"},
+		{ID: "now-passing"},
+		{ID: "disappeared"}, // renamed/removed upstream, absent from results entirely
+	}
+
+	diff := Diff(results, baseline)
+
+	if len(diff.Regressions) != 1 || diff.Regressions[0].ID != "regression" {
+		t.Fatalf("regressions = %+v", diff.Regressions)
+	}
+	if len(diff.Expected) != 1 || diff.Expected[0].Result.ID != "expected-fail" || diff.Expected[0].Entry.Cause != "some-cause" {
+		t.Fatalf("expected = %+v", diff.Expected)
+	}
+	staleIDs := map[string]bool{}
+	for _, e := range diff.Stale {
+		staleIDs[e.ID] = true
+	}
+	if len(diff.Stale) != 2 || !staleIDs["now-passing"] || !staleIDs["disappeared"] {
+		t.Fatalf("stale = %+v", diff.Stale)
+	}
+	if !diff.Regressed() {
+		t.Fatal("expected Regressed() to be true (has both a regression and stale entries)")
+	}
+}
+
+func TestDiff_NothingWrong(t *testing.T) {
+	results := []Result{
+		{ID: "expected-fail", Status: StatusFail, Message: "known issue"},
+		{ID: "unlisted-pass", Status: StatusPass},
+	}
+	baseline := []Entry{
+		{ID: "expected-fail"},
+	}
+
+	diff := Diff(results, baseline)
+	if diff.Regressed() {
+		t.Fatalf("expected clean diff, got regressions=%+v stale=%+v", diff.Regressions, diff.Stale)
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	baseline := []Entry{
+		{ID: "expected-fail", Cause: "some-cause"},
+		{ID: "now-passing"},
+	}
+	diff := DiffResult{
+		Regressions: []Result{{ID: "regression", Status: StatusFail, Message: "new break"}},
+		Stale:       []Entry{{ID: "now-passing"}},
+		Expected:    []ExpectedFailure{{Result: Result{ID: "expected-fail"}, Entry: baseline[0]}},
+	}
+
+	got := Reconcile(baseline, diff)
+
+	want := []Entry{
+		{ID: "expected-fail", Cause: "some-cause"}, // untouched
+		{ID: "regression"},                         // newly added, blank cause
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // parsers maps a --format value to the adapter that turns a runner's raw output
@@ -23,7 +24,7 @@ var parsers = map[string]func([]byte) ([]Result, error){
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: baseline <check|update> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: baseline <check|update|tag> [flags]")
 		os.Exit(2)
 	}
 
@@ -33,8 +34,10 @@ func main() {
 		code = runCheck(os.Args[2:])
 	case "update":
 		code = runUpdate(os.Args[2:])
+	case "tag":
+		code = runTag(os.Args[2:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown subcommand %q (want check or update)\n", os.Args[1])
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q (want check, update, or tag)\n", os.Args[1])
 		code = 2
 	}
 	os.Exit(code)
@@ -187,5 +190,79 @@ func runUpdate(args []string) int {
 
 	fmt.Printf("%s: %d entries removed, %d entries added, %d total now\n",
 		f.baselinePath, len(diff.Stale), len(diff.Regressions), len(updated))
+	return 0
+}
+
+// tagMatching sets Cause (and Note, if given) on every baseline entry that is
+// still failing (present in messageByID) and whose ID or current message
+// contains match. Returns how many entries changed. A human decision, made in
+// bulk instead of one JSON edit at a time.
+//
+// An entry that already has a Cause is left untouched unless force is true —
+// a broad ID match (e.g. a whole describe block) can otherwise silently
+// clobber a more specific tag an earlier pass already got right.
+func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, note string, force bool) int {
+	n := 0
+	for i, e := range baseline {
+		if e.Cause != "" && !force {
+			continue
+		}
+		msg, stillFailing := messageByID[e.ID]
+		if !stillFailing {
+			continue
+		}
+		if !strings.Contains(e.ID, match) && !strings.Contains(msg, match) {
+			continue
+		}
+		baseline[i].Cause = cause
+		if note != "" {
+			baseline[i].Note = note
+		}
+		n++
+	}
+	return n
+}
+
+func runTag(args []string) int {
+	fs := flag.NewFlagSet("tag", flag.ContinueOnError)
+	baselinePath := fs.String("baseline", "", "path to the baseline JSON file")
+	resultsGlob := fs.String("results", "", "glob of raw results files to parse")
+	format := fs.String("format", "mocha-json", "raw results format (mocha-json)")
+	match := fs.String("match", "", "substring to match against each entry's ID or current failure message")
+	cause := fs.String("cause", "", "cause to assign to every matching entry")
+	note := fs.String("note", "", "optional note to assign alongside cause")
+	force := fs.Bool("force", false, "overwrite entries that already have a cause (default: leave them untouched)")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *baselinePath == "" || *resultsGlob == "" || *match == "" || *cause == "" {
+		fmt.Fprintln(os.Stderr, "usage: baseline tag --baseline <path> --results <glob> --match <substring> --cause <name> [--note <text>] [--force]")
+		return 2
+	}
+
+	results, err := loadResults(*format, *resultsGlob)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	baseline, err := LoadBaseline(*baselinePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	diff := Diff(results, baseline)
+	messageByID := make(map[string]string, len(diff.Expected))
+	for _, exp := range diff.Expected {
+		messageByID[exp.Entry.ID] = exp.Result.Message
+	}
+
+	n := tagMatching(baseline, messageByID, *match, *cause, *note, *force)
+	if err := SaveBaseline(*baselinePath, baseline); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	fmt.Printf("%s: tagged %d entries matching %q with cause %q\n", *baselinePath, n, *match, *cause)
 	return 0
 }

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -1,0 +1,191 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// parsers maps a --format value to the adapter that turns a runner's raw output
+// into []Result. Adding a runner later is "add one entry here."
+var parsers = map[string]func([]byte) ([]Result, error){
+	"mocha-json": ParseMochaJSON,
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: baseline <check|update> [flags]")
+		os.Exit(2)
+	}
+
+	var code int
+	switch os.Args[1] {
+	case "check":
+		code = runCheck(os.Args[2:])
+	case "update":
+		code = runUpdate(os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q (want check or update)\n", os.Args[1])
+		code = 2
+	}
+	os.Exit(code)
+}
+
+type commonFlags struct {
+	suite        string
+	format       string
+	baselinePath string
+	resultsGlob  string
+}
+
+func parseCommonFlags(name string, args []string) (*commonFlags, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	f := &commonFlags{}
+	fs.StringVar(&f.suite, "suite", "", "suite name, for the report header")
+	fs.StringVar(&f.format, "format", "mocha-json", "raw results format (mocha-json)")
+	fs.StringVar(&f.baselinePath, "baseline", "", "path to the baseline JSON file")
+	fs.StringVar(&f.resultsGlob, "results", "", "glob of raw results files to parse")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if f.baselinePath == "" {
+		return nil, fmt.Errorf("--baseline is required")
+	}
+	if f.resultsGlob == "" {
+		return nil, fmt.Errorf("--results is required")
+	}
+	return f, nil
+}
+
+// loadResults resolves the --results glob and parses every match with the adapter
+// selected by --format, concatenating their results. A test ID repeated across (or
+// within) matched files is folded into one entry rather than double-counted — OZ's
+// suite genuinely does this (a shared-behavior helper invoked twice in one file
+// produces two identical fullTitles) — but only when every occurrence agrees on
+// status and message; a real disagreement (e.g. an overlapping --results glob mixing
+// two different runs of the same test) is ambiguous and gets rejected instead.
+func loadResults(format, resultsGlob string) ([]Result, error) {
+	parse, ok := parsers[format]
+	if !ok {
+		return nil, fmt.Errorf("unknown --format %q", format)
+	}
+
+	paths, err := filepath.Glob(resultsGlob)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --results glob: %w", err)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("--results %q matched no files", resultsGlob)
+	}
+	sort.Strings(paths)
+
+	var all []Result
+	seen := make(map[string]Result)
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read results %s: %w", p, err)
+		}
+		results, err := parse(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse results %s: %w", p, err)
+		}
+		for _, r := range results {
+			if prev, dup := seen[r.ID]; dup {
+				if prev.Status == r.Status && prev.Message == r.Message {
+					continue
+				}
+				return nil, fmt.Errorf("test ID %q reported inconsistently (%s vs %s) in %s", r.ID, prev.Status, r.Status, p)
+			}
+			seen[r.ID] = r
+			all = append(all, r)
+		}
+	}
+	return all, nil
+}
+
+func writeStepSummary(report []byte) error {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_STEP_SUMMARY: %w", err)
+	}
+	defer f.Close()
+	_, err = f.Write(report)
+	return err
+}
+
+func runCheck(args []string) int {
+	f, err := parseCommonFlags("check", args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	results, err := loadResults(f.format, f.resultsGlob)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	baseline, err := LoadBaseline(f.baselinePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	diff := Diff(results, baseline)
+
+	var buf bytes.Buffer
+	WriteReport(&buf, f.suite, results, diff)
+	fmt.Print(buf.String())
+	if err := writeStepSummary(buf.Bytes()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+
+	if diff.Regressed() {
+		return 1
+	}
+	return 0
+}
+
+func runUpdate(args []string) int {
+	f, err := parseCommonFlags("update", args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	results, err := loadResults(f.format, f.resultsGlob)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	baseline, err := LoadBaseline(f.baselinePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	diff := Diff(results, baseline)
+	updated := Reconcile(baseline, diff)
+	if err := SaveBaseline(f.baselinePath, updated); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	fmt.Printf("%s: %d entries removed, %d entries added, %d total now\n",
+		f.baselinePath, len(diff.Stale), len(diff.Regressions), len(updated))
+	return 0
+}

--- a/cmd/baseline/main_test.go
+++ b/cmd/baseline/main_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMochaFixture(t *testing.T, dir, name, fullTitle, errMessage string) string {
+	t.Helper()
+	err := ""
+	if errMessage != "" {
+		err = `"message": ` + `"` + errMessage + `"`
+	}
+	data := `{
+  "stats": {"tests": 1, "passes": 0, "pending": 0, "failures": 0},
+  "tests": [{"fullTitle": "` + fullTitle + `", "err": {` + err + `}}],
+  "pending": [],
+  "failures": [],
+  "passes": []
+}`
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestLoadResults_AgreeingDuplicateIsFolded(t *testing.T) {
+	dir := t.TempDir()
+	writeMochaFixture(t, dir, "a.json", "shared test", "")
+	writeMochaFixture(t, dir, "b.json", "shared test", "")
+
+	results, err := loadResults("mocha-json", filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatalf("loadResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected the repeated ID to fold into one result, got %+v", results)
+	}
+}
+
+func TestLoadResults_ConflictingDuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeMochaFixture(t, dir, "a.json", "shared test", "")
+	writeMochaFixture(t, dir, "b.json", "shared test", "boom")
+
+	_, err := loadResults("mocha-json", filepath.Join(dir, "*.json"))
+	if err == nil {
+		t.Fatal("expected an error for a test ID reported with conflicting outcomes")
+	}
+}

--- a/cmd/baseline/main_test.go
+++ b/cmd/baseline/main_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -54,5 +55,64 @@ func TestLoadResults_ConflictingDuplicateErrors(t *testing.T) {
 	_, err := loadResults("mocha-json", filepath.Join(dir, "*.json"))
 	if err == nil {
 		t.Fatal("expected an error for a test ID reported with conflicting outcomes")
+	}
+}
+
+func TestTagMatching(t *testing.T) {
+	baseline := []Entry{
+		{ID: "Packing packs"},
+		{ID: "Packing extracts"},
+		{ID: "unrelated test", Cause: "already-tagged"},
+		{ID: "gone upstream"}, // not in messageByID: upstream removed/renamed it
+	}
+	messageByID := map[string]string{
+		"Packing packs":    "could not decode result data (value=\"0x\", ...)",
+		"Packing extracts": "could not decode result data (value=\"0x\", ...)",
+		"unrelated test":   "something else entirely",
+	}
+
+	n := tagMatching(baseline, messageByID, "Packing", "max-code-size", "", false)
+
+	if n != 2 {
+		t.Fatalf("expected 2 tagged, got %d", n)
+	}
+	want := []Entry{
+		{ID: "Packing packs", Cause: "max-code-size"},
+		{ID: "Packing extracts", Cause: "max-code-size"},
+		{ID: "unrelated test", Cause: "already-tagged"},
+		{ID: "gone upstream"},
+	}
+	if !reflect.DeepEqual(baseline, want) {
+		t.Fatalf("got %+v, want %+v", baseline, want)
+	}
+}
+
+func TestTagMatching_MatchesOnMessageToo(t *testing.T) {
+	baseline := []Entry{{ID: "some test"}}
+	messageByID := map[string]string{"some test": "max code size exceeded: code size 25144 limit 24576"}
+
+	n := tagMatching(baseline, messageByID, "max code size exceeded", "max-code-size", "confirmed via logs", false)
+
+	if n != 1 || baseline[0].Cause != "max-code-size" || baseline[0].Note != "confirmed via logs" {
+		t.Fatalf("got %+v", baseline)
+	}
+}
+
+func TestTagMatching_SkipsAlreadyTaggedUnlessForced(t *testing.T) {
+	// A broad ID match (e.g. a whole describe block) shouldn't clobber a more
+	// specific cause an earlier, more targeted pass already got right.
+	baseline := []Entry{{ID: "AccessControlDefaultAdminRules ERC165 uses less than 30k gas", Cause: "gas-stub"}}
+	messageByID := map[string]string{
+		"AccessControlDefaultAdminRules ERC165 uses less than 30k gas": "expected 10000000 to be at most 30000.",
+	}
+
+	n := tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", false)
+	if n != 0 || baseline[0].Cause != "gas-stub" {
+		t.Fatalf("expected the existing tag to survive untouched, got %+v", baseline)
+	}
+
+	n = tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", true)
+	if n != 1 || baseline[0].Cause != "fixed-block-context" {
+		t.Fatalf("expected --force to overwrite, got %+v", baseline)
 	}
 }

--- a/cmd/baseline/testdata/allfail.json
+++ b/cmd/baseline/testdata/allfail.json
@@ -1,0 +1,13 @@
+{
+  "stats": { "suites": 1, "tests": 2, "passes": 0, "pending": 0, "failures": 2 },
+  "tests": [
+    { "fullTitle": "Foo bar test A", "err": { "message": "boom A" } },
+    { "fullTitle": "Foo bar test B", "err": { "message": "boom B" } }
+  ],
+  "pending": [],
+  "failures": [
+    { "fullTitle": "Foo bar test A", "err": { "message": "boom A" } },
+    { "fullTitle": "Foo bar test B", "err": { "message": "boom B" } }
+  ],
+  "passes": []
+}

--- a/cmd/baseline/testdata/allpass.json
+++ b/cmd/baseline/testdata/allpass.json
@@ -1,0 +1,13 @@
+{
+  "stats": { "suites": 1, "tests": 2, "passes": 2, "pending": 0, "failures": 0 },
+  "tests": [
+    { "fullTitle": "Foo bar test A", "err": {} },
+    { "fullTitle": "Foo bar test B", "err": {} }
+  ],
+  "pending": [],
+  "failures": [],
+  "passes": [
+    { "fullTitle": "Foo bar test A", "err": {} },
+    { "fullTitle": "Foo bar test B", "err": {} }
+  ]
+}

--- a/cmd/baseline/testdata/hookfail.json
+++ b/cmd/baseline/testdata/hookfail.json
@@ -1,0 +1,13 @@
+{
+  "stats": { "suites": 1, "tests": 1, "passes": 1, "pending": 0, "failures": 1 },
+  "tests": [
+    { "fullTitle": "Foo bar test A", "err": {} }
+  ],
+  "pending": [],
+  "failures": [
+    { "fullTitle": "Foo \"before each\" hook for \"bar test B\"", "err": { "message": "boom hook" } }
+  ],
+  "passes": [
+    { "fullTitle": "Foo bar test A", "err": {} }
+  ]
+}

--- a/cmd/baseline/testdata/mixed.json
+++ b/cmd/baseline/testdata/mixed.json
@@ -1,0 +1,17 @@
+{
+  "stats": { "suites": 1, "tests": 3, "passes": 1, "pending": 1, "failures": 1 },
+  "tests": [
+    { "fullTitle": "Foo bar test A", "err": {} },
+    { "fullTitle": "Foo bar test B", "err": { "message": "boom B" } },
+    { "fullTitle": "Foo bar test C", "err": {} }
+  ],
+  "pending": [
+    { "fullTitle": "Foo bar test C", "err": {} }
+  ],
+  "failures": [
+    { "fullTitle": "Foo bar test B", "err": { "message": "boom B" } }
+  ],
+  "passes": [
+    { "fullTitle": "Foo bar test A", "err": {} }
+  ]
+}

--- a/testdata/hardhat.wrapper.config.js
+++ b/testdata/hardhat.wrapper.config.js
@@ -9,6 +9,23 @@
 const path = require('path');
 const ozConfig = require(path.join(process.cwd(), 'hardhat.config.js'));
 
+// Mocha's built-in JSON reporter calls JSON.stringify on failing assertions' actual/
+// expected values; a raw BigInt anywhere in a deep-equal diff throws inside that
+// (uncaught, silent) and the reporter writes nothing at all for the whole run — no
+// error, just empty output. ethers v6 returns BigInt everywhere, so this hits often.
+// toJSON is what JSON.stringify calls when present, so this fixes it globally.
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
+
+// This Hardhat version has no --reporter CLI flag; the mocha reporter must come from
+// config. Gated by an env var so a plain `npx hardhat test` still gets the normal
+// human-readable reporter.
+const mochaConfig = { ...ozConfig.mocha };
+if (process.env.HARDHAT_REPORTER) {
+  mochaConfig.reporter = process.env.HARDHAT_REPORTER;
+}
+
 module.exports = {
   ...ozConfig,
 
@@ -18,6 +35,8 @@ module.exports = {
     ...ozConfig.paths,
     root: process.cwd(),
   },
+
+  mocha: mochaConfig,
 
   networks: {
     ...ozConfig.networks,

--- a/testdata/hardhat.wrapper.config.js
+++ b/testdata/hardhat.wrapper.config.js
@@ -20,10 +20,12 @@ BigInt.prototype.toJSON = function () {
 
 // This Hardhat version has no --reporter CLI flag; the mocha reporter must come from
 // config. Gated by an env var so a plain `npx hardhat test` still gets the normal
-// human-readable reporter.
+// human-readable reporter. When set, use the combined reporter (mocha-spec-and-json-
+// reporter.js) so a single run gives both the live console view and the JSON file
+// cmd/baseline parses, instead of picking one or the other.
 const mochaConfig = { ...ozConfig.mocha };
-if (process.env.HARDHAT_REPORTER) {
-  mochaConfig.reporter = process.env.HARDHAT_REPORTER;
+if (process.env.HARDHAT_JSON_OUTPUT) {
+  mochaConfig.reporter = path.join(__dirname, 'mocha-spec-and-json-reporter.js');
 }
 
 module.exports = {

--- a/testdata/mocha-spec-and-json-reporter.js
+++ b/testdata/mocha-spec-and-json-reporter.js
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Combines Mocha's own built-in Spec (human-readable, to stdout) and JSON
+// (machine-readable, to a file) reporters against the same test run, so one
+// invocation gives both a live console view and a report `cmd/baseline` can
+// parse — no need to run the suite twice, and no third-party reporter
+// package: both are required directly from the already-installed `mocha`.
+//
+// Resolved relative to process.cwd() (the OpenZeppelin checkout), not this
+// file's own directory, since this file lives outside that checkout — same
+// reason hardhat.wrapper.config.js resolves ozConfig via process.cwd().
+'use strict';
+
+const path = require('path');
+const mochaLib = path.join(process.cwd(), 'node_modules', 'mocha', 'lib');
+const Spec = require(path.join(mochaLib, 'reporters', 'spec'));
+const JSONReporter = require(path.join(mochaLib, 'reporters', 'json'));
+
+module.exports = function (runner, options) {
+  new Spec(runner, options);
+
+  const outputPath = process.env.HARDHAT_JSON_OUTPUT;
+  new JSONReporter(runner, {
+    ...options,
+    reporterOption: outputPath ? { output: outputPath } : undefined,
+  });
+};


### PR DESCRIPTION
See readme.md.

This is a standalone tool, purely for managing our tests. Implemented for the OpenZeppelin Hardhat tests, not yet integrated in the CI.

In a next PR, I'll enable the full hardhat suite and create a file with our baseline status and known to fail tests.

After that we can enable the same format for the ethereum tests suite.