### PR TITLE
fix: register hardhat_mine stub in the test RPC

### DIFF
--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -47,6 +47,15 @@ func (api *HardhatAPI) SetCode(ctx context.Context, address common.Address, code
 	return true, nil
 }
 
+// Mine accepts hardhat_mine for RPC compatibility with Hardhat tests.
+// It does not advance chain state: fabric-evm creates blocks via Fabric
+// consensus, not mining. Optional blocks/interval params match Hardhat's
+// signature and are ignored.
+func (api *HardhatAPI) Mine(ctx context.Context, blocks *hexutil.Uint64, interval *hexutil.Uint64) error {
+	hardhatLogger.Debugf("HardhatAPI.Mine() called blocks=%v interval=%v (stub; no state change)", blocks, interval)
+	return nil
+}
+
 // EvmAPI provides EVM-specific RPC methods for testing, particularly snapshot/revert.
 // Uses LightKVS history mechanism to capture and restore ledger state, and Store
 // for database snapshot/revert.

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+
+WARNING: This package contains test-only/unsafe RPC implementations.
+DO NOT use in production environments.
+*/
+
+package testimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("hardhat", NewHardhatAPI()); err != nil {
+		t.Fatalf("RegisterName hardhat: %v", err)
+	}
+
+	client := rpc.DialInProc(srv)
+	defer client.Close()
+
+	// Hardhat accepts zero, one, or two optional hex quantities.
+	cases := []struct {
+		name   string
+		params []any
+	}{
+		{"no params", nil},
+		{"blocks only", []any{"0x100"}},
+		{"blocks and interval", []any{"0x3e8", "0x3c"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result any
+			var err error
+			if len(tc.params) == 0 {
+				err = client.CallContext(context.TODO(), &result, "hardhat_mine")
+			} else {
+				err = client.CallContext(context.TODO(), &result, "hardhat_mine", tc.params...)
+			}
+			if err != nil {
+				t.Fatalf("hardhat_mine: %v", err)
+			}
+			if result != nil {
+				t.Fatalf("result = %#v, want nil", result)
+			}
+		})
+	}
+}

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -2,9 +2,6 @@
 Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: LGPL-3.0-or-later
-
-WARNING: This package contains test-only/unsafe RPC implementations.
-DO NOT use in production environments.
 */
 
 package testimpl
