### PR TITLE
OpenZeppelin/Hardhat compatibility tests ci gate

### DIFF
--- a/.github/workflows/baseline-report-comment.yml
+++ b/.github/workflows/baseline-report-comment.yml
@@ -37,17 +37,29 @@ jobs:
         id: prnum
         run: |
           if [ -f oz-baseline-artifact/pr_number.txt ]; then
-            echo "number=$(cat oz-baseline-artifact/pr_number.txt)" >> "$GITHUB_OUTPUT"
+            n=$(cat oz-baseline-artifact/pr_number.txt)
+            [[ "$n" =~ ^[0-9]+$ ]] || { echo "Non-numeric PR number; skipping."; exit 0; }
+            echo "number=$n" >> "$GITHUB_OUTPUT"
           else
             echo "No PR number found — not a pull_request run, or no artifact was produced. Skipping comment."
           fi
 
       - name: Find-or-update PR comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.prnum.outputs.number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+
+      - name: Find-or-update PR comment
         if: steps.prnum.outputs.number != ''
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.prnum.outputs.number }}
         with:
           # Builds a compact PR comment from cmd/baseline check --json's structured
-          # Summary: an always-visible ✅/❌/🎉 headline, regressions/stale surfaced
+          # summary: an always-visible ✅/❌/🎉 headline, regressions/stale surfaced
           # immediately since those are the only actionable bit, everything else
           # (by-suite, cause histogram) folded behind <details>. Inlined here rather
           # than in a checked-out repo file so this workflow keeps needing zero
@@ -110,7 +122,7 @@ jobs:
             out += footer;
 
             const { owner, repo } = context.repo;
