### PR TITLE
test: fetch & vendor execution-specs fixtures (tests@v20.0.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,10 @@ test-local:
 test-local-x:
 	@go test -timeout 30s -v -run ^TestLocalX$$ ./integration
 
+.PHONY: fetch-execution-specs-tests
+fetch-execution-specs-tests:
+	@./scripts/fetch_execution_specs_tests.sh
+
 .PHONY: eth-tests
 eth-tests:
 	@go test -test.fullpath=true -timeout 2000s -run ^TestEthereumTests$$ github.com/hyperledger/fabric-x-evm/integration

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ those tests:
 git submodule update --init --recursive
 ```
 
+The newer `ethereum/execution-specs` conformance fixtures (Osaka+) are fetched
+separately — they are downloaded and checksum-verified into a gitignored
+`testdata/execution-specs-tests/` directory rather than vendored as a submodule:
+
+```shell
+make fetch-execution-specs-tests
+```
+
 #### Local
 
 The simplest integration tests don't require a Fabric network, but still

--- a/scripts/fetch_execution_specs_tests.sh
+++ b/scripts/fetch_execution_specs_tests.sh
@@ -10,7 +10,9 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Pinned ethereum/execution-specs conformance fixtures (tests@v20.0.1: Osaka + BPO1 + BPO2).
 # Bump the tag and checksum together, deliberately.
 VERSION="tests@v20.0.1"
-URL="https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz"
+# Derive the URL from VERSION (URL-encoding the '@') so a version bump only
+# touches VERSION + SHA256, never a separately-pinned URL.
+URL="https://github.com/ethereum/execution-specs/releases/download/${VERSION/@/%40}/fixtures.tar.gz"
 SHA256="3586193db06d4d5745d5e90b3c3008c2255a4e19ccd8f11a3ce887aec8c0b17c"
 
 DEST_DIR="${PROJECT_ROOT}/testdata/execution-specs-tests"

--- a/scripts/fetch_execution_specs_tests.sh
+++ b/scripts/fetch_execution_specs_tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Pinned ethereum/execution-specs conformance fixtures (tests@v20.0.1: Osaka + BPO1 + BPO2).
+# Bump the tag and checksum together, deliberately.
+VERSION="tests@v20.0.1"
+URL="https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz"
+SHA256="3586193db06d4d5745d5e90b3c3008c2255a4e19ccd8f11a3ce887aec8c0b17c"
+
+DEST_DIR="${PROJECT_ROOT}/testdata/execution-specs-tests"
+TARBALL="${DEST_DIR}/fixtures.tar.gz"
+FIXTURES_DIR="${DEST_DIR}/fixtures"
+
+# sha256 helper: sha256sum on Linux/CI, shasum on macOS.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "error: need 'sha256sum' or 'shasum' to verify the download" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "${DEST_DIR}"
+
+if [ -f "${TARBALL}" ]; then
+  # Present already: verify it. Matching checksum -> idempotent skip.
+  # Mismatch -> fail loudly rather than silently re-downloading over it.
+  if [ "$(sha256_of "${TARBALL}")" = "${SHA256}" ]; then
+    echo "==> ${VERSION} fixtures already present and verified; skipping download"
+  else
+    echo "error: existing ${TARBALL} failed checksum verification." >&2
+    echo "  expected ${SHA256}" >&2
+    echo "  delete the file and re-run to fetch a clean copy." >&2
+    exit 1
+  fi
+else
+  echo "==> Downloading ${VERSION} fixtures (~400 MB)..."
+  # Show a progress bar interactively; stay quiet in CI/non-TTY logs.
+  if [ -t 1 ]; then
+    curl --fail --location --progress-bar "${URL}" --output "${TARBALL}"
+  else
+    curl --fail --location --silent --show-error "${URL}" --output "${TARBALL}"
+  fi
+  if [ "$(sha256_of "${TARBALL}")" != "${SHA256}" ]; then
+    echo "error: downloaded ${TARBALL} failed checksum verification; removing it." >&2
+    echo "  expected ${SHA256}" >&2
+    rm -f "${TARBALL}"
+    exit 1
+  fi
+fi
+
+echo "==> Extracting into ${DEST_DIR}/ ..."
+rm -rf "${FIXTURES_DIR}"
+tar -xzf "${TARBALL}" -C "${DEST_DIR}"
+
+echo "==> Done. Fixtures at: ${FIXTURES_DIR}"


### PR DESCRIPTION
## Addressed issue
Closes #235

## Summary
- Add `make fetch-execution-specs-tests` + `scripts/fetch_execution_specs_tests.sh`: downloads the pinned `fixtures.tar.gz` (`tests@v20.0.1` — Osaka + BPO1 + BPO2), verifies its sha256, and extracts into a gitignored `testdata/execution-specs-tests/fixtures/`.
- Idempotent (skips re-download when present + verified); a checksum mismatch **fails loudly** instead of silently re-downloading. The sha256 tool is cross-platform (`sha256sum`/`shasum`); download progress shows only on a TTY (quiet in CI logs).
- Gitignore the fixtures dir; document the target in the README next to the submodule init.
- Scope is fetch-only (per the issue): no changes to `ethereum_test.go`, the `eth-tests*` targets, CI, the old submodule, or `-legacy`.

## Validation done
- Download → verify → extract works; re-run is idempotent (no re-download).
- Corrupting the local tarball fails loudly (`exit 1`), no silent re-download.
- `fixtures/{state_tests, blockchain_tests, transaction_tests}/` all present (8172 / 8618 / 38 JSON files).
- `make checks` passes; `ethereum_test.go` and `tests.yml` untouched.

##Screenshot 
<img width="1469" height="356" alt="Screenshot 2026-07-21 at 4 01 12 AM" src="https://github.com/user-attachments/assets/d20dbb4f-b4b5-4ba5-a7f5-337bb627ee2f" />
