### PR TITLE
fix: blocknumber sentinel values

### DIFF
--- a/endorser/execution/executor.go
+++ b/endorser/execution/executor.go
@@ -154,13 +154,21 @@ func (e *EVMEngine) NonceAt(_ context.Context, account common.Address, blockNumb
 	return snap.GetNonce(account), nil
 }
 
+// resolveStateBlockNumber converts a state-query block number to the KVSSnapshotter
+// convention (0 = latest). nil and any negative value (an unresolved go-ethereum block-tag
+// sentinel) resolve to 0/latest rather than corrupting via *big.Int.Uint64()'s absolute-value
+// conversion.
+func resolveStateBlockNumber(blockNumber *big.Int) uint64 {
+	if blockNumber == nil || blockNumber.Sign() < 0 {
+		return 0
+	}
+	return blockNumber.Uint64()
+}
+
 // newExecutor creates a fresh executor with an isolated StateDB.
 // blockNumber selects the Fabric block height for the state snapshot (nil = latest).
 func (e *EVMEngine) newExecutor(blockNumber *big.Int) (*Executor, error) {
-	var stateBlockNum uint64
-	if blockNumber != nil {
-		stateBlockNum = blockNumber.Uint64()
-	}
+	stateBlockNum := resolveStateBlockNumber(blockNumber)
 
 	// Begin a new reader to get snapshot isolation
 	reader, err := e.kvs.NewSnapshot(stateBlockNum)
@@ -190,10 +198,7 @@ func (e *EVMEngine) newExecutor(blockNumber *big.Int) (*Executor, error) {
 // newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height (0 = latest).
 // The caller must close the returned reader when done.
 func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, ReadStore, error) {
-	blockNum := uint64(0)
-	if blockNumber != nil {
-		blockNum = blockNumber.Uint64()
-	}
+	blockNum := resolveStateBlockNumber(blockNumber)
 
 	// Begin a new reader to get snapshot isolation
 	reader, err := e.kvs.NewSnapshot(blockNum)

--- a/endorser/execution/executor_test.go
+++ b/endorser/execution/executor_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package execution
 
 import (
+	"context"
+	"math/big"
 	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -115,5 +117,66 @@ func TestNewExecutor_BareStateDBWhenDebugDisabled(t *testing.T) {
 
 	if _, ok := ex.state.(*StateDB); !ok {
 		t.Fatalf("expected *StateDB, got %T", ex.state)
+	}
+}
+
+// TestNewSnapshotAt_NegativeBlockNumberResolvesToLatest guards against callers upstream
+// handing this engine a negative *big.Int carrying an unresolved go-ethereum block-tag
+// sentinel (e.g. "earliest" == -5 in the pinned go-ethereum version). blockNumber.Uint64()
+// on a negative big.Int silently returns the absolute value instead of erroring, so
+// "earliest" would resolve to block 5 instead of "latest" — returning real but wrong
+// state instead of failing loudly.
+func TestNewSnapshotAt_NegativeBlockNumberResolvesToLatest(t *testing.T) {
+	backend, err := state.NewWriteDB(Channel, "file:exec_negblock_snapshot?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvs := &testVersionedDBSnapshotter{db: backend}
+	cfg := EVMConfig{ChainConfig: common.BuildChainConfig(4011)}
+	eng := NewEVMEngine(Namespace, kvs, cfg, false)
+
+	wantLatest, err := backend.BlockNumber(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, reader, err := eng.newSnapshotAt(big.NewInt(-5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	got := reader.(*testVersionedDBReader).blockNumber
+	if got != wantLatest {
+		t.Errorf("newSnapshotAt(-5) resolved to block %d, want latest (%d)", got, wantLatest)
+	}
+}
+
+// TestNewExecutor_NegativeBlockNumberResolvesToLatest is the newExecutor counterpart of
+// TestNewSnapshotAt_NegativeBlockNumberResolvesToLatest; it backs eth_call/eth_estimateGas
+// rather than eth_getBalance/eth_getCode/eth_getStorageAt/eth_getTransactionCount.
+func TestNewExecutor_NegativeBlockNumberResolvesToLatest(t *testing.T) {
+	backend, err := state.NewWriteDB(Channel, "file:exec_negblock_executor?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvs := &testVersionedDBSnapshotter{db: backend}
+	cfg := EVMConfig{ChainConfig: common.BuildChainConfig(4011)}
+	eng := NewEVMEngine(Namespace, kvs, cfg, false)
+
+	wantLatest, err := backend.BlockNumber(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ex, err := eng.newExecutor(big.NewInt(-5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ex.Close()
+
+	got := ex.reader.(*testVersionedDBReader).blockNumber
+	if got != wantLatest {
+		t.Errorf("newExecutor(-5) resolved to block %d, want latest (%d)", got, wantLatest)
 	}
 }

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -414,7 +414,11 @@ func (api *EthAPI) FeeHistory(ctx context.Context, blockCount hexutil.Uint, last
 // eth_getLogs
 func (api *EthAPI) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([]*types.Log, error) {
 	logger.Debugf("EthAPI.GetLogs() called with criteria=%+v", crit)
-	query := filterCriteriaToLogFilter(crit)
+	query, err := api.filterCriteriaToLogFilter(ctx, crit)
+	if err != nil {
+		logger.Debugf("EthAPI.GetLogs() returning error: %v", err)
+		return nil, err
+	}
 
 	logs, err := api.b.GetLogs(ctx, query)
 	if err != nil {
@@ -432,15 +436,19 @@ func (api *EthAPI) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([]
 	return result, nil
 }
 
-func filterCriteriaToLogFilter(crit filters.FilterCriteria) domain.LogFilter {
+func (api *EthAPI) filterCriteriaToLogFilter(ctx context.Context, crit filters.FilterCriteria) (domain.LogFilter, error) {
 	filter := domain.LogFilter{}
 
 	if crit.BlockHash != nil {
 		hash := crit.BlockHash.Bytes()
 		filter.BlockHash = &hash
 	} else {
-		filter.FromBlock = resolveLogFilterBlockNumber(crit.FromBlock)
-		filter.ToBlock = resolveLogFilterBlockNumber(crit.ToBlock)
+		from, err := api.resolveLogFilterFromBlock(ctx, crit.FromBlock)
+		if err != nil {
+			return domain.LogFilter{}, err
+		}
+		filter.FromBlock = from
+		filter.ToBlock = resolveLogFilterToBlock(crit.ToBlock)
 	}
 
 	if len(crit.Addresses) > 0 {
@@ -462,7 +470,7 @@ func filterCriteriaToLogFilter(crit filters.FilterCriteria) domain.LogFilter {
 		}
 	}
 
-	return filter
+	return filter, nil
 }
 
 func domainLogToTypesLog(l domain.Log) *types.Log {
@@ -605,10 +613,30 @@ func blockNumberToUint64(num rpc.BlockNumber) uint64 {
 	return uint64(num)
 }
 
-// resolveLogFilterBlockNumber converts a FilterCriteria block bound to a LogFilter bound:
-// nil (omitted), "latest", "pending", "safe" and "finalized" all resolve to nil (open end);
-// "earliest" resolves to block 0.
-func resolveLogFilterBlockNumber(n *big.Int) *uint64 {
+// resolveLogFilterFromBlock resolves the lower bound of an eth_getLogs range.
+// An omitted bound defaults to "latest" per the JSON-RPC spec, so it — like "latest",
+// "pending", "safe" and "finalized" — resolves to the head block; "earliest" is block 0.
+// Resolving to nil would mean genesis and return the whole chain's logs.
+func (api *EthAPI) resolveLogFilterFromBlock(ctx context.Context, n *big.Int) (*uint64, error) {
+	if n != nil && n.Sign() >= 0 {
+		v := n.Uint64()
+		return &v, nil
+	}
+	if n != nil && n.Cmp(big.NewInt(int64(rpc.EarliestBlockNumber))) == 0 {
+		zero := uint64(0)
+		return &zero, nil
+	}
+	head, err := api.b.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &head, nil
+}
+
+// resolveLogFilterToBlock resolves the upper bound of an eth_getLogs range.
+// nil (omitted), "latest", "pending", "safe" and "finalized" all leave the bound
+// open, which the store reads as the head block; "earliest" resolves to block 0.
+func resolveLogFilterToBlock(n *big.Int) *uint64 {
 	if n == nil {
 		return nil
 	}

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -439,14 +439,8 @@ func filterCriteriaToLogFilter(crit filters.FilterCriteria) domain.LogFilter {
 		hash := crit.BlockHash.Bytes()
 		filter.BlockHash = &hash
 	} else {
-		if crit.FromBlock != nil {
-			from := crit.FromBlock.Uint64()
-			filter.FromBlock = &from
-		}
-		if crit.ToBlock != nil {
-			to := crit.ToBlock.Uint64()
-			filter.ToBlock = &to
-		}
+		filter.FromBlock = resolveLogFilterBlockNumber(crit.FromBlock)
+		filter.ToBlock = resolveLogFilterBlockNumber(crit.ToBlock)
 	}
 
 	if len(crit.Addresses) > 0 {
@@ -584,9 +578,15 @@ func (api *EthAPI) blockNumberOrHashToBlockNumber(ctx context.Context, numOrHash
 	return new(big.Int).SetUint64(*num), nil
 }
 
-// rpcBlockNumberToBigInt converts rpc.BlockNumber to *big.Int
+// rpcBlockNumberToBigInt converts rpc.BlockNumber to *big.Int for state queries.
+// "earliest" resolves to block 0; every other negative sentinel (latest, pending, safe,
+// finalized, and any future one) resolves to nil/"latest" — every committed Fabric block
+// is final, so finalized == latest is semantically correct here too.
 func rpcBlockNumberToBigInt(num rpc.BlockNumber) *big.Int {
-	if num == rpc.PendingBlockNumber || num == rpc.LatestBlockNumber {
+	if num == rpc.EarliestBlockNumber {
+		return big.NewInt(0)
+	}
+	if num < 0 {
 		return nil
 	}
 	return big.NewInt(num.Int64())
@@ -603,4 +603,22 @@ func blockNumberToUint64(num rpc.BlockNumber) uint64 {
 		return math.MaxUint64
 	}
 	return uint64(num)
+}
+
+// resolveLogFilterBlockNumber converts a FilterCriteria block bound to a LogFilter bound:
+// nil (omitted), "latest", "pending", "safe" and "finalized" all resolve to nil (open end);
+// "earliest" resolves to block 0.
+func resolveLogFilterBlockNumber(n *big.Int) *uint64 {
+	if n == nil {
+		return nil
+	}
+	if n.Cmp(big.NewInt(int64(rpc.EarliestBlockNumber))) == 0 {
+		zero := uint64(0)
+		return &zero
+	}
+	if n.Sign() < 0 {
+		return nil
+	}
+	v := n.Uint64()
+	return &v
 }

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
@@ -30,9 +31,12 @@ func TestRpcBlockNumberToBigInt(t *testing.T) {
 	}{
 		{"pending", rpc.PendingBlockNumber, nil},
 		{"latest", rpc.LatestBlockNumber, nil},
+		{"earliest", rpc.EarliestBlockNumber, big.NewInt(0)},
+		{"safe", rpc.SafeBlockNumber, nil},
+		{"finalized", rpc.FinalizedBlockNumber, nil},
 		{"zero", 0, big.NewInt(0)},
 		{"positive", 100, big.NewInt(100)},
-		{"negative", -10, big.NewInt(-10)},
+		{"unrecognized negative sentinel", -10, nil},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +78,60 @@ func TestBlockNumberToUint64(t *testing.T) {
 	}
 }
 
+// TestFilterCriteriaToLogFilter_LatestToBlock reproduces issue #192: eth_getLogs
+// with toBlock: "latest" must leave the upper bound unset, not resolve it to
+// block 1. It unmarshals real JSON-RPC input so go-ethereum's own sentinel
+// encoding (rpc.LatestBlockNumber, a negative constant) is exercised.
+func TestFilterCriteriaToLogFilter_LatestToBlock(t *testing.T) {
+	var crit filters.FilterCriteria
+	if err := json.Unmarshal([]byte(`{"fromBlock":"0x1","toBlock":"latest"}`), &crit); err != nil {
+		t.Fatalf("unmarshal FilterCriteria: %v", err)
+	}
+
+	got := filterCriteriaToLogFilter(crit)
+
+	if got.FromBlock == nil || *got.FromBlock != 1 {
+		t.Errorf("FromBlock = %v, want 1", got.FromBlock)
+	}
+	if got.ToBlock != nil {
+		t.Errorf("ToBlock = %v, want nil (unbounded/latest)", *got.ToBlock)
+	}
+}
+
+func TestFilterCriteriaToLogFilter_BlockBounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantFrom *uint64
+		wantTo   *uint64
+	}{
+		{"omitted bounds", `{}`, nil, nil},
+		{"explicit numbers", `{"fromBlock":"0x2","toBlock":"0x5"}`, new(uint64(2)), new(uint64(5))},
+		{"earliest from, literal 0x0 to", `{"fromBlock":"earliest","toBlock":"0x0"}`, new(uint64(0)), new(uint64(0))},
+		{"latest to", `{"fromBlock":"0x1","toBlock":"latest"}`, new(uint64(1)), nil},
+		{"pending to", `{"toBlock":"pending"}`, nil, nil},
+		{"latest from", `{"fromBlock":"latest"}`, nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var crit filters.FilterCriteria
+			if err := json.Unmarshal([]byte(tt.json), &crit); err != nil {
+				t.Fatalf("unmarshal FilterCriteria: %v", err)
+			}
+
+			got := filterCriteriaToLogFilter(crit)
+
+			if (got.FromBlock == nil) != (tt.wantFrom == nil) || (got.FromBlock != nil && *got.FromBlock != *tt.wantFrom) {
+				t.Errorf("FromBlock = %v, want %v", got.FromBlock, tt.wantFrom)
+			}
+			if (got.ToBlock == nil) != (tt.wantTo == nil) || (got.ToBlock != nil && *got.ToBlock != *tt.wantTo) {
+				t.Errorf("ToBlock = %v, want %v", got.ToBlock, tt.wantTo)
+			}
+		})
+	}
+}
+
 func TestBlockNumberOrHashToBlockNumber(t *testing.T) {
 	api := NewEthAPI(&stubBackend{})
 
@@ -84,9 +142,10 @@ func TestBlockNumberOrHashToBlockNumber(t *testing.T) {
 	}{
 		{"latest", rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), nil},
 		{"pending", rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber), nil},
+		{"earliest", rpc.BlockNumberOrHashWithNumber(rpc.EarliestBlockNumber), big.NewInt(0)},
 		{"zero", rpc.BlockNumberOrHashWithNumber(0), big.NewInt(0)},
 		{"positive", rpc.BlockNumberOrHashWithNumber(100), big.NewInt(100)},
-		{"negative", rpc.BlockNumberOrHashWithNumber(-10), big.NewInt(-10)},
+		{"unrecognized negative sentinel", rpc.BlockNumberOrHashWithNumber(-10), nil},
 	}
 
 	for _, tt := range tests {

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -88,7 +88,11 @@ func TestFilterCriteriaToLogFilter_LatestToBlock(t *testing.T) {
 		t.Fatalf("unmarshal FilterCriteria: %v", err)
 	}
 
-	got := filterCriteriaToLogFilter(crit)
+	api := NewEthAPI(&stubBackend{blockNum: 7})
+	got, err := api.filterCriteriaToLogFilter(context.Background(), crit)
+	if err != nil {
+		t.Fatalf("filterCriteriaToLogFilter() error = %v", err)
+	}
 
 	if got.FromBlock == nil || *got.FromBlock != 1 {
 		t.Errorf("FromBlock = %v, want 1", got.FromBlock)
@@ -105,13 +109,18 @@ func TestFilterCriteriaToLogFilter_BlockBounds(t *testing.T) {
 		wantFrom *uint64
 		wantTo   *uint64
 	}{
-		{"omitted bounds", `{}`, nil, nil},
+		{"omitted bounds", `{}`, new(uint64(7)), nil},
 		{"explicit numbers", `{"fromBlock":"0x2","toBlock":"0x5"}`, new(uint64(2)), new(uint64(5))},
 		{"earliest from, literal 0x0 to", `{"fromBlock":"earliest","toBlock":"0x0"}`, new(uint64(0)), new(uint64(0))},
 		{"latest to", `{"fromBlock":"0x1","toBlock":"latest"}`, new(uint64(1)), nil},
-		{"pending to", `{"toBlock":"pending"}`, nil, nil},
-		{"latest from", `{"fromBlock":"latest"}`, nil, nil},
+		{"pending to", `{"toBlock":"pending"}`, new(uint64(7)), nil},
+		{"latest from", `{"fromBlock":"latest"}`, new(uint64(7)), nil},
+		{"pending from", `{"fromBlock":"pending"}`, new(uint64(7)), nil},
+		{"safe from", `{"fromBlock":"safe"}`, new(uint64(7)), nil},
+		{"finalized from", `{"fromBlock":"finalized"}`, new(uint64(7)), nil},
 	}
+
+	api := NewEthAPI(&stubBackend{blockNum: 7})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -120,7 +129,10 @@ func TestFilterCriteriaToLogFilter_BlockBounds(t *testing.T) {
 				t.Fatalf("unmarshal FilterCriteria: %v", err)
 			}
 
-			got := filterCriteriaToLogFilter(crit)
+			got, err := api.filterCriteriaToLogFilter(context.Background(), crit)
+			if err != nil {
+				t.Fatalf("filterCriteriaToLogFilter() error = %v", err)
+			}
 
 			if (got.FromBlock == nil) != (tt.wantFrom == nil) || (got.FromBlock != nil && *got.FromBlock != *tt.wantFrom) {
 				t.Errorf("FromBlock = %v, want %v", got.FromBlock, tt.wantFrom)

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -240,7 +240,22 @@ func (g *Gateway) GetBlockTxCountByHash(ctx context.Context, hash common.Hash) (
 
 // GetBlockTxCountByNumber counts the transactions in a specific block.
 func (g *Gateway) GetBlockTxCountByNumber(ctx context.Context, num uint64) (int64, error) {
+	num, err := g.resolveBlockNumber(ctx, num)
+	if err != nil {
+		return 0, err
+	}
 	return g.store.GetBlockTxCountByNumber(ctx, num)
+}
+
+// resolveBlockNumber resolves the math.MaxUint64 "latest" sentinel to the current block
+// number; every other value passes through unchanged. GetBlockByNumber has its own
+// dedicated LatestBlock store call instead of using this, since it can resolve "latest"
+// in a single query rather than two.
+func (g *Gateway) resolveBlockNumber(ctx context.Context, num uint64) (uint64, error) {
+	if num != math.MaxUint64 {
+		return num, nil
+	}
+	return g.store.BlockNumber(ctx)
 }
 
 // State
@@ -333,6 +348,10 @@ func (g *Gateway) GetTransactionByBlockHashAndIndex(ctx context.Context, hash co
 
 // GetTransactionByBlockNumberAndIndex retrieves a transaction based on block number in the transaction index in that block.
 func (g *Gateway) GetTransactionByBlockNumberAndIndex(ctx context.Context, num uint64, idx int64) (*domain.Transaction, error) {
+	num, err := g.resolveBlockNumber(ctx, num)
+	if err != nil {
+		return nil, err
+	}
 	return g.store.GetTransactionByBlockNumberAndIndex(ctx, num, idx)
 }
 

--- a/gateway/core/api_test.go
+++ b/gateway/core/api_test.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 
@@ -16,6 +17,83 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubStore is a minimal Store fake that records the block number it was actually
+// queried with, so tests can verify sentinel resolution happens before the store is hit.
+type stubStore struct {
+	blockNumber     uint64
+	txCountByNumber map[uint64]int64
+	txCountArg      *uint64
+	txByNumberArg   *uint64
+}
+
+func (s *stubStore) BlockNumber(ctx context.Context) (uint64, error) { return s.blockNumber, nil }
+func (s *stubStore) BlockNumberByHash(ctx context.Context, hash []byte) (*uint64, error) {
+	return nil, nil
+}
+func (s *stubStore) LatestBlock(ctx context.Context, full bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubStore) GetBlockByNumber(ctx context.Context, num uint64, full bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubStore) GetBlockByHash(ctx context.Context, hash []byte, full bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (s *stubStore) GetBlockTxCountByHash(ctx context.Context, hash []byte) (int64, error) {
+	return 0, nil
+}
+func (s *stubStore) GetBlockTxCountByNumber(ctx context.Context, num uint64) (int64, error) {
+	s.txCountArg = &num
+	return s.txCountByNumber[num], nil
+}
+func (s *stubStore) GetTransactionByHash(ctx context.Context, hash []byte) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubStore) GetTransactionByBlockHashAndIndex(ctx context.Context, hash []byte, idx int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (s *stubStore) GetTransactionByBlockNumberAndIndex(ctx context.Context, num uint64, idx int64) (*domain.Transaction, error) {
+	s.txByNumberArg = &num
+	return nil, nil
+}
+func (s *stubStore) GetLogs(ctx context.Context, filter domain.LogFilter) ([]domain.Log, error) {
+	return nil, nil
+}
+func (s *stubStore) GetLogsByTxHash(ctx context.Context, txHash []byte) ([]domain.Log, error) {
+	return nil, nil
+}
+
+var _ Store = (*stubStore)(nil)
+
+// TestGetBlockTxCountByNumber_LatestSentinelResolvesToCurrentBlock guards against a bug
+// found alongside the eth_getLogs "latest" bug: GetBlockByNumber special-cases
+// math.MaxUint64 ("latest") by resolving it to the current block number, but
+// GetBlockTxCountByNumber forwarded it to the store unresolved, where int64(MaxUint64)
+// wraps to -1 and silently matches no row.
+func TestGetBlockTxCountByNumber_LatestSentinelResolvesToCurrentBlock(t *testing.T) {
+	store := &stubStore{blockNumber: 42, txCountByNumber: map[uint64]int64{42: 7}}
+	g := &Gateway{store: store}
+
+	count, err := g.GetBlockTxCountByNumber(context.Background(), math.MaxUint64)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), count)
+	require.NotNil(t, store.txCountArg)
+	assert.Equal(t, uint64(42), *store.txCountArg)
+}
+
+// TestGetTransactionByBlockNumberAndIndex_LatestSentinelResolvesToCurrentBlock is the
+// GetTransactionByBlockNumberAndIndex counterpart of
+// TestGetBlockTxCountByNumber_LatestSentinelResolvesToCurrentBlock.
+func TestGetTransactionByBlockNumberAndIndex_LatestSentinelResolvesToCurrentBlock(t *testing.T) {
+	store := &stubStore{blockNumber: 42}
+	g := &Gateway{store: store}
+
+	_, err := g.GetTransactionByBlockNumberAndIndex(context.Background(), math.MaxUint64, 0)
+	require.NoError(t, err)
+	require.NotNil(t, store.txByNumberArg)
+	assert.Equal(t, uint64(42), *store.txByNumberArg)
+}
 
 // nonceStub returns a stubEndorser whose NonceAt yields nonce 0.
 func nonceStub() *stubEndorser {


### PR DESCRIPTION
Closes #192, along with 2 related sentinel-resolution bugs.

**gateway/api/eth.go** - filterCriteriaToLogFilter (the original #192 fix) and rpcBlockNumberToBigInt (new: earliest/safe/finalized were leaking through as raw negative numbers instead of resolving correctly. New helper resolveLogFilterBlockNumber.

**endorser/execution/executor.go** - newExecutor and newSnapshotAt both called .Uint64() directly on a possibly-negative *big.Int, corrupting eth_call/eth_estimateGas/eth_getBalance/eth_getCode/eth_getStorageAt/eth_getTransactionCount into reading state from the wrong block when a negative sentinel leaked through.

**gateway/core/api.go** - GetBlockTxCountByNumber and GetTransactionByBlockNumberAndIndex were missing the math.MaxUint64→latest resolution that GetBlockByNumber already had.