-            const prNumber = Number('${{ steps.prnum.outputs.number }}');
+            const prNumber = Number(process.env.PR_NUMBER);
             const comments = await github.rest.issues.listComments({
               owner,
               repo,

--- a/.github/workflows/baseline-report-comment.yml
+++ b/.github/workflows/baseline-report-comment.yml
@@ -1,0 +1,126 @@
+name: Baseline Report Comment
+
+# Companion to the "Tests" workflow's oz-hardhat-compat job. Split into its own
+# workflow (rather than a step in Tests) so it can run with elevated permissions
+# safely: this workflow's own definition is read from the default branch, not a
+# PR's branch, so a fork PR editing this file has no effect on what it does. It
+# never checks out repo/PR code — it only reads a plain-text artifact the
+# unprivileged Tests run already produced, and posts/updates one PR comment from it.
+
+on:
+  workflow_run:
+    workflows: [ "Tests" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  actions: read # required by actions/download-artifact for cross-run download
+  pull-requests: write # minimal scope for posting/updating a PR comment
+
+jobs:
+  comment:
+    name: Post baseline report comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - name: Download summary artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true # no artifact at all means an early infra failure upstream; nothing to comment
+        with:
+          name: oz-baseline-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: oz-baseline-artifact
+
+      - name: Check for PR number
+        id: prnum
+        run: |
+          if [ -f oz-baseline-artifact/pr_number.txt ]; then
+            echo "number=$(cat oz-baseline-artifact/pr_number.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "No PR number found — not a pull_request run, or no artifact was produced. Skipping comment."
+          fi
+
+      - name: Find-or-update PR comment
+        if: steps.prnum.outputs.number != ''
+        uses: actions/github-script@v7
+        with:
+          # Builds a compact PR comment from cmd/baseline check --json's structured
+          # Summary: an always-visible ✅/❌/🎉 headline, regressions/stale surfaced
+          # immediately since those are the only actionable bit, everything else
+          # (by-suite, cause histogram) folded behind <details>. Inlined here rather
+          # than in a checked-out repo file so this workflow keeps needing zero
+          # checkout of repo/PR code.
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- oz-baseline-report -->';
+            const summary = JSON.parse(fs.readFileSync('oz-baseline-artifact/summary.json', 'utf8'));
+            const regressionCount = summary.regressions.length;
+            const staleCount = summary.stale.length;
+
+            // Three possible states: regressions, new fixes, or no change.
+            // Only the latter requires no action from the developer.
+            let headline;
+            let footer = '';
+            if (regressionCount > 0) {
+              const bits = [`${regressionCount} regression${regressionCount === 1 ? '' : 's'}`];
+              if (staleCount > 0) {
+                bits.push(`🎉 ${staleCount} fixed`);
+                footer = "<sub>Run `go run ./cmd/baseline update --suite oz-hardhat` to accept the expected regressions and drop the fixed entries, then commit the updated baseline.</sub>\n";
+              } else {
+                footer = "<sub>A regression above that's actually expected, not a bug? Run `go run ./cmd/baseline update --suite oz-hardhat` and commit the updated baseline.</sub>\n";
+              }
+              headline = `### ❌ OZ Hardhat Compatibility — ${bits.join(', ')}`;
+            } else if (staleCount > 0) {
+              headline = `### 🎉 OZ Hardhat Compatibility — ${staleCount} test${staleCount === 1 ? '' : 's'} fixed!`;
+              footer = "<sub>Lock in the win — run `go run ./cmd/baseline update --suite oz-hardhat` and commit the updated baseline to remove these.</sub>\n";
+            } else {
+              headline = `### ✅ OZ Hardhat Compatibility — ${summary.passRate.toFixed(1)}% passing (${summary.pass}/${summary.total})`;
+            }
+
+            let out = `${marker}\n${headline}\n\n`;
+            if (regressionCount === 0 && staleCount === 0) out += `No regressions, no stale entries.\n\n`;
+            if (regressionCount > 0) {
+              out += `**Regressions (${regressionCount})**\n\n`;
+              for (const r of summary.regressions) out += `- \`${r.id}\`: ${r.message}\n`;
+              out += '\n';
+            }
+            if (staleCount > 0) {
+              out += `**Stale baseline entries (${staleCount}) — remove these**\n\n`;
+              for (const id of summary.stale) out += `- \`${id}\`\n`;
+              out += '\n';
+            }
+
+            if (summary.bySuite.length > 1 || summary.causes.length > 0) {
+              out += `<details>\n<summary>Full breakdown — ${summary.summaryLine}</summary>\n\n`;
+              if (summary.bySuite.length > 1) {
+                out += `**By suite**\n\n`;
+                for (const s of summary.bySuite) out += `- ${s.name}: ${s.pass}/${s.total} passing (${s.passRate.toFixed(0)}%)\n`;
+                out += '\n';
+              }
+              if (summary.causes.length > 0) {
+                const total = summary.causes.reduce((n, c) => n + c.count, 0);
+                out += `**Expected failures by cause (${total})**\n\n`;
+                for (const c of summary.causes) out += `- ${c.cause}: ${c.count}\n`;
+                out += '\n';
+              }
+              out += `</details>\n\n`;
+            }
+            out += footer;
+
+            const { owner, repo } = context.repo;
+            const prNumber = Number('${{ steps.prnum.outputs.number }}');
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.data.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: out });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: out });
+            }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [ opened, synchronize, reopened, labeled ]
     branches: [ "main" ]
   workflow_dispatch:
+
 
 permissions:
   contents: read
@@ -40,14 +41,70 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: false
 
-      - name: Hardhat integration tests
-        run: make hardhat-tests
+  oz-hardhat-compat:
+    name: OZ Hardhat Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache OZ node_modules
+        uses: actions/cache@v4
+        with:
+          path: testdata/openzeppelin-contracts/node_modules
+          key: ${{ runner.os }}-oz-node-modules-${{ hashFiles('testdata/openzeppelin-contracts/package-lock.json') }}
+
+      - name: Hardhat OZ compatibility suite (full)
+        run: make hardhat-tests-full
+
+      - name: OZ baseline check (gate)
+        run: |
+          mkdir -p oz-baseline-artifact
+          set +e
+          go run ./cmd/baseline check --suite oz-hardhat > oz-baseline-artifact/report.md
+          check_status=$?
+          set -e
+          cat oz-baseline-artifact/report.md
+          if [ "${check_status}" -ne 0 ]; then
+            {
+              echo ""
+              echo "---"
+              echo "A regression above that's actually expected, or a stale entry now passing? Run:"
+              echo "  go run ./cmd/baseline update --suite oz-hardhat"
+              echo "and commit the updated testdata/oz_known_failures.json."
+            } >> oz-baseline-artifact/report.md
+          fi
+          # Structured summary for the comment step; check_status above is the real gate.
+          go run ./cmd/baseline check --suite oz-hardhat --json > oz-baseline-artifact/summary.json || true
+          exit "${check_status}"
+
+      - name: Record PR number for report comment
+        if: always() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > oz-baseline-artifact/pr_number.txt
+
+      - name: Upload OZ baseline report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oz-baseline-report
+          path: oz-baseline-artifact/
+          retention-days: 1
+          if-no-files-found: warn
 
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: quick-tests
+    needs: [ quick-tests, oz-hardhat-compat ]
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||

