### PR TITLE
endorser: add dormant gRPC server for the EvmEndorsement service

### DIFF
--- a/api/endorsementpb/endorsement.pb.go
+++ b/api/endorsementpb/endorsement.pb.go
@@ -33,7 +33,9 @@ type ExecuteRequest struct {
 	// Proposal hash, required by classic Fabric because the submitted payload
 	// must carry it. Fabric-X does not need the proposal, so this is empty
 	// there and the full proposal never crosses the wire.
-	ProposalHash  []byte `protobuf:"bytes,2,opt,name=proposal_hash,json=proposalHash,proto3" json:"proposal_hash,omitempty"`
+	ProposalHash []byte `protobuf:"bytes,2,opt,name=proposal_hash,json=proposalHash,proto3" json:"proposal_hash,omitempty"`
+	// Invocation built by the sender, which the endorser passes to the builder.
+	Invocation    *Invocation `protobuf:"bytes,3,opt,name=invocation,proto3" json:"invocation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -82,6 +84,83 @@ func (x *ExecuteRequest) GetProposalHash() []byte {
 	return nil
 }
 
+func (x *ExecuteRequest) GetInvocation() *Invocation {
+	if x != nil {
+		return x.Invocation
+	}
+	return nil
+}
+
+// Invocation carries the parts of the sender's invocation that the endorsement
+// builder consumes.
+type Invocation struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	TxId             string                 `protobuf:"bytes,1,opt,name=tx_id,json=txId,proto3" json:"tx_id,omitempty"`
+	Args             [][]byte               `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
+	ChaincodeName    string                 `protobuf:"bytes,3,opt,name=chaincode_name,json=chaincodeName,proto3" json:"chaincode_name,omitempty"`
+	ChaincodeVersion string                 `protobuf:"bytes,4,opt,name=chaincode_version,json=chaincodeVersion,proto3" json:"chaincode_version,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *Invocation) Reset() {
+	*x = Invocation{}
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Invocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Invocation) ProtoMessage() {}
+
+func (x *Invocation) ProtoReflect() protoreflect.Message {
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Invocation.ProtoReflect.Descriptor instead.
+func (*Invocation) Descriptor() ([]byte, []int) {
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Invocation) GetTxId() string {
+	if x != nil {
+		return x.TxId
+	}
+	return ""
+}
+
+func (x *Invocation) GetArgs() [][]byte {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *Invocation) GetChaincodeName() string {
+	if x != nil {
+		return x.ChaincodeName
+	}
+	return ""
+}
+
+func (x *Invocation) GetChaincodeVersion() string {
+	if x != nil {
+		return x.ChaincodeVersion
+	}
+	return ""
+}
+
 type ExecuteResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Serialized read-write set of the execution.
@@ -101,7 +180,7 @@ type ExecuteResponse struct {
 
 func (x *ExecuteResponse) Reset() {
 	*x = ExecuteResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[1]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -113,7 +192,7 @@ func (x *ExecuteResponse) String() string {
 func (*ExecuteResponse) ProtoMessage() {}
 
 func (x *ExecuteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[1]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -126,7 +205,7 @@ func (x *ExecuteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{1}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ExecuteResponse) GetReadWriteSet() []byte {
@@ -197,7 +276,7 @@ type CallRequest struct {
 
 func (x *CallRequest) Reset() {
 	*x = CallRequest{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[2]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -209,7 +288,7 @@ func (x *CallRequest) String() string {
 func (*CallRequest) ProtoMessage() {}
 
 func (x *CallRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[2]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -222,7 +301,7 @@ func (x *CallRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallRequest.ProtoReflect.Descriptor instead.
 func (*CallRequest) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{2}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CallRequest) GetFrom() []byte {
@@ -286,7 +365,7 @@ type CallResponse struct {
 
 func (x *CallResponse) Reset() {
 	*x = CallResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[3]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -298,7 +377,7 @@ func (x *CallResponse) String() string {
 func (*CallResponse) ProtoMessage() {}
 
 func (x *CallResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[3]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -311,7 +390,7 @@ func (x *CallResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallResponse.ProtoReflect.Descriptor instead.
 func (*CallResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{3}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CallResponse) GetReturnData() []byte {
@@ -345,7 +424,7 @@ type BalanceRequest struct {
 
 func (x *BalanceRequest) Reset() {
 	*x = BalanceRequest{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[4]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -357,7 +436,7 @@ func (x *BalanceRequest) String() string {
 func (*BalanceRequest) ProtoMessage() {}
 
 func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[4]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -370,7 +449,7 @@ func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceRequest.ProtoReflect.Descriptor instead.
 func (*BalanceRequest) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{4}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *BalanceRequest) GetAccount() []byte {
@@ -397,7 +476,7 @@ type BalanceResponse struct {
 
 func (x *BalanceResponse) Reset() {
 	*x = BalanceResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[5]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -409,7 +488,7 @@ func (x *BalanceResponse) String() string {
 func (*BalanceResponse) ProtoMessage() {}
 
 func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[5]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -422,7 +501,7 @@ func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceResponse.ProtoReflect.Descriptor instead.
 func (*BalanceResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{5}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *BalanceResponse) GetBalance() []byte {
@@ -444,7 +523,7 @@ type StorageRequest struct {
 
 func (x *StorageRequest) Reset() {
 	*x = StorageRequest{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[6]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -456,7 +535,7 @@ func (x *StorageRequest) String() string {
 func (*StorageRequest) ProtoMessage() {}
 
 func (x *StorageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[6]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -469,7 +548,7 @@ func (x *StorageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageRequest.ProtoReflect.Descriptor instead.
 func (*StorageRequest) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{6}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *StorageRequest) GetAccount() []byte {
@@ -503,7 +582,7 @@ type StorageResponse struct {
 
 func (x *StorageResponse) Reset() {
 	*x = StorageResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[7]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -515,7 +594,7 @@ func (x *StorageResponse) String() string {
 func (*StorageResponse) ProtoMessage() {}
 
 func (x *StorageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[7]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -528,7 +607,7 @@ func (x *StorageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageResponse.ProtoReflect.Descriptor instead.
 func (*StorageResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{7}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *StorageResponse) GetValue() []byte {
@@ -548,7 +627,7 @@ type CodeRequest struct {
 
 func (x *CodeRequest) Reset() {
 	*x = CodeRequest{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[8]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -560,7 +639,7 @@ func (x *CodeRequest) String() string {
 func (*CodeRequest) ProtoMessage() {}
 
 func (x *CodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[8]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -573,7 +652,7 @@ func (x *CodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeRequest.ProtoReflect.Descriptor instead.
 func (*CodeRequest) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{8}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CodeRequest) GetAccount() []byte {
@@ -599,7 +678,7 @@ type CodeResponse struct {
 
 func (x *CodeResponse) Reset() {
 	*x = CodeResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[9]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -611,7 +690,7 @@ func (x *CodeResponse) String() string {
 func (*CodeResponse) ProtoMessage() {}
 
 func (x *CodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[9]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -624,7 +703,7 @@ func (x *CodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeResponse.ProtoReflect.Descriptor instead.
 func (*CodeResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{9}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CodeResponse) GetCode() []byte {
@@ -644,7 +723,7 @@ type NonceRequest struct {
 
 func (x *NonceRequest) Reset() {
 	*x = NonceRequest{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[10]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -656,7 +735,7 @@ func (x *NonceRequest) String() string {
 func (*NonceRequest) ProtoMessage() {}
 
 func (x *NonceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[10]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -669,7 +748,7 @@ func (x *NonceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceRequest.ProtoReflect.Descriptor instead.
 func (*NonceRequest) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{10}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *NonceRequest) GetAccount() []byte {
@@ -695,7 +774,7 @@ type NonceResponse struct {
 
 func (x *NonceResponse) Reset() {
 	*x = NonceResponse{}
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[11]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -707,7 +786,7 @@ func (x *NonceResponse) String() string {
 func (*NonceResponse) ProtoMessage() {}
 
 func (x *NonceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[11]
+	mi := &file_api_endorsementpb_endorsement_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -720,7 +799,7 @@ func (x *NonceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceResponse.ProtoReflect.Descriptor instead.
 func (*NonceResponse) Descriptor() ([]byte, []int) {
-	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{11}
+	return file_api_endorsementpb_endorsement_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *NonceResponse) GetNonce() uint64 {
@@ -734,11 +813,20 @@ var File_api_endorsementpb_endorsement_proto protoreflect.FileDescriptor
 
 const file_api_endorsementpb_endorsement_proto_rawDesc = "" +
 	"\n" +
-	"#api/endorsementpb/endorsement.proto\x12\rendorsementpb\"V\n" +
+	"#api/endorsementpb/endorsement.proto\x12\rendorsementpb\"\x91\x01\n" +
 	"\x0eExecuteRequest\x12\x1f\n" +
 	"\vethereum_tx\x18\x01 \x01(\fR\n" +
 	"ethereumTx\x12#\n" +
-	"\rproposal_hash\x18\x02 \x01(\fR\fproposalHash\"\xd8\x01\n" +
+	"\rproposal_hash\x18\x02 \x01(\fR\fproposalHash\x129\n" +
+	"\n" +
+	"invocation\x18\x03 \x01(\v2\x19.endorsementpb.InvocationR\n" +
+	"invocation\"\x89\x01\n" +
+	"\n" +
+	"Invocation\x12\x13\n" +
+	"\x05tx_id\x18\x01 \x01(\tR\x04txId\x12\x12\n" +
+	"\x04args\x18\x02 \x03(\fR\x04args\x12%\n" +
+	"\x0echaincode_name\x18\x03 \x01(\tR\rchaincodeName\x12+\n" +
+	"\x11chaincode_version\x18\x04 \x01(\tR\x10chaincodeVersion\"\xd8\x01\n" +
 	"\x0fExecuteResponse\x12$\n" +
 	"\x0eread_write_set\x18\x01 \x01(\fR\freadWriteSet\x12\x14\n" +
 	"\x05event\x18\x02 \x01(\fR\x05event\x12\x16\n" +
@@ -807,39 +895,41 @@ func file_api_endorsementpb_endorsement_proto_rawDescGZIP() []byte {
 	return file_api_endorsementpb_endorsement_proto_rawDescData
 }
 
-var file_api_endorsementpb_endorsement_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_api_endorsementpb_endorsement_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_api_endorsementpb_endorsement_proto_goTypes = []any{
 	(*ExecuteRequest)(nil),  // 0: endorsementpb.ExecuteRequest
-	(*ExecuteResponse)(nil), // 1: endorsementpb.ExecuteResponse
-	(*CallRequest)(nil),     // 2: endorsementpb.CallRequest
-	(*CallResponse)(nil),    // 3: endorsementpb.CallResponse
-	(*BalanceRequest)(nil),  // 4: endorsementpb.BalanceRequest
-	(*BalanceResponse)(nil), // 5: endorsementpb.BalanceResponse
-	(*StorageRequest)(nil),  // 6: endorsementpb.StorageRequest
-	(*StorageResponse)(nil), // 7: endorsementpb.StorageResponse
-	(*CodeRequest)(nil),     // 8: endorsementpb.CodeRequest
-	(*CodeResponse)(nil),    // 9: endorsementpb.CodeResponse
-	(*NonceRequest)(nil),    // 10: endorsementpb.NonceRequest
-	(*NonceResponse)(nil),   // 11: endorsementpb.NonceResponse
+	(*Invocation)(nil),      // 1: endorsementpb.Invocation
+	(*ExecuteResponse)(nil), // 2: endorsementpb.ExecuteResponse
+	(*CallRequest)(nil),     // 3: endorsementpb.CallRequest
+	(*CallResponse)(nil),    // 4: endorsementpb.CallResponse
+	(*BalanceRequest)(nil),  // 5: endorsementpb.BalanceRequest
+	(*BalanceResponse)(nil), // 6: endorsementpb.BalanceResponse
+	(*StorageRequest)(nil),  // 7: endorsementpb.StorageRequest
+	(*StorageResponse)(nil), // 8: endorsementpb.StorageResponse
+	(*CodeRequest)(nil),     // 9: endorsementpb.CodeRequest
+	(*CodeResponse)(nil),    // 10: endorsementpb.CodeResponse
+	(*NonceRequest)(nil),    // 11: endorsementpb.NonceRequest
+	(*NonceResponse)(nil),   // 12: endorsementpb.NonceResponse
 }
 var file_api_endorsementpb_endorsement_proto_depIdxs = []int32{
-	0,  // 0: endorsementpb.EvmEndorsement.Execute:input_type -> endorsementpb.ExecuteRequest
-	2,  // 1: endorsementpb.EvmEndorsement.Call:input_type -> endorsementpb.CallRequest
-	4,  // 2: endorsementpb.EvmEndorsement.BalanceAt:input_type -> endorsementpb.BalanceRequest
-	6,  // 3: endorsementpb.EvmEndorsement.StorageAt:input_type -> endorsementpb.StorageRequest
-	8,  // 4: endorsementpb.EvmEndorsement.CodeAt:input_type -> endorsementpb.CodeRequest
-	10, // 5: endorsementpb.EvmEndorsement.NonceAt:input_type -> endorsementpb.NonceRequest
-	1,  // 6: endorsementpb.EvmEndorsement.Execute:output_type -> endorsementpb.ExecuteResponse
-	3,  // 7: endorsementpb.EvmEndorsement.Call:output_type -> endorsementpb.CallResponse
-	5,  // 8: endorsementpb.EvmEndorsement.BalanceAt:output_type -> endorsementpb.BalanceResponse
-	7,  // 9: endorsementpb.EvmEndorsement.StorageAt:output_type -> endorsementpb.StorageResponse
-	9,  // 10: endorsementpb.EvmEndorsement.CodeAt:output_type -> endorsementpb.CodeResponse
-	11, // 11: endorsementpb.EvmEndorsement.NonceAt:output_type -> endorsementpb.NonceResponse
-	6,  // [6:12] is the sub-list for method output_type
-	0,  // [0:6] is the sub-list for method input_type
-	0,  // [0:0] is the sub-list for extension type_name
-	0,  // [0:0] is the sub-list for extension extendee
-	0,  // [0:0] is the sub-list for field type_name
+	1,  // 0: endorsementpb.ExecuteRequest.invocation:type_name -> endorsementpb.Invocation
+	0,  // 1: endorsementpb.EvmEndorsement.Execute:input_type -> endorsementpb.ExecuteRequest
+	3,  // 2: endorsementpb.EvmEndorsement.Call:input_type -> endorsementpb.CallRequest
+	5,  // 3: endorsementpb.EvmEndorsement.BalanceAt:input_type -> endorsementpb.BalanceRequest
+	7,  // 4: endorsementpb.EvmEndorsement.StorageAt:input_type -> endorsementpb.StorageRequest
+	9,  // 5: endorsementpb.EvmEndorsement.CodeAt:input_type -> endorsementpb.CodeRequest
+	11, // 6: endorsementpb.EvmEndorsement.NonceAt:input_type -> endorsementpb.NonceRequest
+	2,  // 7: endorsementpb.EvmEndorsement.Execute:output_type -> endorsementpb.ExecuteResponse
+	4,  // 8: endorsementpb.EvmEndorsement.Call:output_type -> endorsementpb.CallResponse
+	6,  // 9: endorsementpb.EvmEndorsement.BalanceAt:output_type -> endorsementpb.BalanceResponse
+	8,  // 10: endorsementpb.EvmEndorsement.StorageAt:output_type -> endorsementpb.StorageResponse
+	10, // 11: endorsementpb.EvmEndorsement.CodeAt:output_type -> endorsementpb.CodeResponse
+	12, // 12: endorsementpb.EvmEndorsement.NonceAt:output_type -> endorsementpb.NonceResponse
+	7,  // [7:13] is the sub-list for method output_type
+	1,  // [1:7] is the sub-list for method input_type
+	1,  // [1:1] is the sub-list for extension type_name
+	1,  // [1:1] is the sub-list for extension extendee
+	0,  // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_api_endorsementpb_endorsement_proto_init() }
@@ -847,18 +937,18 @@ func file_api_endorsementpb_endorsement_proto_init() {
 	if File_api_endorsementpb_endorsement_proto != nil {
 		return
 	}
-	file_api_endorsementpb_endorsement_proto_msgTypes[2].OneofWrappers = []any{}
-	file_api_endorsementpb_endorsement_proto_msgTypes[4].OneofWrappers = []any{}
-	file_api_endorsementpb_endorsement_proto_msgTypes[6].OneofWrappers = []any{}
-	file_api_endorsementpb_endorsement_proto_msgTypes[8].OneofWrappers = []any{}
-	file_api_endorsementpb_endorsement_proto_msgTypes[10].OneofWrappers = []any{}
+	file_api_endorsementpb_endorsement_proto_msgTypes[3].OneofWrappers = []any{}
+	file_api_endorsementpb_endorsement_proto_msgTypes[5].OneofWrappers = []any{}
+	file_api_endorsementpb_endorsement_proto_msgTypes[7].OneofWrappers = []any{}
+	file_api_endorsementpb_endorsement_proto_msgTypes[9].OneofWrappers = []any{}
+	file_api_endorsementpb_endorsement_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_endorsementpb_endorsement_proto_rawDesc), len(file_api_endorsementpb_endorsement_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/endorsementpb/endorsement.proto
+++ b/api/endorsementpb/endorsement.proto
@@ -33,6 +33,18 @@ message ExecuteRequest {
     // must carry it. Fabric-X does not need the proposal, so this is empty
     // there and the full proposal never crosses the wire.
     bytes proposal_hash = 2;
+
+    // Invocation built by the sender, which the endorser passes to the builder.
+    Invocation invocation = 3;
+}
+
+// Invocation carries the parts of the sender's invocation that the endorsement
+// builder consumes.
+message Invocation {
+    string tx_id = 1;
+    repeated bytes args = 2;
+    string chaincode_name = 3;
+    string chaincode_version = 4;
 }
 
 message ExecuteResponse {

--- a/endorser/server/handlers.go
+++ b/endorser/server/handlers.go
@@ -1,0 +1,136 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hyperledger/fabric-x-evm/api/endorsementpb"
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
+)
+
+// Execute endorses an Ethereum transaction. Application outcomes ride in the
+// response status; only transport faults surface as a gRPC error.
+func (s *Server) Execute(ctx context.Context, req *endorsementpb.ExecuteRequest) (*endorsementpb.ExecuteResponse, error) {
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(req.GetEthereumTx()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal tx: %v", err)
+	}
+	// Provisional: today the client builds the invocation (creator identity +
+	// proposal); the wire shape that carries it, and the fabricx.TxPackager
+	// change behind the Fabric-X "no proposal on the wire" decision, are
+	// finalized with the client PR (#244). Until then the server forwards with
+	// an empty invocation; req.proposal_hash is reserved for classic Fabric.
+	resp, err := s.svc.Execute(ctx, endorsement.Invocation{}, tx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "execute: %v", err)
+	}
+	return executeResponse(resp), nil
+}
+
+// Call runs a read-only eth_call. A revert or failed execution is an
+// application outcome carried in the response; only transport faults are a
+// gRPC error.
+func (s *Server) Call(ctx context.Context, req *endorsementpb.CallRequest) (*endorsementpb.CallResponse, error) {
+	out, err := s.svc.Call(ctx, callMsg(req), blockNumber(req.BlockNumber))
+	if err != nil {
+		var ce *common.CallError
+		if errors.As(err, &ce) {
+			return &endorsementpb.CallResponse{ReturnData: ce.Data, Status: ce.Status, Message: ce.Message}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "call: %v", err)
+	}
+	return &endorsementpb.CallResponse{ReturnData: out, Status: common.StatusOK}, nil
+}
+
+func (s *Server) BalanceAt(ctx context.Context, req *endorsementpb.BalanceRequest) (*endorsementpb.BalanceResponse, error) {
+	bal, err := s.svc.BalanceAt(ctx, ethcommon.BytesToAddress(req.GetAccount()), blockNumber(req.BlockNumber))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "balance: %v", err)
+	}
+	return &endorsementpb.BalanceResponse{Balance: bal.Bytes()}, nil
+}
+
+func (s *Server) StorageAt(ctx context.Context, req *endorsementpb.StorageRequest) (*endorsementpb.StorageResponse, error) {
+	val, err := s.svc.StorageAt(ctx, ethcommon.BytesToAddress(req.GetAccount()), ethcommon.BytesToHash(req.GetKey()), blockNumber(req.BlockNumber))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "storage: %v", err)
+	}
+	return &endorsementpb.StorageResponse{Value: val}, nil
+}
+
+func (s *Server) CodeAt(ctx context.Context, req *endorsementpb.CodeRequest) (*endorsementpb.CodeResponse, error) {
+	code, err := s.svc.CodeAt(ctx, ethcommon.BytesToAddress(req.GetAccount()), blockNumber(req.BlockNumber))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "code: %v", err)
+	}
+	return &endorsementpb.CodeResponse{Code: code}, nil
+}
+
+func (s *Server) NonceAt(ctx context.Context, req *endorsementpb.NonceRequest) (*endorsementpb.NonceResponse, error) {
+	nonce, err := s.svc.NonceAt(ctx, ethcommon.BytesToAddress(req.GetAccount()), blockNumber(req.BlockNumber))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "nonce: %v", err)
+	}
+	return &endorsementpb.NonceResponse{Nonce: nonce}, nil
+}
+
+// blockNumber turns the optional block selector into the *big.Int the engine
+// expects; a nil selector means latest.
+func blockNumber(bn *uint64) *big.Int {
+	if bn == nil {
+		return nil
+	}
+	return new(big.Int).SetUint64(*bn)
+}
+
+// callMsg builds an ethereum.CallMsg from the request fields. Empty from/to are
+// left unset; gas price and value are big-endian integer bytes.
+func callMsg(req *endorsementpb.CallRequest) *ethereum.CallMsg {
+	msg := &ethereum.CallMsg{Gas: req.GetGas(), Data: req.GetData()}
+	if from := req.GetFrom(); len(from) > 0 {
+		msg.From = ethcommon.BytesToAddress(from)
+	}
+	if to := req.GetTo(); len(to) > 0 {
+		addr := ethcommon.BytesToAddress(to)
+		msg.To = &addr
+	}
+	if gp := req.GetGasPrice(); len(gp) > 0 {
+		msg.GasPrice = new(big.Int).SetBytes(gp)
+	}
+	if v := req.GetValue(); len(v) > 0 {
+		msg.Value = new(big.Int).SetBytes(v)
+	}
+	return msg
+}
+
+// executeResponse maps the endorser's ProposalResponse onto the wire response.
+// The read-write set and event live inside the payload today; splitting them
+// into their own fields is finalized with the client PR (#244).
+func executeResponse(pr *peer.ProposalResponse) *endorsementpb.ExecuteResponse {
+	out := &endorsementpb.ExecuteResponse{}
+	if r := pr.GetResponse(); r != nil {
+		out.Status = r.Status
+		out.Message = r.Message
+		out.Payload = r.Payload
+	}
+	if e := pr.GetEndorsement(); e != nil {
+		out.EndorserId = e.Endorser
+		out.Signature = e.Signature
+	}
+	return out
+}

--- a/endorser/server/handlers.go
+++ b/endorser/server/handlers.go
@@ -30,34 +30,27 @@ func (s *Server) Execute(ctx context.Context, req *endorsementpb.ExecuteRequest)
 	if err := tx.UnmarshalBinary(req.GetEthereumTx()); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal tx: %v", err)
 	}
-	inv, err := s.invocation(req.GetEthereumTx(), req.GetProposalHash())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "build invocation: %v", err)
-	}
-	resp, err := s.svc.Execute(ctx, inv, tx)
+	resp, err := s.svc.Execute(ctx, invocation(req), tx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "execute: %v", err)
 	}
 	return executeResponse(resp), nil
 }
 
-// invocation rebuilds the endorsement invocation from the transaction using the
-// endorser's identity and namespace, keeping the caller's proposal hash when set.
-func (s *Server) invocation(ethTx, proposalHash []byte) (endorsement.Invocation, error) {
-	args := [][]byte{{byte(common.ProposalTypeEVMTx)}, ethTx}
-	inv, err := endorsement.NewInvocation(s.signer, s.channel, s.namespace, s.nsVersion, args)
-	if err != nil {
-		return endorsement.Invocation{}, err
+// invocation maps the sender's invocation onto the endorsement invocation the
+// builder consumes.
+func invocation(req *endorsementpb.ExecuteRequest) endorsement.Invocation {
+	i := req.GetInvocation()
+	return endorsement.Invocation{
+		TxID:         i.GetTxId(),
+		Args:         i.GetArgs(),
+		CCID:         &peer.ChaincodeID{Name: i.GetChaincodeName(), Version: i.GetChaincodeVersion()},
+		ProposalHash: req.GetProposalHash(),
 	}
-	if len(proposalHash) > 0 {
-		inv.ProposalHash = proposalHash
-	}
-	return inv, nil
 }
 
-// Call runs a read-only eth_call. A revert or failed execution is an
-// application outcome carried in the response; only transport faults are a
-// gRPC error.
+// Call runs a read-only eth_call. A revert or failed execution is carried in
+// the response; only transport faults are a gRPC error.
 func (s *Server) Call(ctx context.Context, req *endorsementpb.CallRequest) (*endorsementpb.CallResponse, error) {
 	out, err := s.svc.Call(ctx, callMsg(req), blockNumber(req.BlockNumber))
 	if err != nil {

--- a/endorser/server/handlers.go
+++ b/endorser/server/handlers.go
@@ -30,16 +30,29 @@ func (s *Server) Execute(ctx context.Context, req *endorsementpb.ExecuteRequest)
 	if err := tx.UnmarshalBinary(req.GetEthereumTx()); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal tx: %v", err)
 	}
-	// Provisional: today the client builds the invocation (creator identity +
-	// proposal); the wire shape that carries it, and the fabricx.TxPackager
-	// change behind the Fabric-X "no proposal on the wire" decision, are
-	// finalized with the client PR (#244). Until then the server forwards with
-	// an empty invocation; req.proposal_hash is reserved for classic Fabric.
-	resp, err := s.svc.Execute(ctx, endorsement.Invocation{}, tx)
+	inv, err := s.invocation(req.GetEthereumTx(), req.GetProposalHash())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build invocation: %v", err)
+	}
+	resp, err := s.svc.Execute(ctx, inv, tx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "execute: %v", err)
 	}
 	return executeResponse(resp), nil
+}
+
+// invocation rebuilds the endorsement invocation from the transaction using the
+// endorser's identity and namespace, keeping the caller's proposal hash when set.
+func (s *Server) invocation(ethTx, proposalHash []byte) (endorsement.Invocation, error) {
+	args := [][]byte{{byte(common.ProposalTypeEVMTx)}, ethTx}
+	inv, err := endorsement.NewInvocation(s.signer, s.channel, s.namespace, s.nsVersion, args)
+	if err != nil {
+		return endorsement.Invocation{}, err
+	}
+	if len(proposalHash) > 0 {
+		inv.ProposalHash = proposalHash
+	}
+	return inv, nil
 }
 
 // Call runs a read-only eth_call. A revert or failed execution is an
@@ -48,8 +61,7 @@ func (s *Server) Execute(ctx context.Context, req *endorsementpb.ExecuteRequest)
 func (s *Server) Call(ctx context.Context, req *endorsementpb.CallRequest) (*endorsementpb.CallResponse, error) {
 	out, err := s.svc.Call(ctx, callMsg(req), blockNumber(req.BlockNumber))
 	if err != nil {
-		var ce *common.CallError
-		if errors.As(err, &ce) {
+		if ce, ok := errors.AsType[*common.CallError](err); ok {
 			return &endorsementpb.CallResponse{ReturnData: ce.Data, Status: ce.Status, Message: ce.Message}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "call: %v", err)
@@ -119,8 +131,6 @@ func callMsg(req *endorsementpb.CallRequest) *ethereum.CallMsg {
 }
 
 // executeResponse maps the endorser's ProposalResponse onto the wire response.
-// The read-write set and event live inside the payload today; splitting them
-// into their own fields is finalized with the client PR (#244).
 func executeResponse(pr *peer.ProposalResponse) *endorsementpb.ExecuteResponse {
 	out := &endorsementpb.ExecuteResponse{}
 	if r := pr.GetResponse(); r != nil {

--- a/endorser/server/server.go
+++ b/endorser/server/server.go
@@ -1,0 +1,53 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+// Package server exposes the endorser over gRPC by adapting the EvmEndorsement
+// service onto the in-process endorser through the api.Service seam. It is
+// dormant: nothing starts or dials it until the enable step (#246).
+package server
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric-x-committer/utils/serve"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/hyperledger/fabric-x-evm/api/endorsementpb"
+	"github.com/hyperledger/fabric-x-evm/endorser/api"
+)
+
+// Config is the gRPC server configuration (endpoint, mTLS, keep-alive,
+// max-concurrent-streams, rate-limit). It is the serve package's own config.
+//
+// serve is sourced from fabric-x-committer for now; once it is published into
+// fabric-x-common (committer#675) this alias moves there, a mechanical change.
+type Config = serve.Config
+
+// Server adapts the EvmEndorsement gRPC service onto an api.Service.
+type Server struct {
+	endorsementpb.UnimplementedEvmEndorsementServer
+	svc api.Service
+}
+
+// New returns a Server backed by the given endorser service.
+func New(svc api.Service) *Server {
+	return &Server{svc: svc}
+}
+
+// RegisterService registers the endorsement and health services on the gRPC
+// server. It implements serve.Registerer so the server can be bootstrapped by
+// the serve package.
+func (s *Server) RegisterService(servers serve.Servers) {
+	endorsementpb.RegisterEvmEndorsementServer(servers.GRPC, s)
+	healthpb.RegisterHealthServer(servers.GRPC, health.NewServer())
+}
+
+// Serve bootstraps the gRPC server (listen, mTLS, keep-alive, limits, health)
+// from cfg and serves until ctx is done. Dormant until wired by the enable step.
+func (s *Server) Serve(ctx context.Context, cfg *Config) error {
+	return serve.Serve(ctx, s, cfg)
+}

--- a/endorser/server/server.go
+++ b/endorser/server/server.go
@@ -5,14 +5,14 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 */
 
 // Package server exposes the endorser over gRPC by adapting the EvmEndorsement
-// service onto the in-process endorser through the api.Service seam. It is
-// dormant: nothing starts or dials it until the enable step (#246).
+// service onto the in-process endorser through the api.Service seam.
 package server
 
 import (
 	"context"
 
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
+	sdk "github.com/hyperledger/fabric-x-sdk"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
@@ -21,21 +21,26 @@ import (
 )
 
 // Config is the gRPC server configuration (endpoint, mTLS, keep-alive,
-// max-concurrent-streams, rate-limit). It is the serve package's own config.
+// max-concurrent-streams, rate-limit).
 //
-// serve is sourced from fabric-x-committer for now; once it is published into
-// fabric-x-common (committer#675) this alias moves there, a mechanical change.
+// TODO: switch to fabric-x-common's serve once it is available there.
 type Config = serve.Config
 
 // Server adapts the EvmEndorsement gRPC service onto an api.Service.
 type Server struct {
 	endorsementpb.UnimplementedEvmEndorsementServer
-	svc api.Service
+	svc       api.Service
+	signer    sdk.Signer
+	channel   string
+	namespace string
+	nsVersion string
 }
 
-// New returns a Server backed by the given endorser service.
-func New(svc api.Service) *Server {
-	return &Server{svc: svc}
+// New returns a Server backed by the given endorser service. The signer,
+// channel, namespace, and version rebuild the endorsement invocation from an
+// incoming transaction.
+func New(svc api.Service, signer sdk.Signer, channel, namespace, nsVersion string) *Server {
+	return &Server{svc: svc, signer: signer, channel: channel, namespace: namespace, nsVersion: nsVersion}
 }
 
 // RegisterService registers the endorsement and health services on the gRPC
@@ -47,7 +52,7 @@ func (s *Server) RegisterService(servers serve.Servers) {
 }
 
 // Serve bootstraps the gRPC server (listen, mTLS, keep-alive, limits, health)
-// from cfg and serves until ctx is done. Dormant until wired by the enable step.
+// from cfg and serves until ctx is done.
 func (s *Server) Serve(ctx context.Context, cfg *Config) error {
 	return serve.Serve(ctx, s, cfg)
 }

--- a/endorser/server/server.go
+++ b/endorser/server/server.go
@@ -12,7 +12,6 @@ import (
 	"context"
 
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
-	sdk "github.com/hyperledger/fabric-x-sdk"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
@@ -29,23 +28,15 @@ type Config = serve.Config
 // Server adapts the EvmEndorsement gRPC service onto an api.Service.
 type Server struct {
 	endorsementpb.UnimplementedEvmEndorsementServer
-	svc       api.Service
-	signer    sdk.Signer
-	channel   string
-	namespace string
-	nsVersion string
+	svc api.Service
 }
 
-// New returns a Server backed by the given endorser service. The signer,
-// channel, namespace, and version rebuild the endorsement invocation from an
-// incoming transaction.
-func New(svc api.Service, signer sdk.Signer, channel, namespace, nsVersion string) *Server {
-	return &Server{svc: svc, signer: signer, channel: channel, namespace: namespace, nsVersion: nsVersion}
+// New returns a Server backed by the given endorser service.
+func New(svc api.Service) *Server {
+	return &Server{svc: svc}
 }
 
-// RegisterService registers the endorsement and health services on the gRPC
-// server. It implements serve.Registerer so the server can be bootstrapped by
-// the serve package.
+// RegisterService registers the endorsement and health services on the gRPC server.
 func (s *Server) RegisterService(servers serve.Servers) {
 	endorsementpb.RegisterEvmEndorsementServer(servers.GRPC, s)
 	healthpb.RegisterHealthServer(servers.GRPC, health.NewServer())

--- a/endorser/server/server_test.go
+++ b/endorser/server/server_test.go
@@ -62,13 +62,18 @@ func (s *stubService) NonceAt(_ context.Context, _ ethcommon.Address, _ *big.Int
 	return s.nonce, s.readErr
 }
 
+type stubSigner struct{}
+
+func (stubSigner) Sign([]byte) ([]byte, error) { return []byte("sig"), nil }
+func (stubSigner) Serialize() ([]byte, error)  { return []byte("creator"), nil }
+
 // newTestClient stands up the Server on an in-memory bufconn connection and
 // returns a client wired to it.
 func newTestClient(t *testing.T, svc *stubService) endorsementpb.EvmEndorsementClient {
 	t.Helper()
 	lis := bufconn.Listen(1024 * 1024)
 	gs := grpc.NewServer()
-	endorsementpb.RegisterEvmEndorsementServer(gs, New(svc))
+	endorsementpb.RegisterEvmEndorsementServer(gs, New(svc, stubSigner{}, "ch", "ns", "1.0"))
 	go func() { _ = gs.Serve(lis) }()
 	t.Cleanup(gs.Stop)
 

--- a/endorser/server/server_test.go
+++ b/endorser/server/server_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/hyperledger/fabric-x-evm/api/endorsementpb"
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-sdk/endorsement"
+)
+
+// stubService is an api.Service returning fixed values, so the handlers can be
+// exercised without a real endorser.
+type stubService struct {
+	execResp *peer.ProposalResponse
+	execErr  error
+	callOut  []byte
+	callErr  error
+	balance  *big.Int
+	storage  []byte
+	code     []byte
+	nonce    uint64
+	readErr  error
+}
+
+func (s *stubService) Execute(_ context.Context, _ endorsement.Invocation, _ *types.Transaction) (*peer.ProposalResponse, error) {
+	return s.execResp, s.execErr
+}
+func (s *stubService) Call(_ context.Context, _ *ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	return s.callOut, s.callErr
+}
+func (s *stubService) BalanceAt(_ context.Context, _ ethcommon.Address, _ *big.Int) (*big.Int, error) {
+	return s.balance, s.readErr
+}
+func (s *stubService) StorageAt(_ context.Context, _ ethcommon.Address, _ ethcommon.Hash, _ *big.Int) ([]byte, error) {
+	return s.storage, s.readErr
+}
+func (s *stubService) CodeAt(_ context.Context, _ ethcommon.Address, _ *big.Int) ([]byte, error) {
+	return s.code, s.readErr
+}
+func (s *stubService) NonceAt(_ context.Context, _ ethcommon.Address, _ *big.Int) (uint64, error) {
+	return s.nonce, s.readErr
+}
+
+// newTestClient stands up the Server on an in-memory bufconn connection and
+// returns a client wired to it.
+func newTestClient(t *testing.T, svc *stubService) endorsementpb.EvmEndorsementClient {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	gs := grpc.NewServer()
+	endorsementpb.RegisterEvmEndorsementServer(gs, New(svc))
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return endorsementpb.NewEvmEndorsementClient(conn)
+}
+
+func TestBalanceAt_Forwards(t *testing.T) {
+	client := newTestClient(t, &stubService{balance: big.NewInt(42)})
+
+	resp, err := client.BalanceAt(context.Background(), &endorsementpb.BalanceRequest{Account: ethcommon.Address{}.Bytes()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := new(big.Int).SetBytes(resp.GetBalance()); got.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("balance = %v, want 42", got)
+	}
+}
+
+func TestStorageAt_Forwards(t *testing.T) {
+	want := []byte{0x11, 0x22}
+	client := newTestClient(t, &stubService{storage: want})
+
+	resp, err := client.StorageAt(context.Background(), &endorsementpb.StorageRequest{Account: ethcommon.Address{}.Bytes(), Key: ethcommon.Hash{}.Bytes()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(resp.GetValue(), want) {
+		t.Errorf("value = %x, want %x", resp.GetValue(), want)
+	}
+}
+
+func TestCodeAt_Forwards(t *testing.T) {
+	want := []byte{0xfe, 0xed}
+	client := newTestClient(t, &stubService{code: want})
+
+	resp, err := client.CodeAt(context.Background(), &endorsementpb.CodeRequest{Account: ethcommon.Address{}.Bytes()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(resp.GetCode(), want) {
+		t.Errorf("code = %x, want %x", resp.GetCode(), want)
+	}
+}
+
+func TestNonceAt_Forwards(t *testing.T) {
+	client := newTestClient(t, &stubService{nonce: 7})
+
+	resp, err := client.NonceAt(context.Background(), &endorsementpb.NonceRequest{Account: ethcommon.Address{}.Bytes()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetNonce() != 7 {
+		t.Errorf("nonce = %d, want 7", resp.GetNonce())
+	}
+}
+
+func TestReadError_IsGRPCError(t *testing.T) {
+	client := newTestClient(t, &stubService{readErr: errors.New("db down")})
+
+	_, err := client.BalanceAt(context.Background(), &endorsementpb.BalanceRequest{Account: ethcommon.Address{}.Bytes()})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal", status.Code(err))
+	}
+}
+
+func TestCall_Success(t *testing.T) {
+	want := []byte{0xde, 0xad}
+	client := newTestClient(t, &stubService{callOut: want})
+
+	resp, err := client.Call(context.Background(), &endorsementpb.CallRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(resp.GetReturnData(), want) {
+		t.Errorf("returnData = %x, want %x", resp.GetReturnData(), want)
+	}
+	if resp.GetStatus() != common.StatusOK {
+		t.Errorf("status = %d, want %d", resp.GetStatus(), common.StatusOK)
+	}
+}
+
+// A revert is an application outcome: it comes back in the response status, not
+// as a gRPC error, and carries the revert payload.
+func TestCall_RevertIsInBand(t *testing.T) {
+	data := []byte{0x08, 0xc3, 0x79, 0xa0}
+	client := newTestClient(t, &stubService{
+		callErr: &common.CallError{Status: common.StatusEVMRevert, Message: "reverted", Data: data},
+	})
+
+	resp, err := client.Call(context.Background(), &endorsementpb.CallRequest{})
+	if err != nil {
+		t.Fatalf("revert must not be a gRPC error, got: %v", err)
+	}
+	if resp.GetStatus() != common.StatusEVMRevert {
+		t.Errorf("status = %d, want %d", resp.GetStatus(), common.StatusEVMRevert)
+	}
+	if resp.GetMessage() != "reverted" || !bytes.Equal(resp.GetReturnData(), data) {
+		t.Errorf("message = %q, data = %x", resp.GetMessage(), resp.GetReturnData())
+	}
+}
+
+// A non-CallError from Call is a transport fault and surfaces as a gRPC error.
+func TestCall_TransportErrorIsGRPCError(t *testing.T) {
+	client := newTestClient(t, &stubService{callErr: errors.New("connection reset")})
+
+	_, err := client.Call(context.Background(), &endorsementpb.CallRequest{})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal", status.Code(err))
+	}
+}
+
+func TestExecute_MapsProposalResponse(t *testing.T) {
+	pr := &peer.ProposalResponse{
+		Response:    &peer.Response{Status: common.StatusEVMRevert, Message: "reverted", Payload: []byte{0x01}},
+		Endorsement: &peer.Endorsement{Endorser: []byte("id"), Signature: []byte("sig")},
+	}
+	client := newTestClient(t, &stubService{execResp: pr})
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 0, Gas: 21000, GasPrice: big.NewInt(1)})
+	raw, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal tx: %v", err)
+	}
+
+	resp, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{EthereumTx: raw})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetStatus() != common.StatusEVMRevert || resp.GetMessage() != "reverted" {
+		t.Errorf("status = %d, message = %q", resp.GetStatus(), resp.GetMessage())
+	}
+	if !bytes.Equal(resp.GetEndorserId(), []byte("id")) || !bytes.Equal(resp.GetSignature(), []byte("sig")) {
+		t.Errorf("endorserId = %x, signature = %x", resp.GetEndorserId(), resp.GetSignature())
+	}
+}
+
+func TestExecute_InvalidTxIsInvalidArgument(t *testing.T) {
+	client := newTestClient(t, &stubService{})
+
+	_, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{EthereumTx: []byte("not a tx")})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestExecute_TransportErrorIsGRPCError(t *testing.T) {
+	client := newTestClient(t, &stubService{execErr: errors.New("engine down")})
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 0, Gas: 21000, GasPrice: big.NewInt(1)})
+	raw, _ := tx.MarshalBinary()
+
+	_, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{EthereumTx: raw})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal", status.Code(err))
+	}
+}

--- a/endorser/server/server_test.go
+++ b/endorser/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-committer/utils/serve"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -41,12 +42,19 @@ type stubService struct {
 	code     []byte
 	nonce    uint64
 	readErr  error
+
+	// captured from the last call, so tests can assert what was forwarded
+	gotInv   endorsement.Invocation
+	gotMsg   *ethereum.CallMsg
+	gotBlock *big.Int
 }
 
-func (s *stubService) Execute(_ context.Context, _ endorsement.Invocation, _ *types.Transaction) (*peer.ProposalResponse, error) {
+func (s *stubService) Execute(_ context.Context, inv endorsement.Invocation, _ *types.Transaction) (*peer.ProposalResponse, error) {
+	s.gotInv = inv
 	return s.execResp, s.execErr
 }
-func (s *stubService) Call(_ context.Context, _ *ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+func (s *stubService) Call(_ context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	s.gotMsg, s.gotBlock = msg, blockNumber
 	return s.callOut, s.callErr
 }
 func (s *stubService) BalanceAt(_ context.Context, _ ethcommon.Address, _ *big.Int) (*big.Int, error) {
@@ -62,18 +70,13 @@ func (s *stubService) NonceAt(_ context.Context, _ ethcommon.Address, _ *big.Int
 	return s.nonce, s.readErr
 }
 
-type stubSigner struct{}
-
-func (stubSigner) Sign([]byte) ([]byte, error) { return []byte("sig"), nil }
-func (stubSigner) Serialize() ([]byte, error)  { return []byte("creator"), nil }
-
 // newTestClient stands up the Server on an in-memory bufconn connection and
 // returns a client wired to it.
 func newTestClient(t *testing.T, svc *stubService) endorsementpb.EvmEndorsementClient {
 	t.Helper()
 	lis := bufconn.Listen(1024 * 1024)
 	gs := grpc.NewServer()
-	endorsementpb.RegisterEvmEndorsementServer(gs, New(svc, stubSigner{}, "ch", "ns", "1.0"))
+	endorsementpb.RegisterEvmEndorsementServer(gs, New(svc))
 	go func() { _ = gs.Serve(lis) }()
 	t.Cleanup(gs.Stop)
 
@@ -137,12 +140,39 @@ func TestNonceAt_Forwards(t *testing.T) {
 	}
 }
 
-func TestReadError_IsGRPCError(t *testing.T) {
-	client := newTestClient(t, &stubService{readErr: errors.New("db down")})
-
-	_, err := client.BalanceAt(context.Background(), &endorsementpb.BalanceRequest{Account: ethcommon.Address{}.Bytes()})
-	if status.Code(err) != codes.Internal {
-		t.Fatalf("code = %v, want Internal", status.Code(err))
+// A failed state read is infrastructure, not an application outcome, so every
+// reader surfaces it as a gRPC error.
+func TestReadErrors_AreGRPCErrors(t *testing.T) {
+	ctx := context.Background()
+	addr := ethcommon.Address{}.Bytes()
+	tests := []struct {
+		name string
+		call func(endorsementpb.EvmEndorsementClient) error
+	}{
+		{"balance", func(c endorsementpb.EvmEndorsementClient) error {
+			_, err := c.BalanceAt(ctx, &endorsementpb.BalanceRequest{Account: addr})
+			return err
+		}},
+		{"storage", func(c endorsementpb.EvmEndorsementClient) error {
+			_, err := c.StorageAt(ctx, &endorsementpb.StorageRequest{Account: addr, Key: ethcommon.Hash{}.Bytes()})
+			return err
+		}},
+		{"code", func(c endorsementpb.EvmEndorsementClient) error {
+			_, err := c.CodeAt(ctx, &endorsementpb.CodeRequest{Account: addr})
+			return err
+		}},
+		{"nonce", func(c endorsementpb.EvmEndorsementClient) error {
+			_, err := c.NonceAt(ctx, &endorsementpb.NonceRequest{Account: addr})
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, &stubService{readErr: errors.New("db down")})
+			if got := status.Code(tt.call(client)); got != codes.Internal {
+				t.Errorf("code = %v, want Internal", got)
+			}
+		})
 	}
 }
 
@@ -235,5 +265,110 @@ func TestExecute_TransportErrorIsGRPCError(t *testing.T) {
 	_, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{EthereumTx: raw})
 	if status.Code(err) != codes.Internal {
 		t.Fatalf("code = %v, want Internal", status.Code(err))
+	}
+}
+
+// The sender's invocation is mapped onto the invocation the builder consumes.
+func TestExecute_ForwardsInvocation(t *testing.T) {
+	svc := &stubService{execResp: &peer.ProposalResponse{Response: &peer.Response{Status: common.StatusOK}}}
+	client := newTestClient(t, svc)
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 0, Gas: 21000, GasPrice: big.NewInt(1)})
+	raw, _ := tx.MarshalBinary()
+
+	_, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{
+		EthereumTx:   raw,
+		ProposalHash: []byte{0xaa},
+		Invocation: &endorsementpb.Invocation{
+			TxId:             "tx-1",
+			Args:             [][]byte{{0xfb}, raw},
+			ChaincodeName:    "evm",
+			ChaincodeVersion: "1.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := svc.gotInv
+	if got.TxID != "tx-1" {
+		t.Errorf("TxID = %q, want tx-1", got.TxID)
+	}
+	if got.CCID.GetName() != "evm" || got.CCID.GetVersion() != "1.0" {
+		t.Errorf("CCID = %v", got.CCID)
+	}
+	if !bytes.Equal(got.ProposalHash, []byte{0xaa}) {
+		t.Errorf("ProposalHash = %x, want aa", got.ProposalHash)
+	}
+	if len(got.Args) != 2 {
+		t.Errorf("Args = %d, want 2", len(got.Args))
+	}
+}
+
+// A response carrying neither a Response nor an Endorsement maps to an empty result.
+func TestExecute_EmptyProposalResponse(t *testing.T) {
+	client := newTestClient(t, &stubService{execResp: &peer.ProposalResponse{}})
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 0, Gas: 21000, GasPrice: big.NewInt(1)})
+	raw, _ := tx.MarshalBinary()
+
+	resp, err := client.Execute(context.Background(), &endorsementpb.ExecuteRequest{EthereumTx: raw})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetStatus() != 0 || len(resp.GetEndorserId()) != 0 || len(resp.GetSignature()) != 0 {
+		t.Errorf("resp = %+v, want empty", resp)
+	}
+}
+
+// Every optional call field and the block selector reach the engine.
+func TestCall_ForwardsAllFields(t *testing.T) {
+	svc := &stubService{callOut: []byte{0x01}}
+	client := newTestClient(t, svc)
+
+	from := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	to := ethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	blockNumber := uint64(7)
+
+	if _, err := client.Call(context.Background(), &endorsementpb.CallRequest{
+		From:        from.Bytes(),
+		To:          to.Bytes(),
+		Gas:         21000,
+		GasPrice:    big.NewInt(5).Bytes(),
+		Value:       big.NewInt(9).Bytes(),
+		Data:        []byte{0xde, 0xad},
+		BlockNumber: &blockNumber,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msg := svc.gotMsg
+	if msg.From != from {
+		t.Errorf("From = %s, want %s", msg.From, from)
+	}
+	if msg.To == nil || *msg.To != to {
+		t.Errorf("To = %v, want %s", msg.To, to)
+	}
+	if msg.Gas != 21000 || msg.GasPrice.Int64() != 5 || msg.Value.Int64() != 9 {
+		t.Errorf("gas = %d, gasPrice = %v, value = %v", msg.Gas, msg.GasPrice, msg.Value)
+	}
+	if !bytes.Equal(msg.Data, []byte{0xde, 0xad}) {
+		t.Errorf("Data = %x", msg.Data)
+	}
+	if svc.gotBlock == nil || svc.gotBlock.Uint64() != 7 {
+		t.Errorf("blockNumber = %v, want 7", svc.gotBlock)
+	}
+}
+
+// RegisterService exposes both the endorsement and health services.
+func TestRegisterService(t *testing.T) {
+	gs := grpc.NewServer()
+	New(&stubService{}).RegisterService(serve.Servers{GRPC: gs})
+
+	info := gs.GetServiceInfo()
+	for _, name := range []string{"endorsementpb.EvmEndorsement", "grpc.health.v1.Health"} {
+		if _, ok := info[name]; !ok {
+			t.Errorf("%s not registered", name)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/holiman/uint256 v1.3.2
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
+	github.com/hyperledger/fabric-x-committer v1.0.4
 	github.com/hyperledger/fabric-x-common v0.2.8
 	github.com/hyperledger/fabric-x-sdk v0.0.0-20260716122159-9451eea280d6
 	github.com/prometheus/client_golang v1.23.2
@@ -43,6 +44,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cockroachdb/errors v1.14.0 // indirect
@@ -93,11 +95,13 @@ require (
 	github.com/hyperledger-labs/SmartBFT v1.0.1 // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 // indirect
 	github.com/hyperledger/fabric-x v1.0.1 // indirect
-	github.com/hyperledger/fabric-x-committer v1.0.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/influxdata/influxdb-client-go/v2 v2.4.0 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
@@ -143,6 +147,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.5 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+	github.com/yugabyte/pgx/v5 v5.7.6-yb-1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=


### PR DESCRIPTION
Closes #243 

Adds a **dormant** gRPC server that implements the `EvmEndorsement` service by forwarding the six RPCs to the in-process endorser through the `api.Service` interface. Nothing starts or dials it yet; it is exercised only by unit tests.

## What's here (`endorser/server`)

- `server.go`
  - Implements `Server` (embedding `UnimplementedEvmEndorsementServer` and holding an `api.Service`)
  - Adds `RegisterService` (endorsement service + gRPC health)
  - Adds `Serve`
  - Defines `type Config = serve.Config`
- `handlers.go`
  - Implements the six RPC handlers
  - The five state reads and `Call` forward directly
  - `Call` carries application outcomes (revert, execution failure, rejected transaction) in-band through the response status/message/data, reserving gRPC errors for transport failures
- `server_test.go`
  - Adds unit tests using an in-memory `bufconn` connection with a stub `api.Service`
  - Covers handler forwarding, response status mapping, the application-vs-transport error split, and `Execute` forwarding

## Execute

`Execute` reconstructs the `Invocation` server-side from the transaction (arguments `[{proposalType}, ethTxBytes]`, the endorser's namespace, and the caller's proposal hash when present) before forwarding it to the existing builder.

For Fabric-X, the builder only requires the arguments, chaincode name, and transaction ID. Owning our own `EndorsementBuilder` and removing the proposal entirely is tracked separately in #265.

## Bootstrap (`serve`)

Server bootstrap (listener, mTLS, keep-alives, limits, and health) currently comes from `serve` in **fabric-x-committer**, allowing the server to be implemented and reviewed.

Once `fabric-x-committer#675` publishes `serve` into `fabric-x-common`, the import will be switched (tracked in #266).

Because of this, `go mod tidy` promotes `fabric-x-committer` to a direct dependency, bringing in a few transitive dependencies (for example `pgx` and `backoff`) that will disappear once the migration to `fabric-x-common` is complete.


## Tests

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt` (no changes)
- [x] Unit tests pass
