### PR TITLE
Update compatibility documentation regarding reverted transactions

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -365,7 +365,7 @@ will get no matches and must rely on `eth_getLogs` instead.
 MVCC conflict — the two are indistinguishable at this level (see Transaction lifecycle and
 finality).
 
-**Reverted transactions emit no events**: when a transaction reverts — including a transfer blocked by a compliance contract such as ERC-1404 — no events are emitted and the on-chain log for that transaction is empty. Audit trail for rejected operations must be captured at the application layer.
+**Reverted transactions emit no events**: when a transaction reverts — including a transfer blocked by a compliance contract such as ERC-1404 — no events are emitted and the on-chain log for that transaction is empty. This is consistent with other EVM based systems.
 
 ---
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -365,6 +365,8 @@ will get no matches and must rely on `eth_getLogs` instead.
 MVCC conflict — the two are indistinguishable at this level (see Transaction lifecycle and
 finality).
 
+**Reverted transactions emit no events**: when a transaction reverts — including a transfer blocked by a compliance contract such as ERC-1404 — no events are emitted and the on-chain log for that transaction is empty. Audit trail for rejected operations must be captured at the application layer.
+
 ---
 
 ## eth_call


### PR DESCRIPTION
Adds a note that reverted transactions emit no events on-chain. Relevant for compliance systems using ERC-1404 or similar restricted token standards. Closes #206