--- a/Makefile
+++ b/Makefile
@@ -248,12 +248,12 @@ eth-tests-slow-legacy:
 eth-tests-execution-specs: fetch-execution-specs-tests
 	@go test -test.fullpath=true -timeout 2000s -run ^TestExecutionSpecStateTests$$ github.com/hyperledger/fabric-x-evm/integration
 
+# Single-file smoke test — CI runs hardhat-tests-full (below) instead.
 .PHONY: hardhat-tests
 hardhat-tests:
 	@./scripts/run_hardhat_test.sh
 
-# Runs the full OZ compatible set, not just ERC20.test.js.
-# Local only, not CI-gated — hardhat-tests above is what CI runs.
+# Full OZ compatible set — what CI's oz-hardhat-compat job runs.
 .PHONY: hardhat-tests-full
 hardhat-tests-full:
 	@./scripts/run_hardhat_test.sh --full

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -18,10 +18,11 @@ diff: new unlisted failure → regression; listed test that now passes → stale
 instead of a list someone has to remember to prune by hand. It makes the approach consistent and
 measurable.
 
-**Currently wired up for OpenZeppelin only, not yet used anywhere in CI.** The `--format` flag
-exists so a `go test -json` adapter can be added later for `TestEthereumTests`, replacing
-`eth_tests.skip`/`.slow` with the same mechanism at per-subtest granularity — not built yet, but the
-reason the result model and CLI are format-agnostic rather than Mocha-specific.
+**Currently wired up for OpenZeppelin only** — gates every PR via the `oz-hardhat-compat` job in
+[`tests.yml`](../../.github/workflows/tests.yml). The `--format` flag exists so a `go test -json`
+adapter can be added later for `TestEthereumTests`, replacing `eth_tests.skip`/`.slow` with the same
+mechanism at per-subtest granularity — not built yet, but the reason the result model and CLI are
+format-agnostic rather than Mocha-specific.
 
 ## After bumping `testdata/openzeppelin-contracts`
 
@@ -74,6 +75,11 @@ that).
 Prints a summary and exits non-zero if anything regressed:
 - a failure that isn't in the baseline (a real regression), or
 - a baseline entry that's no longer failing (stale — remove it).
+
+`--json` prints a machine-readable `Summary` instead (same counts, regressions, stale entries, and
+cause histogram, structured rather than prose) — for a caller building its own presentation, e.g. the
+PR-comment bot in [`baseline-report-comment.yml`](../../.github/workflows/baseline-report-comment.yml),
+instead of re-parsing the human-readable report. Same exit code either way.
 
 `--results` is a glob (matched with `filepath.Glob`, so quote it against your shell expanding it
 early) that merges several files — useful since a Mocha file that crashes at load time can zero out

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -63,11 +63,13 @@ one run gives both, instead of picking one or the other.
 ## Check (the CI gate)
 
 ```shell
-go run ./cmd/baseline check \
-  --suite oz-hardhat \
-  --baseline testdata/oz_known_failures.json \
-  --results 'testdata/oz-hardhat-results/*.json'
+go run ./cmd/baseline check --suite oz-hardhat
 ```
+
+A known `--suite` (currently just `oz-hardhat`) already implies `--baseline testdata/oz_known_failures.json`
+and `--results 'testdata/oz-hardhat-results/*.json'` — pass either flag explicitly to override, e.g.
+against a scratch baseline or a single results file (see the worked examples below, which do exactly
+that).
 
 Prints a summary and exits non-zero if anything regressed:
 - a failure that isn't in the baseline (a real regression), or
