### PR TITLE
test: run execution-specs state_tests through the existing harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ testdata/*
 !testdata/alloc_tether_replay.json
 !testdata/test_accounts.json
 !testdata/eth_tests.skip
+!testdata/execution_specs_tests.skip
+!testdata/execution_specs_tests.slow
 !testdata/shared_config.yaml
 *.un~
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,10 @@ eth-tests-slow:
 eth-tests-slow-legacy:
 	@go test -test.fullpath=true -timeout 10000s -run ^TestEthereumTests$$ github.com/hyperledger/fabric-x-evm/integration -very_slow -legacy
 
+.PHONY: eth-tests-execution-specs
+eth-tests-execution-specs: fetch-execution-specs-tests
+	@go test -test.fullpath=true -timeout 2000s -run ^TestExecutionSpecStateTests$$ github.com/hyperledger/fabric-x-evm/integration
+
 .PHONY: hardhat-tests
 hardhat-tests:
 	@./scripts/run_hardhat_test.sh

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -221,8 +221,17 @@ func runEthereumTestFile(t *testing.T, path string) {
 
 // runSingleEthereumTest executes one ethereum test case with all configurations
 func runSingleEthereumTest(t *testing.T, stateTest *StateTest) {
-	// Iterate through all subtests (fork/index combinations)
+	runStateTestSubtests(t, stateTest, nil)
+}
+
+// runStateTestSubtests runs each fork/index subtest; a non-nil forkAllowlist restricts to those forks.
+func runStateTestSubtests(t *testing.T, stateTest *StateTest, forkAllowlist map[string]struct{}) {
 	for _, subtest := range stateTest.Subtests() {
+		if forkAllowlist != nil {
+			if _, ok := forkAllowlist[subtest.Fork]; !ok {
+				continue
+			}
+		}
 		key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 
 		if testing.Short() && rand.Intn(2) > 0 {

--- a/integration/execution_specs_test.go
+++ b/integration/execution_specs_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package integration
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+// executionSpecForks limits the suite to Osaka-forward, plus Prague/Cancun as cheap regression.
+var executionSpecForks = map[string]struct{}{
+	"Osaka":  {},
+	"BPO1":   {},
+	"BPO2":   {},
+	"Prague": {},
+	"Cancun": {},
+}
+
+// TestExecutionSpecStateTests runs the execution-specs state_tests through the shared harness, limited to executionSpecForks.
+func TestExecutionSpecStateTests(t *testing.T) {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr)) // disable grpc logging
+
+	testsDir := filepath.Join("..", "testdata", "execution-specs-tests", "fixtures", "state_tests")
+	if _, err := os.Stat(testsDir); os.IsNotExist(err) {
+		t.Skipf("execution-specs fixtures not found at %s; run `make fetch-execution-specs-tests`", testsDir)
+	}
+
+	skip, err := loadSkip(filepath.Join("..", "testdata", "execution_specs_tests.skip"))
+	if err != nil {
+		t.Fatalf("Failed to load skip list: %v", err)
+	}
+	t.Logf("Loaded skip list with %d entries", len(skip))
+
+	slow, err := loadSlow(filepath.Join("..", "testdata", "execution_specs_tests.slow"))
+	if err != nil {
+		t.Fatalf("Failed to load slow list: %v", err)
+	}
+	t.Logf("Loaded slow list with %d entries", len(slow))
+
+	allFiles, err := findJSONFiles(testsDir)
+	if err != nil {
+		t.Fatalf("Failed to find test files: %v", err)
+	}
+	allFiles = filterSkippedTests(allFiles, skip)
+	testFiles := filterSlowTests(allFiles, slow, *want_very_slow)
+	t.Logf("Running %d execution-specs state_tests files after filtering", len(testFiles))
+
+	for _, testPath := range testFiles {
+		t.Run(filepath.Base(testPath), func(t *testing.T) {
+			runExecutionSpecStateTestFile(t, testPath)
+		})
+	}
+}
+
+// runExecutionSpecStateTestFile runs one fixtures file's state tests against the fork allowlist.
+func runExecutionSpecStateTestFile(t *testing.T, path string) {
+	tests, err := ParseTestFile(path)
+	if err != nil {
+		t.Fatalf("Failed to parse test file: %v", err)
+	}
+	for name, test := range tests {
+		// EEST bakes the fork into the test name, so skip a test with no allowlisted fork entirely.
+		if !hasAllowlistedFork(test) {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runStateTestSubtests(t, test, executionSpecForks)
+		})
+	}
+}
+
+// hasAllowlistedFork reports whether any subtest targets an allowlisted fork.
+func hasAllowlistedFork(test *StateTest) bool {
+	for _, subtest := range test.Subtests() {
+		if _, ok := executionSpecForks[subtest.Fork]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/integration/execution_specs_test.go
+++ b/integration/execution_specs_test.go
@@ -68,7 +68,7 @@ func runExecutionSpecStateTestFile(t *testing.T, path string) {
 	}
 	for name, test := range tests {
 		// EEST bakes the fork into the test name, so skip a test with no allowlisted fork entirely.
-		if !hasAllowlistedFork(test) {
+		if !hasAllowlistedFork(test, executionSpecForks) {
 			continue
 		}
 		t.Run(name, func(t *testing.T) {
@@ -78,10 +78,10 @@ func runExecutionSpecStateTestFile(t *testing.T, path string) {
 	}
 }
 
-// hasAllowlistedFork reports whether any subtest targets an allowlisted fork.
-func hasAllowlistedFork(test *StateTest) bool {
+// hasAllowlistedFork reports whether any subtest targets a fork in the allowlist.
+func hasAllowlistedFork(test *StateTest, forkAllowlist map[string]struct{}) bool {
 	for _, subtest := range test.Subtests() {
-		if _, ok := executionSpecForks[subtest.Fork]; ok {
+		if _, ok := forkAllowlist[subtest.Fork]; ok {
 			return true
 		}
 	}

--- a/testdata/execution_specs_tests.skip
+++ b/testdata/execution_specs_tests.skip
@@ -1,0 +1,3 @@
+# Tests skipped for the execution-specs conformance suite (TestExecutionSpecStateTests).
+# One test path per line; blank lines and lines starting with '#' are ignored.
+# Populated in the skip/slow triage chunk (#237) — empty for now.

--- a/testdata/execution_specs_tests.slow
+++ b/testdata/execution_specs_tests.slow
@@ -1,0 +1,3 @@
+# Slow tests for the execution-specs conformance suite (run only with -very_slow).
+# One test path per line; blank lines and lines starting with '#' are ignored.
+# Populated in the skip/slow triage chunk (#237) — empty for now.


### PR DESCRIPTION
## Addressed issue
Closes #236

## Summary
- Extract the per-fixture fork/index loop from `runSingleEthereumTest` into a
  shared `runStateTestSubtests` that takes an optional fork allowlist; a nil
  allowlist runs every fork, so `TestEthereumTests` is unchanged.
- Add `TestExecutionSpecStateTests`, which runs the execution-specs `state_tests`
  (fetched via `make fetch-execution-specs-tests`) through that shared harness,
  restricted to Osaka-forward — Osaka, BPO1, BPO2, plus Prague/Cancun as
  regression. A fixture whose forks are all outside the allowlist is skipped
  entirely; a mixed fixture runs only its allowlisted forks. Skips cleanly when
  the fixtures are absent and honors `execution_specs_tests.skip` / `.slow`
  (both empty for now; populated in #237).
- Add `make eth-tests-execution-specs` (fetch + run).

## Validation done
- `make checks` passes; package builds and `gofmt` clean.
- Fork allowlist verified: on a fixture spanning Berlin→Osaka, only
  Cancun/Osaka/Prague subtests execute; 0 disallowed forks across a ~22k-subtest
  sweep.
- `TestEthereumTests` (old corpus) behavior unchanged — the refactored path
  passes a nil allowlist.
- Runner surfaces real conformance gaps as expected (a sampled slice fails on
  precompile / gas-metering edge cases under Cancun); triaging those into the
  skip/slow lists is #237.
  
  ## Screenshots
<img width="1469" height="653" alt="Screenshot 2026-07-21 at 12 05 56 PM" src="https://github.com/user-attachments/assets/39490fd0-ec94-421e-bd90-55d088671122" />
<img width="1469" height="811" alt="Screenshot 2026-07-21 at 12 06 09 PM" src="https://github.com/user-attachments/assets/39fa6418-00c2-41c1-bdff-5ee63ccf0ec2" />