@@ -39,9 +36,9 @@ func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
 			var result any
 			var err error
 			if len(tc.params) == 0 {
-				err = client.CallContext(context.TODO(), &result, "hardhat_mine")
+				err = client.CallContext(context.Background(), &result, "hardhat_mine")
 			} else {
-				err = client.CallContext(context.TODO(), &result, "hardhat_mine", tc.params...)
+				err = client.CallContext(context.Background(), &result, "hardhat_mine", tc.params...)
 			}
 			if err != nil {
 				t.Fatalf("hardhat_mine: %v", err)

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -151,16 +151,7 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessControlDefaultAdminRules defaultAdminDelay() when there is a scheduled delay change returns new delay after delay schedule passes",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules defaultAdminDelay() when there is a scheduled delay change returns old delay before delay schedule passes",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules defaultAdminDelay() when there is a scheduled delay change returns old delay exactly when delay schedule passes",
-    "cause": "hardhat_mine"
+    "id": "AccessControlDefaultAdminRules defaultAdminDelay() when there is a scheduled delay change returns new delay after delay schedule passes"
   },
   {
     "id": "AccessControlDefaultAdminRules owner() changes if the default admin changes",
@@ -173,28 +164,7 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdmin() when there is a scheduled default admin transfer returns pending admin and schedule after it passes if not accepted",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdmin() when there is a scheduled default admin transfer returns pending admin and schedule before it passes if not accepted",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdmin() when there is a scheduled default admin transfer returns pending admin and schedule exactly when it passes if not accepted",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdminDelay() when there is a scheduled delay change returns new delay before delay schedule passes",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdminDelay() when there is a scheduled delay change returns new delay exactly when delay schedule passes",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessControlDefaultAdminRules pendingDefaultAdminDelay() when there is a scheduled delay change returns zero delay after delay schedule passes",
-    "cause": "hardhat_mine"
+    "id": "AccessControlDefaultAdminRules pendingDefaultAdminDelay() when there is a scheduled delay change returns zero delay after delay schedule passes"
   },
   {
     "id": "AccessControlDefaultAdminRules renounces admin allows to recover access using the internal _grantRole",
@@ -243,16 +213,15 @@
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager #execute cannot execute a setAuthority call when a target admin delay is set",
-    "cause": "hardhat_mine"
+    "id": "AccessManager #execute cannot execute a setAuthority call when a target admin delay is set"
   },
   {
     "id": "AccessManager #execute executes with a delay consuming the scheduled operation",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #execute executes with no delay consuming a scheduled operation",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #execute keeps the original _executionId after finishing the call"
@@ -262,12 +231,15 @@
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"succeeds\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -275,18 +247,20 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #execute reverts executing twice",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #schedule increases the nonce of an operation scheduled more than once",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #schedule panics scheduling calldata with less than 4 bytes"
@@ -296,7 +270,8 @@
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager #schedule restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect succeeds"
+    "id": "AccessManager #schedule restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect succeeds",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager #schedule reverts if the specified execution date is before the current timestamp + caller execution delay"
@@ -309,14 +284,19 @@
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -324,24 +304,31 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -349,24 +336,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -374,24 +382,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -399,24 +428,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -424,24 +474,31 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -449,40 +506,64 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member with grant delay \"before each\" hook: set granting delay for \"emits event and immediately changes the execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member with grant delay when decreasing the execution delay emits event"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member without grant delay \"before each\" hook: set granting delay for \"emits event and immediately changes the execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member with grant delay when decreasing the execution delay when execution delay effect delay has not taken effect yet does not change the execution delay yet"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is not a role member with grant delay \"before each\" hook: set grant delay and grant role for \"does not grant role to the user yet\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member with grant delay when decreasing the execution delay when execution delay effect delay has taken effect changes the execution delay"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is not a role member without grant delay \"before each\" hook: set granting delay for \"immediately grants the role to the user\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member with grant delay when increasing the execution delay emits event and immediately changes the execution delay"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member without grant delay when decreasing the execution delay emits event"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member without grant delay when decreasing the execution delay when execution delay effect delay has not taken effect yet does not change the execution delay yet"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member without grant delay when decreasing the execution delay when execution delay effect delay has taken effect changes the execution delay"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is already a role member without grant delay when increasing the execution delay emits event and immediately changes the execution delay"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is not a role member with grant delay when grant delay has not taken effect yet does not grant role to the user yet"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is not a role member with grant delay when grant delay has taken effect grants role to the user"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole when the user is not a role member without grant delay immediately grants the role to the user"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -490,32 +571,48 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole when role has been granted when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"revokes a granted role that will take effect in the future\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole when role has been granted when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"revokes a granted role that already took effect\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole when role has been granted when grant delay has taken effect revokes a granted role that already took effect"
   },
   {
     "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -523,24 +620,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -548,32 +666,51 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay when increasing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay when increasing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\""
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay when reducing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay when reducing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\""
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -581,24 +718,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -606,24 +764,45 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"reverts as AccessManagerNotReady\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is shorter than execution delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is not scheduled reverts as AccessManagerNotScheduled"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect without operation delay when operation is scheduled \"before each\" hook: schedule operation for \"reverts as AccessManagerNotReady\"",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds called directly",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect succeeds via execute",
+    "cause": "execution reverted"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation has expired reverts as AccessManagerExpired",
@@ -631,54 +810,44 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds called directly",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is not delayed when caller has an execution delay when operation is scheduled when operation is ready for execution succeeds via execute",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay when increasing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay when increasing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\""
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay when reducing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay when reducing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\""
   },
   {
     "id": "AccessManager getters #canCall when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"should return true and no delay\"",
     "cause": "hardhat_impersonateAccount"
   },
   {
-    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"should return false and no execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled should return false and execution delay"
   },
   {
-    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"should return false and execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is scheduled \"before each\" hook: schedule operation for \"should return false and execution delay\"",
+    "cause": "execution reverted"
   },
   {
-    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"should return false and no execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect should return true and no execution delay"
   },
   {
-    "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"should return true and no execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has not taken effect yet role is not in effect and execution delay is set"
   },
   {
-    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"role is not in effect and execution delay is set\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect access has role in effect and execution delay is set"
   },
   {
-    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"access has role in effect and execution delay is set\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has not taken effect yet access has role not in effect without execution delay"
   },
   {
-    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"access has role not in effect without execution delay\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"role is in effect without execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect role is in effect without execution delay"
   },
   {
     "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is not delayed when caller has an execution delay access has role in effect and execution delay is set"
@@ -687,48 +856,25 @@
     "id": "AccessManager getters #getAccess when the required role is granted to the caller when role granting is not delayed when caller has no execution delay access has role in effect without execution delay"
   },
   {
-    "id": "AccessManager getters #getRoleGrantDelay when the grant admin delay is setup when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"returns the old role grant delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getRoleGrantDelay when the grant admin delay is setup when grant delay has taken effect returns the new role grant delay"
   },
   {
-    "id": "AccessManager getters #getRoleGrantDelay when the grant admin delay is setup when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"returns the new role grant delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getSchedule when operation is scheduled when operation has expired returns 0"
   },
   {
-    "id": "AccessManager getters #getSchedule when operation is scheduled when operation has expired \"before each\" hook: set next block time when operation expired for \"returns 0\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getSchedule when operation is scheduled when operation is not ready for execution returns schedule in the future"
   },
   {
-    "id": "AccessManager getters #getSchedule when operation is scheduled when operation is not ready for execution \"before each\" hook: set next block time before operation is ready for \"returns schedule in the future\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getSchedule when operation is scheduled when operation is ready for execution returns schedule"
   },
   {
-    "id": "AccessManager getters #getSchedule when operation is scheduled when operation is ready for execution \"before each\" hook: set next block time when operation is ready for execution for \"returns schedule\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #getTargetAdminDelay when the target admin delay is setup when effect delay has taken effect returns the new target admin delay"
   },
   {
-    "id": "AccessManager getters #getTargetAdminDelay when the target admin delay is setup when effect delay has not taken effect yet \"before each\" hook: set next block timestamp before effect takes effect for \"returns the old target admin delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect has role and execution delay"
   },
   {
-    "id": "AccessManager getters #getTargetAdminDelay when the target admin delay is setup when effect delay has taken effect \"before each\" hook: set next block timestamp when effect takes effect for \"returns the new target admin delay\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"does not have role but execution delay\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"has role and execution delay\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has not taken effect yet \"before each\" hook: set next block timestamp before grant takes effect for \"does not have role nor execution delay\"",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect \"before each\" hook: set next block timestamp when grant takes effect for \"has role and no execution delay\"",
-    "cause": "hardhat_mine"
+    "id": "AccessManager getters #hasRole when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has no execution delay when grant delay has taken effect has role and no execution delay"
   },
   {
     "id": "Address functionCall with valid contract receiver reverts when the called function runs out of gas"
@@ -771,11 +917,7 @@
   },
   {
     "id": "BlockHeader reads all fields from pre-parsed list",
-    "cause": "hardhat_mine"
-  },
-  {
-    "id": "BlockHeader verify rejects tampered header",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "Clones with immutable args: 0x clone construct with value factory has enough balance",
@@ -922,15 +1064,15 @@
     "cause": "personal_sign"
   },
   {
-    "id": "ECDSA recover with valid signature using \u003csigner\u003e.sign returns a different address",
+    "id": "ECDSA recover with valid signature using <signer>.sign returns a different address",
     "cause": "personal_sign"
   },
   {
-    "id": "ECDSA recover with valid signature using \u003csigner\u003e.sign returns signer address with correct signature",
+    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature",
     "cause": "personal_sign"
   },
   {
-    "id": "ECDSA recover with valid signature using \u003csigner\u003e.sign returns signer address with correct signature for arbitrary length message",
+    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature for arbitrary length message",
     "cause": "personal_sign"
   },
   {
@@ -1367,7 +1509,7 @@
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes generally returns the voting balance at the appropriate checkpoint",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes returns 0 if there are no checkpoints",
@@ -1375,12 +1517,12 @@
     "note": "block.number is hardcoded at 0 (see COMPATIBILITY.md); manifests as block-number diffs or checkpoint-count mismatches, since checkpoints never actually advance"
   },
   {
-    "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite numCheckpoints does not add more than one checkpoint in a block",
@@ -1403,7 +1545,7 @@
   },
   {
     "id": "ERC20Votes vote with blockNumber getPastTotalSupply generally returns the voting balance at the appropriate checkpoint",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber getPastTotalSupply returns 0 if there are no checkpoints",
@@ -1411,12 +1553,12 @@
     "note": "block.number is hardcoded at 0 (see COMPATIBILITY.md); manifests as block-number diffs or checkpoint-count mismatches, since checkpoints never actually advance"
   },
   {
-    "id": "ERC20Votes vote with blockNumber getPastTotalSupply returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber getPastTotalSupply returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with blockNumber getPastTotalSupply returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber getPastTotalSupply returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber recent checkpoints",
@@ -1429,12 +1571,12 @@
     "note": "block.number is hardcoded at 0 (see COMPATIBILITY.md); manifests as block-number diffs or checkpoint-count mismatches, since checkpoints never actually advance"
   },
   {
-    "id": "ERC20Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature delegation update",
@@ -1473,7 +1615,7 @@
   },
   {
     "id": "ERC20Votes vote with blockNumber run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with blockNumber set delegation call delegation with balance",
@@ -1502,19 +1644,19 @@
   },
   {
     "id": "ERC20Votes vote with blockNumber transfers \"after each\" hook for \"no delegation\"",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with timestamp Compound test suite getPastVotes generally returns the voting balance at the appropriate checkpoint",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with timestamp Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with timestamp Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with timestamp Compound test suite numCheckpoints does not add more than one checkpoint in a block",
@@ -1537,15 +1679,15 @@
   },
   {
     "id": "ERC20Votes vote with timestamp getPastTotalSupply generally returns the voting balance at the appropriate checkpoint",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with timestamp getPastTotalSupply returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp getPastTotalSupply returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with timestamp getPastTotalSupply returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp getPastTotalSupply returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with timestamp recent checkpoints",
@@ -1553,12 +1695,12 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "ERC20Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC20Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC20Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature delegation update",
@@ -1592,7 +1734,7 @@
   },
   {
     "id": "ERC20Votes vote with timestamp run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC20Votes vote with timestamp set delegation call delegation with balance",
@@ -1621,7 +1763,7 @@
   },
   {
     "id": "ERC20Votes vote with timestamp transfers \"after each\" hook for \"no delegation\"",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC2771Context \"before each\" hook for \"recognize trusted forwarder\"",
@@ -1717,11 +1859,11 @@
   },
   {
     "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects at the validAfter boundary (current == validAfter)",
-    "cause": "hardhat_mine"
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects at the validBefore boundary (current == validBefore)",
-    "cause": "hardhat_mine"
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects authorization not yet valid",
@@ -1820,10 +1962,12 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC6372Utils blockNumber clock mode from uint48"
+    "id": "ERC6372Utils blockNumber clock mode from uint48",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC6372Utils timestamp clock mode from uint48"
+    "id": "ERC6372Utils timestamp clock mode from uint48",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC6909 like an ERC6909 ERC165 when the interfaceId is not supported uses less than 30k",
@@ -1898,21 +2042,24 @@
     "cause": "fixed-block-number"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints"
+    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "ERC721Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature delegation update"
+    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature delegation update",
+    "cause": "execution reverted"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature delegation with tokens"
+    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature delegation with tokens",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature accept signed delegation",
@@ -1935,15 +2082,16 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints"
+    "id": "ERC721Votes vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
     "id": "ERC721Votes vote with blockNumber run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC721Votes vote with blockNumber transfers \"after each\" hook for \"no delegation\"",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "ERC721Wrapper ERC712 behavior ERC165 when the interfaceId is not supported uses less than 30k",
@@ -2113,1062 +2261,1062 @@
   {
     "id": "Packing extract / replace extract bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes1 + bytes1 =\u003e bytes2",
+    "id": "Packing pack pack bytes1 + bytes1 => bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes10 + bytes10 =\u003e bytes20",
+    "id": "Packing pack pack bytes10 + bytes10 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes10 + bytes12 =\u003e bytes22",
+    "id": "Packing pack pack bytes10 + bytes12 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes10 + bytes2 =\u003e bytes12",
+    "id": "Packing pack pack bytes10 + bytes2 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes10 + bytes22 =\u003e bytes32",
+    "id": "Packing pack pack bytes10 + bytes22 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes10 + bytes6 =\u003e bytes16",
+    "id": "Packing pack pack bytes10 + bytes6 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes10 =\u003e bytes22",
+    "id": "Packing pack pack bytes12 + bytes10 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes12 =\u003e bytes24",
+    "id": "Packing pack pack bytes12 + bytes12 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes16 =\u003e bytes28",
+    "id": "Packing pack pack bytes12 + bytes16 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes20 =\u003e bytes32",
+    "id": "Packing pack pack bytes12 + bytes20 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes4 =\u003e bytes16",
+    "id": "Packing pack pack bytes12 + bytes4 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes12 + bytes8 =\u003e bytes20",
+    "id": "Packing pack pack bytes12 + bytes8 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes16 + bytes12 =\u003e bytes28",
+    "id": "Packing pack pack bytes16 + bytes12 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes16 + bytes16 =\u003e bytes32",
+    "id": "Packing pack pack bytes16 + bytes16 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes16 + bytes4 =\u003e bytes20",
+    "id": "Packing pack pack bytes16 + bytes4 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes16 + bytes6 =\u003e bytes22",
+    "id": "Packing pack pack bytes16 + bytes6 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes16 + bytes8 =\u003e bytes24",
+    "id": "Packing pack pack bytes16 + bytes8 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes10 =\u003e bytes12",
+    "id": "Packing pack pack bytes2 + bytes10 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes2 =\u003e bytes4",
+    "id": "Packing pack pack bytes2 + bytes2 => bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes20 =\u003e bytes22",
+    "id": "Packing pack pack bytes2 + bytes20 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes22 =\u003e bytes24",
+    "id": "Packing pack pack bytes2 + bytes22 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes4 =\u003e bytes6",
+    "id": "Packing pack pack bytes2 + bytes4 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes6 =\u003e bytes8",
+    "id": "Packing pack pack bytes2 + bytes6 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes2 + bytes8 =\u003e bytes10",
+    "id": "Packing pack pack bytes2 + bytes8 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes20 + bytes12 =\u003e bytes32",
+    "id": "Packing pack pack bytes20 + bytes12 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes20 + bytes2 =\u003e bytes22",
+    "id": "Packing pack pack bytes20 + bytes2 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes20 + bytes4 =\u003e bytes24",
+    "id": "Packing pack pack bytes20 + bytes4 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes20 + bytes8 =\u003e bytes28",
+    "id": "Packing pack pack bytes20 + bytes8 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes22 + bytes10 =\u003e bytes32",
+    "id": "Packing pack pack bytes22 + bytes10 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes22 + bytes2 =\u003e bytes24",
+    "id": "Packing pack pack bytes22 + bytes2 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes22 + bytes6 =\u003e bytes28",
+    "id": "Packing pack pack bytes22 + bytes6 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes24 + bytes4 =\u003e bytes28",
+    "id": "Packing pack pack bytes24 + bytes4 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes24 + bytes8 =\u003e bytes32",
+    "id": "Packing pack pack bytes24 + bytes8 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes28 + bytes4 =\u003e bytes32",
+    "id": "Packing pack pack bytes28 + bytes4 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes12 =\u003e bytes16",
+    "id": "Packing pack pack bytes4 + bytes12 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes16 =\u003e bytes20",
+    "id": "Packing pack pack bytes4 + bytes16 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes2 =\u003e bytes6",
+    "id": "Packing pack pack bytes4 + bytes2 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes20 =\u003e bytes24",
+    "id": "Packing pack pack bytes4 + bytes20 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes24 =\u003e bytes28",
+    "id": "Packing pack pack bytes4 + bytes24 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes28 =\u003e bytes32",
+    "id": "Packing pack pack bytes4 + bytes28 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes4 =\u003e bytes8",
+    "id": "Packing pack pack bytes4 + bytes4 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes6 =\u003e bytes10",
+    "id": "Packing pack pack bytes4 + bytes6 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes4 + bytes8 =\u003e bytes12",
+    "id": "Packing pack pack bytes4 + bytes8 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes10 =\u003e bytes16",
+    "id": "Packing pack pack bytes6 + bytes10 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes16 =\u003e bytes22",
+    "id": "Packing pack pack bytes6 + bytes16 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes2 =\u003e bytes8",
+    "id": "Packing pack pack bytes6 + bytes2 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes22 =\u003e bytes28",
+    "id": "Packing pack pack bytes6 + bytes22 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes4 =\u003e bytes10",
+    "id": "Packing pack pack bytes6 + bytes4 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes6 + bytes6 =\u003e bytes12",
+    "id": "Packing pack pack bytes6 + bytes6 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes12 =\u003e bytes20",
+    "id": "Packing pack pack bytes8 + bytes12 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes16 =\u003e bytes24",
+    "id": "Packing pack pack bytes8 + bytes16 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes2 =\u003e bytes10",
+    "id": "Packing pack pack bytes8 + bytes2 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes20 =\u003e bytes28",
+    "id": "Packing pack pack bytes8 + bytes20 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes24 =\u003e bytes32",
+    "id": "Packing pack pack bytes8 + bytes24 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes4 =\u003e bytes12",
+    "id": "Packing pack pack bytes8 + bytes4 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
-    "id": "Packing pack pack bytes8 + bytes8 =\u003e bytes16",
+    "id": "Packing pack pack bytes8 + bytes8 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity consume consume one key does not affect another key"
@@ -3177,16 +3325,14 @@
     "id": "RateLimiter RefillingBucket with some capacity consume consume(0) is a no-op that returns true"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity fully refills after a window has elapsed",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity fully refills after a window has elapsed"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity multiple consumes in the same block accumulate",
     "cause": "evm_setAutomine"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity refills linearly over time",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity refills linearly over time"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume one key does not affect another key"
@@ -3195,44 +3341,36 @@
     "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume(0) is a no-op that returns true"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity updateSettings side effect on usage",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity updateSettings side effect on usage"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity updateSettings with window=0 collapses refill to a single second",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity updateSettings with window=0 collapses refill to a single second"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity used does not go below zero",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity used does not go below zero"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity used saturates to zero after a long idle",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter RefillingBucket with some capacity used saturates to zero after a long idle"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity using sync to mitigate updateSettings side effect",
     "cause": "evm_setAutomine"
   },
   {
-    "id": "RateLimiter SlidingWindow with some capacity consume after a full-window idle truncates cumulative history",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter SlidingWindow with some capacity consume after a full-window idle truncates cumulative history"
   },
   {
     "id": "RateLimiter SlidingWindow with some capacity multiple consumes in the same block overwrite the checkpoint in place",
     "cause": "evm_setAutomine"
   },
   {
-    "id": "RateLimiter SlidingWindow with some capacity only consumptions outside the window drop out",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter SlidingWindow with some capacity only consumptions outside the window drop out"
   },
   {
-    "id": "RateLimiter SlidingWindow with some capacity past consumptions drop out after the window elapses",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter SlidingWindow with some capacity past consumptions drop out after the window elapses"
   },
   {
-    "id": "RateLimiter SlidingWindow with some capacity updateSettings with window=0 collapses window to a single second",
-    "cause": "hardhat_mine"
+    "id": "RateLimiter SlidingWindow with some capacity updateSettings with window=0 collapses window to a single second"
   },
   {
     "id": "RelayedCall default (zero) salt direct call to the relayer"
@@ -3280,7 +3418,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Time Delay get \u0026 getFull",
+    "id": "Time Delay get & getFull",
     "cause": "fixed-timestamp",
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
@@ -3308,66 +3446,63 @@
     "cause": "gas-stub"
   },
   {
-    "id": "TimelockController dependency \"before each\" hook for \"cannot execute before dependency\"",
-    "cause": "hardhat_mine"
+    "id": "TimelockController dependency can execute after dependency",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "TimelockController dependency cannot execute before dependency"
   },
   {
     "id": "TimelockController maintenance timelock scheduled maintenance",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "TimelockController methods batch execute partial execution",
-    "cause": "hardhat_mine"
+    "id": "TimelockController methods batch execute partial execution"
   },
   {
-    "id": "TimelockController methods batch execute with scheduled operation on time \"before each\" hook for \"executor can reveal\"",
-    "cause": "hardhat_mine"
+    "id": "TimelockController methods batch execute with scheduled operation on time executor can reveal",
+    "cause": "execution reverted"
   },
   {
-    "id": "TimelockController methods batch execute with scheduled operation revert if execution comes too early 2/2",
-    "cause": "hardhat_mine"
+    "id": "TimelockController methods batch execute with scheduled operation on time prevents reentrancy execution",
+    "cause": "execution reverted"
   },
   {
     "id": "TimelockController methods batch schedule proposer can schedule"
   },
   {
-    "id": "TimelockController methods simple execute with scheduled operation on time \"before each\" hook for \"executor can reveal\"",
-    "cause": "hardhat_mine"
+    "id": "TimelockController methods simple execute with scheduled operation on time executor can reveal",
+    "cause": "execution reverted"
   },
   {
-    "id": "TimelockController methods simple execute with scheduled operation revert if execution comes too early 2/2",
-    "cause": "hardhat_mine"
+    "id": "TimelockController methods simple execute with scheduled operation on time prevents reentrancy execution",
+    "cause": "execution reverted"
   },
   {
     "id": "TimelockController methods simple schedule proposer can schedule"
   },
   {
     "id": "TimelockController usage scenario call",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "TimelockController usage scenario call nonpayable with eth",
-    "cause": "hardhat_mine"
+    "id": "TimelockController usage scenario call nonpayable with eth"
   },
   {
-    "id": "TimelockController usage scenario call out of gas",
-    "cause": "hardhat_mine"
+    "id": "TimelockController usage scenario call out of gas"
   },
   {
     "id": "TimelockController usage scenario call payable with eth",
-    "cause": "hardhat_mine"
+    "cause": "insufficient-funds"
   },
   {
-    "id": "TimelockController usage scenario call reverting",
-    "cause": "hardhat_mine"
+    "id": "TimelockController usage scenario call reverting"
   },
   {
-    "id": "TimelockController usage scenario call reverting with eth",
-    "cause": "hardhat_mine"
+    "id": "TimelockController usage scenario call reverting with eth"
   },
   {
-    "id": "TimelockController usage scenario call throw",
-    "cause": "hardhat_mine"
+    "id": "TimelockController usage scenario call throw"
   },
   {
     "id": "TransparentUpgradeableProxy \"before each\" hook for \"cannot be initialized with a non-contract address\"",
@@ -3414,21 +3549,24 @@
     "cause": "fixed-block-number"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints"
+    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "Votes vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature delegation update"
+    "id": "Votes vote with blockNumber run votes workflow delegation with signature delegation update",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature delegation with tokens"
+    "id": "Votes vote with blockNumber run votes workflow delegation with signature delegation with tokens",
+    "cause": "execution reverted"
   },
   {
     "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature accept signed delegation",
@@ -3451,29 +3589,32 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints"
+    "id": "Votes vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
     "id": "Votes vote with blockNumber run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "Votes vote with timestamp ERC-6372 behavior in timestamp mode should have a correct clock value",
     "cause": "fixed-timestamp"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "Votes vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature delegation update"
+    "id": "Votes vote with timestamp run votes workflow delegation with signature delegation update",
+    "cause": "execution reverted"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature delegation with tokens"
+    "id": "Votes vote with timestamp run votes workflow delegation with signature delegation with tokens",
+    "cause": "execution reverted"
   },
   {
     "id": "Votes vote with timestamp run votes workflow delegation with signature with signature accept signed delegation",
@@ -3497,38 +3638,38 @@
   },
   {
     "id": "Votes vote with timestamp run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "VotesExtended checkpoint balances with blockNumber checkpoint balances",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended checkpoint balances with blockNumber reverts if current timepoint \u003c= timepoint",
+    "id": "VotesExtended checkpoint balances with blockNumber reverts if current timepoint <= timepoint",
     "cause": "fixed-block-number"
   },
   {
     "id": "VotesExtended checkpoint balances with timestamp checkpoint balances",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended checkpoint balances with timestamp reverts if current timepoint \u003c= timepoint",
+    "id": "VotesExtended checkpoint balances with timestamp reverts if current timepoint <= timepoint",
     "cause": "fixed-timestamp"
   },
   {
     "id": "VotesExtended checkpoint delegates with blockNumber checkpoint delegates",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended checkpoint delegates with blockNumber reverts if current timepoint \u003c= timepoint",
+    "id": "VotesExtended checkpoint delegates with blockNumber reverts if current timepoint <= timepoint",
     "cause": "fixed-block-number"
   },
   {
     "id": "VotesExtended checkpoint delegates with timestamp checkpoint delegates",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended checkpoint delegates with timestamp reverts if current timepoint \u003c= timepoint",
+    "id": "VotesExtended checkpoint delegates with timestamp reverts if current timepoint <= timepoint",
     "cause": "fixed-timestamp"
   },
   {
@@ -3536,21 +3677,24 @@
     "cause": "fixed-block-number"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints"
+    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "VotesExtended vote with blockNumber run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature delegation update"
+    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature delegation update",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature delegation with tokens"
+    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature delegation with tokens",
+    "cause": "execution reverted"
   },
   {
     "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature accept signed delegation",
@@ -3573,29 +3717,32 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints"
+    "id": "VotesExtended vote with blockNumber run votes workflow getPastTotalSupply returns 0 if there are no checkpoints",
+    "cause": "execution reverted"
   },
   {
     "id": "VotesExtended vote with blockNumber run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   },
   {
     "id": "VotesExtended vote with timestamp ERC-6372 behavior in timestamp mode should have a correct clock value",
     "cause": "fixed-timestamp"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if \u003e= last checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "VotesExtended vote with timestamp run votes workflow Compound test suite getPastVotes returns the latest block if >= last checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if \u003c first checkpoint block",
-    "cause": "hardhat_mine"
+    "id": "VotesExtended vote with timestamp run votes workflow Compound test suite getPastVotes returns zero if < first checkpoint block",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature delegation update"
+    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature delegation update",
+    "cause": "execution reverted"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature delegation with tokens"
+    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature delegation with tokens",
+    "cause": "execution reverted"
   },
   {
     "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature accept signed delegation",
@@ -3619,6 +3766,6 @@
   },
   {
     "id": "VotesExtended vote with timestamp run votes workflow getPastTotalSupply returns the correct checkpointed total supply",
-    "cause": "hardhat_mine"
+    "cause": "execution reverted"
   }
 ]


### PR DESCRIPTION
Closes #251
Part of #248

Registers `hardhat_mine` on the test RPC next to the existing Hardhat helpers. This is a stub: the call succeeds and optional `blocks` / `interval` args are accepted for signature compatibility, but chain state is not advanced. Fabric still produces blocks through consensus, so real block or timestamp control stays out of scope (same boundary the issue calls out).

Most OZ callers that hit this method only need it not to return "method not found" (RateLimiter / ERC3009 / ERC20TransferAuthorization setup paths). That matches how `evm_mine` is already stubbed.

## Code

`gateway/testimpl/hardhat_helpers.go` adds `HardhatAPI.Mine`. The hardhat namespace is already registered in the test server, so no wiring change was required beyond the method itself.

`gateway/testimpl/hardhat_helpers_test.go` covers the in process RPC path with zero, one, and two optional hex params (Hardhat docs examples).

## Baseline

After a full compatible set run (`make hardhat-tests-full` / `scripts/run_hardhat_test.sh --full`), `testdata/oz_known_failures.json` was reconciled so the scoreboard matches the stub being present:

* 125 prior failures tagged `hardhat_mine` are gone as a cause
* 52 of those tests now pass and were dropped from the baseline
* remaining failures that used to die on the missing method fail later for other reasons (reverts, funds, timestamps, etc.) and are recorded accordingly

### Full suite summary

```
4755 passed, 896 failed, 1 skipped (5652 total, 84.1% passing)
```

By suite: finance 0/2, metatx 0/12, governance 77/185, access 354/578, crosschain 10/15, proxy 194/252, token 1637/1852, utils 2483/2755.

`cmd/baseline check` against that run is clean (no regressions, no stale entries). Result JSON under `testdata/oz-hardhat-results/` stays gitignored.

## Validation

* `go test ./gateway/testimpl/ ./cmd/baseline/`
* `go test ./... -short`
* `go vet` / `staticcheck` on the tree
* CI style Hardhat path: `ERC20.test.js` (126 passing)
* full OZ compatible set + baseline check as above

Happy to tweak cause tags on the new baseline entries if a different labeling pass is preferred.