@@ -77,7 +79,7 @@ Prints a summary and exits non-zero if anything regressed:
 early) that merges several files — useful since a Mocha file that crashes at load time can zero out
 the whole report for that invocation, so running per-file/per-directory and merging is safer than one
 giant run. `testdata/oz-hardhat-results/` is exactly what `scripts/run_hardhat_test.sh --full` writes
-one file per top-level `test/` directory into, so the command above works as-is after a real run.
+one file per top-level `test/` directory into, so `--suite oz-hardhat` alone works as-is after a real run.
 
 Sample output, an empty baseline against a real run of `ERC20Permit.test.js` (regressions, since
 nothing is listed yet):
@@ -124,11 +126,10 @@ needs the most work — and watch that shrink over time as fixes land.
 ## Update (seed or reconcile the baseline)
 
 ```shell
-go run ./cmd/baseline update \
-  --suite oz-hardhat \
-  --baseline testdata/oz_known_failures.json \
-  --results 'testdata/oz-hardhat-results/*.json'
+go run ./cmd/baseline update --suite oz-hardhat
 ```
+
+Same `--suite` defaulting as `check` above; pass `--baseline`/`--results` explicitly to override.
 
 Rewrites the baseline file: drops stale entries, adds an entry for every new failure — auto-tagging
 `cause` for the high-confidence signatures `inferCause` recognizes, leaving the rest blank for a
@@ -163,14 +164,11 @@ $ cat testdata/oz_known_failures.json
 ## Tag (bulk-assign a cause)
 
 ```shell
-go run ./cmd/baseline tag \
-  --baseline testdata/oz_known_failures.json \
-  --results 'testdata/oz-hardhat-results/*.json' \
-  --match "Packing" \
-  --cause "max-code-size"
+go run ./cmd/baseline tag --suite oz-hardhat --match "Packing" --cause "max-code-size"
 ```
 
-Sets `cause` (and optionally `--note`) on every still-failing entry whose ID or current message
+Same `--suite` defaulting as `check`/`update` above; pass `--baseline`/`--results` explicitly to
+override. Sets `cause` (and optionally `--note`) on every still-failing entry whose ID or current message
 contains `--match` — for a symptom that's too broad or too varied in wording for `inferCause` to
 recognize automatically, but that a human can look at once and confidently label in bulk (e.g. a
 whole describe block, or a message fragment shared across many tests). Entries that already have a

--- a/cmd/baseline/baseline.go
+++ b/cmd/baseline/baseline.go
@@ -298,9 +298,9 @@ type suiteStats struct {
 	pass, fail, skip int
 }
 
-// bySuite buckets results by suiteOf(r.File), sorted by pass rate ascending
-// (the worst-performing suite first) — the same ROI-ranking idea as the cause
-// histogram, but for "where to look next" rather than "what to fix next".
+// bySuite buckets results by suiteOf(r.File), sorted alphabetically by name —
+// a stable order to scan or diff against a previous run, independent of any
+// run's actual pass rates.
 func bySuite(results []Result) []suiteStats {
 	stats := make(map[string]*suiteStats)
 	var order []string
@@ -327,10 +327,6 @@ func bySuite(results []Result) []suiteStats {
 		out = append(out, *stats[name])
 	}
 	sort.Slice(out, func(i, j int) bool {
-		ri, rj := passRate(out[i].pass, out[i].fail), passRate(out[j].pass, out[j].fail)
-		if ri != rj {
-			return ri < rj
-		}
 		return out[i].name < out[j].name
 	})
 	return out
@@ -418,4 +414,98 @@ func groupExpected(expected []ExpectedFailure) []expectedGroup {
 		return out[i].key < out[j].key
 	})
 	return out
