### PR TITLE
ci: measure and report unit-test coverage with Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Unit tests
         run: make unit-tests
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          fail_ci_if_error: false
+
       - name: Hardhat integration tests
         run: make hardhat-tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,8 @@ jobs:
         run: make unit-tests
 
       - name: Upload coverage to Codecov
-        # Fork PRs don't get CODECOV_TOKEN; skip the upload there instead of failing it.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
           fail_ci_if_error: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
         run: make unit-tests
 
       - name: Upload coverage to Codecov
+        # Fork PRs don't get CODECOV_TOKEN; skip the upload there instead of failing it.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ integration/perf/*.html
 integration/perf/*.json
 
 *.log
+
+# unit-test coverage profile (uploaded to Codecov in CI)
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ checks:
 
 .PHONY: unit-tests
 unit-tests:
-	go test ./... -short
+	go test ./... -short -coverprofile=coverage.out -covermode=atomic
 
 .PHONY: pre-pull-images
 pre-pull-images:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "testdata"
+  - "**/*.sql.go" # sqlc-generated


### PR DESCRIPTION
Addressed issue
Closes #234

 Summary
 - unit-tests now emits a coverage profile (go test ./... -short -coverprofile=coverage.out -covermode=atomic); coverage.out is gitignored.
  - The Tests workflow uploads that profile to Codecov after the unit-test step (codecov/codecov-action@v5, token: ${{ secrets.CODECOV_TOKEN }}, fail_ci_if_error: false so an upload hiccup never breaks the pipeline).
 - Adds a minimal codecov.yml: informational statuses (never blocks a PR) and ignores testdata + generated *.sql.go.
 - Scope is measurement/reporting only (per the issue)

 Validation done :
- make unit-tests produces a valid coverage.out locally (~23.6% total); make checks passes; both YAML files parse.