+}
+
+// Summary is check's machine-readable counterpart to WriteReport's prose: the
+// same underlying results/diff, structured for a caller that wants to build its
+// own presentation (e.g. a CI bot posting a PR comment) instead of re-parsing
+// rendered text. Every slice field is always present (never omitted/null), even
+// when empty, so a consumer never needs to guard against a missing key.
+type Summary struct {
+	Suite       string         `json:"suite"`
+	Pass        int            `json:"pass"`
+	Fail        int            `json:"fail"`
+	Skip        int            `json:"skip"`
+	Total       int            `json:"total"`
+	PassRate    float64        `json:"passRate"`
+	SummaryLine string         `json:"summaryLine"` // exactly WriteReport's stats line, so the two never drift apart
+	BySuite     []SuiteSummary `json:"bySuite"`
+	Regressions []Regression   `json:"regressions"`
+	Stale       []string       `json:"stale"`
+	Causes      []CauseCount   `json:"causes"`
+}
+
+type SuiteSummary struct {
+	Name     string  `json:"name"`
+	Pass     int     `json:"pass"`
+	Total    int     `json:"total"`
+	PassRate float64 `json:"passRate"`
+}
+
+type Regression struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+}
+
+type CauseCount struct {
+	Cause string `json:"cause"`
+	Count int    `json:"count"`
+}
+
+// BuildSummary computes Summary from the same inputs WriteReport renders from,
+// reusing its helpers (passRate, bySuite, groupExpected) so the two can never
+// disagree on the underlying numbers, only on presentation.
+func BuildSummary(suite string, results []Result, diff DiffResult) Summary {
+	var pass, fail, skip int
+	for _, r := range results {
+		switch r.Status {
+		case StatusPass:
+			pass++
+		case StatusFail:
+			fail++
+		case StatusSkip:
+			skip++
+		}
+	}
+	rate := passRate(pass, fail)
+
+	bySuiteList := []SuiteSummary{}
+	for _, s := range bySuite(results) {
+		bySuiteList = append(bySuiteList, SuiteSummary{
+			Name:     s.name,
+			Pass:     s.pass,
+			Total:    s.pass + s.fail,
+			PassRate: passRate(s.pass, s.fail),
+		})
+	}
+
+	regressions := []Regression{}
+	for _, r := range diff.Regressions {
+		regressions = append(regressions, Regression{ID: r.ID, Message: r.Message})
+	}
+
+	stale := []string{}
+	for _, e := range diff.Stale {
+		stale = append(stale, e.ID)
+	}
+
+	causes := []CauseCount{}
+	for _, group := range groupExpected(diff.Expected) {
+		causes = append(causes, CauseCount{Cause: group.key, Count: len(group.items)})
+	}
+
+	return Summary{
+		Suite:    suite,
+		Pass:     pass,
+		Fail:     fail,
+		Skip:     skip,
+		Total:    len(results),
+		PassRate: rate,
+		SummaryLine: fmt.Sprintf("%d passed, %d failed, %d skipped (%d total, %.1f%% passing)",
+			pass, fail, skip, len(results), rate),
+		BySuite:     bySuiteList,
+		Regressions: regressions,
+		Stale:       stale,
+		Causes:      causes,
+	}
 }

--- a/cmd/baseline/baseline_test.go
+++ b/cmd/baseline/baseline_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -88,18 +90,18 @@ func TestSuiteOf(t *testing.T) {
 }
 
 func TestBySuite(t *testing.T) {
+	// "zzz" is the worse suite (0%) but must still sort after "aaa" (100%) —
+	// proves the order is alphabetical, not pass-rate.
 	results := []Result{
-		{ID: "a", Status: StatusPass, File: "/x/test/token/A.test.js"},
-		{ID: "b", Status: StatusFail, File: "/x/test/token/B.test.js"},
-		{ID: "c", Status: StatusPass, File: "/x/test/utils/C.test.js"},
-		{ID: "d", Status: StatusPass, File: "/x/test/utils/D.test.js"},
+		{ID: "a", Status: StatusPass, File: "/x/test/aaa/A.test.js"},
+		{ID: "b", Status: StatusFail, File: "/x/test/zzz/B.test.js"},
 	}
 
 	stats := bySuite(results)
 
 	want := []suiteStats{
-		{name: "token", pass: 1, fail: 1}, // 50% — worse, sorts first
-		{name: "utils", pass: 2, fail: 0}, // 100%
+		{name: "aaa", pass: 1, fail: 0},
+		{name: "zzz", pass: 0, fail: 1},
 	}
 	if !reflect.DeepEqual(stats, want) {
 		t.Fatalf("got %+v, want %+v", stats, want)
@@ -185,6 +187,61 @@ func TestDiff_NothingWrong(t *testing.T) {
 	diff := Diff(results, baseline)
 	if diff.Regressed() {
 		t.Fatalf("expected clean diff, got regressions=%+v stale=%+v", diff.Regressions, diff.Stale)
+	}
+}
+
+func TestBuildSummary(t *testing.T) {
+	results := []Result{
+		{ID: "regression", Status: StatusFail, Message: "new break", File: "test/token/ERC20.test.js"},
+		{ID: "expected-fail", Status: StatusFail, Message: "known issue", File: "test/token/ERC20.test.js"},
+		{ID: "now-passing", Status: StatusPass, File: "test/access/AccessControl.test.js"},
+		{ID: "unlisted-pass", Status: StatusPass, File: "test/access/AccessControl.test.js"},
+	}
+	baseline := []Entry{
+		{ID: "expected-fail", Cause: "some-cause"},
+		{ID: "now-passing"},
+	}
+
+	diff := Diff(results, baseline)
+	summary := BuildSummary("oz-hardhat", results, diff)
+
+	if summary.Suite != "oz-hardhat" || summary.Pass != 2 || summary.Fail != 2 || summary.Skip != 0 || summary.Total != 4 {
+		t.Fatalf("counts = %+v", summary)
+	}
+	if summary.SummaryLine != "2 passed, 2 failed, 0 skipped (4 total, 50.0% passing)" {
+		t.Fatalf("summaryLine = %q", summary.SummaryLine)
+	}
+	if len(summary.Regressions) != 1 || summary.Regressions[0] != (Regression{ID: "regression", Message: "new break"}) {
+		t.Fatalf("regressions = %+v", summary.Regressions)
+	}
+	if len(summary.Stale) != 1 || summary.Stale[0] != "now-passing" {
+		t.Fatalf("stale = %+v", summary.Stale)
+	}
+	if len(summary.Causes) != 1 || summary.Causes[0] != (CauseCount{Cause: "some-cause", Count: 1}) {
+		t.Fatalf("causes = %+v", summary.Causes)
+	}
+	if len(summary.BySuite) != 2 {
+		t.Fatalf("bySuite = %+v", summary.BySuite)
+	}
+}
+
+func TestBuildSummary_EmptySlicesMarshalAsEmptyArraysNotNull(t *testing.T) {
+	results := []Result{{ID: "unlisted-pass", Status: StatusPass}}
+	summary := BuildSummary("oz-hardhat", results, Diff(results, nil))
+
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// Every slice field must serialize as "[]", never "null" — a consumer reading
+	// this JSON should never need to guard against a missing/null key. bySuite
+	// isn't asserted here: a single result always yields exactly one suiteStats
+	// bucket (grouped under suiteOf("") == ""), never zero — see TestSuiteOf.
+	for _, field := range []string{`"regressions":[]`, `"stale":[]`, `"causes":[]`} {
+		if !bytes.Contains(data, []byte(field)) {
+			t.Fatalf("expected %s in JSON, got %s", field, data)
+		}
 	}
 }
 

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -22,6 +22,34 @@ var parsers = map[string]func([]byte) ([]Result, error){
 	"mocha-json": ParseMochaJSON,
 }
 
+// suiteDefaults gives --baseline/--results a sensible default from --suite alone, so
+// the common case (CI, docs, day-to-day invocations) doesn't need to repeat both
+// paths every time. Explicit --baseline/--results always override; an unrecognized
+// --suite is still fine, it just doesn't unlock defaults (--suite is otherwise only
+// a report-header label).
+var suiteDefaults = map[string]struct {
+	baselinePath string
+	resultsGlob  string
+}{
+	"oz-hardhat": {
+		baselinePath: "testdata/oz_known_failures.json",
+		resultsGlob:  "testdata/oz-hardhat-results/*.json",
+	},
+}
+
+func applySuiteDefaults(suite string, baselinePath, resultsGlob *string) {
+	d, ok := suiteDefaults[suite]
+	if !ok {
+		return
+	}
+	if *baselinePath == "" {
+		*baselinePath = d.baselinePath
+	}
+	if *resultsGlob == "" {
+		*resultsGlob = d.resultsGlob
+	}
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: baseline <check|update|tag> [flags]")
@@ -53,13 +81,14 @@ type commonFlags struct {
 func parseCommonFlags(name string, args []string) (*commonFlags, error) {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	f := &commonFlags{}
-	fs.StringVar(&f.suite, "suite", "", "suite name, for the report header")
+	fs.StringVar(&f.suite, "suite", "", "suite name, for the report header; a known suite (e.g. oz-hardhat) also supplies --baseline/--results defaults")
 	fs.StringVar(&f.format, "format", "mocha-json", "raw results format (mocha-json)")
-	fs.StringVar(&f.baselinePath, "baseline", "", "path to the baseline JSON file")
-	fs.StringVar(&f.resultsGlob, "results", "", "glob of raw results files to parse")
+	fs.StringVar(&f.baselinePath, "baseline", "", "path to the baseline JSON file (defaults from --suite if known)")
+	fs.StringVar(&f.resultsGlob, "results", "", "glob of raw results files to parse (defaults from --suite if known)")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
+	applySuiteDefaults(f.suite, &f.baselinePath, &f.resultsGlob)
 	if f.baselinePath == "" {
 		return nil, fmt.Errorf("--baseline is required")
 	}
@@ -225,8 +254,9 @@ func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, 
 
 func runTag(args []string) int {
 	fs := flag.NewFlagSet("tag", flag.ContinueOnError)
-	baselinePath := fs.String("baseline", "", "path to the baseline JSON file")
-	resultsGlob := fs.String("results", "", "glob of raw results files to parse")
+	suite := fs.String("suite", "", "suite name; a known suite (e.g. oz-hardhat) supplies --baseline/--results defaults")
+	baselinePath := fs.String("baseline", "", "path to the baseline JSON file (defaults from --suite if known)")
+	resultsGlob := fs.String("results", "", "glob of raw results files to parse (defaults from --suite if known)")
 	format := fs.String("format", "mocha-json", "raw results format (mocha-json)")
 	match := fs.String("match", "", "substring to match against each entry's ID or current failure message")
 	cause := fs.String("cause", "", "cause to assign to every matching entry")
@@ -236,8 +266,9 @@ func runTag(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
+	applySuiteDefaults(*suite, baselinePath, resultsGlob)
 	if *baselinePath == "" || *resultsGlob == "" || *match == "" || *cause == "" {
-		fmt.Fprintln(os.Stderr, "usage: baseline tag --baseline <path> --results <glob> --match <substring> --cause <name> [--note <text>] [--force]")
+		fmt.Fprintln(os.Stderr, "usage: baseline tag --suite <name> --match <substring> --cause <name> [--baseline <path>] [--results <glob>] [--note <text>] [--force]")
 		return 2
 	}
 

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -76,6 +77,7 @@ type commonFlags struct {
 	format       string
 	baselinePath string
 	resultsGlob  string
+	jsonOutput   bool
 }
 
 func parseCommonFlags(name string, args []string) (*commonFlags, error) {
@@ -85,6 +87,7 @@ func parseCommonFlags(name string, args []string) (*commonFlags, error) {
 	fs.StringVar(&f.format, "format", "mocha-json", "raw results format (mocha-json)")
 	fs.StringVar(&f.baselinePath, "baseline", "", "path to the baseline JSON file (defaults from --suite if known)")
 	fs.StringVar(&f.resultsGlob, "results", "", "glob of raw results files to parse (defaults from --suite if known)")
+	fs.BoolVar(&f.jsonOutput, "json", false, "(check only) print a machine-readable Summary as JSON instead of the human-readable report")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -179,11 +182,20 @@ func runCheck(args []string) int {
 
 	diff := Diff(results, baseline)
 
-	var buf bytes.Buffer
-	WriteReport(&buf, f.suite, results, diff)
-	fmt.Print(buf.String())
-	if err := writeStepSummary(buf.Bytes()); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if f.jsonOutput {
+		data, err := json.MarshalIndent(BuildSummary(f.suite, results, diff), "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		fmt.Println(string(data))
+	} else {
+		var buf bytes.Buffer
+		WriteReport(&buf, f.suite, results, diff)
+		fmt.Print(buf.String())
+		if err := writeStepSummary(buf.Bytes()); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 
 	if diff.Regressed() {

--- a/cmd/baseline/main_test.go
+++ b/cmd/baseline/main_test.go
@@ -33,6 +33,30 @@ func writeMochaFixture(t *testing.T, dir, name, fullTitle, errMessage string) st
 	return path
 }
 
+func TestApplySuiteDefaults(t *testing.T) {
+	baselinePath, resultsGlob := "", ""
+	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob)
+	if baselinePath != "testdata/oz_known_failures.json" || resultsGlob != "testdata/oz-hardhat-results/*.json" {
+		t.Fatalf("got baseline=%q results=%q", baselinePath, resultsGlob)
+	}
+}
+
+func TestApplySuiteDefaults_ExplicitValuesWin(t *testing.T) {
+	baselinePath, resultsGlob := "custom.json", "custom/*.json"
+	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob)
+	if baselinePath != "custom.json" || resultsGlob != "custom/*.json" {
+		t.Fatalf("explicit values should not be overridden, got baseline=%q results=%q", baselinePath, resultsGlob)
+	}
+}
+
+func TestApplySuiteDefaults_UnknownSuiteLeavesFlagsEmpty(t *testing.T) {
+	baselinePath, resultsGlob := "", ""
+	applySuiteDefaults("some-future-suite", &baselinePath, &resultsGlob)
+	if baselinePath != "" || resultsGlob != "" {
+		t.Fatalf("unrecognized suite should not set defaults, got baseline=%q results=%q", baselinePath, resultsGlob)
+	}
+}
+
 func TestLoadResults_AgreeingDuplicateIsFolded(t *testing.T) {
 	dir := t.TempDir()
 	writeMochaFixture(t, dir, "a.json", "shared test", "")

--- a/scripts/run_hardhat_test.sh
+++ b/scripts/run_hardhat_test.sh
@@ -31,7 +31,6 @@ COMPAT_DIRS=(access crosschain finance governance metatx proxy token utils)
 # it's there — e.g. `grep '"fullTitle": "..."' -A2 testdata/oz-hardhat-results/*.json`
 # to find which file a failing test lives in, without any code needing to track it.
 RESULTS_DIR="${PROJECT_ROOT}/testdata/oz-hardhat-results"
-BASELINE_PATH="${PROJECT_ROOT}/testdata/oz_known_failures.json"
 
 cleanup() {
     if [ -n "${TESTNODE_PID}" ] && kill -0 "${TESTNODE_PID}" 2>/dev/null; then
@@ -159,8 +158,7 @@ run_full_suite() {
     # build is what the (not-yet-built) CI gate is for; a local, exploratory
     # --full run shouldn't error out just because a known failure is still
     # known to fail.
-    go run ./cmd/baseline check --suite oz-hardhat \
-        --baseline "${BASELINE_PATH}" --results "${RESULTS_DIR}/*.json" || true
+    go run ./cmd/baseline check --suite oz-hardhat || true
 }
 
 main() {


### PR DESCRIPTION
This change does a couple of things:

- Adds a CI gate for the OpenZeppelin compatibility tests. Any divergence from the baseline file causes the CI to fail:
  - ❌ Regressions must be fixed, or exceptions manually added to the baseline json
  - 🎉 New tests succeeding? Great, remove the succeeding tests from the baseline json
  - ✅ Only if the outcome matches the baseline json, the CI succeeds.
- Creates or updates a comment on a PR with the ✅/❌/🎉 result of the CI gate and a summary with short instructions.
- Makes the `baseline` tool easier to use with default file names.
- Adds JSON output to the `baseline` tool to make it machine readable.