### PR TITLE
test: fix execution-specs harness gaps, wire up CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,30 @@ jobs:
       - name: Fabric integration tests
         run: make integration-tests
 
+  execution-specs-tests:
+    name: Execution-Specs Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: quick-tests
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'want-integration-tests'))
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Execution-specs state tests
+        run: make eth-tests-execution-specs
+
   optional-tests:
     name: Optional Tests
     runs-on: ubuntu-latest

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -227,6 +227,12 @@ roots. Because the EVM reads account state (existence, `HasSelfDestructed`, stor
 root — SELFDESTRUCT and CREATE/CREATE2-collision / empty-account cases. These divergences are
 deliberate consequences of the modern-only semantics above, not regressions.
 
+The newer execution-specs suite (`TestExecutionSpecStateTests`, Osaka-forward fixtures) exercises
+the same paths and compares against the fixtures' expected roots. Its known-divergent cases are
+quarantined in `testdata/execution_specs_tests.skip`: the EIP-7610 create-collision fixtures above,
+and a `CREATE` transaction from a non-existent sender (currently a nil-pointer panic in
+`DualStateDB.Snapshot`). All other Osaka-forward state tests pass.
+
 **Native ETH balances not funded**: balances are implemented but unused. Accounts have zero ETH 
 balance by default. Value transfers inside the EVM (`CALL` with value, `SELFDESTRUCT` beneficiary, 
 etc.) will fail or produce wrong results for accounts that were never explicitly funded.

--- a/integration/ethereum_helpers.go
+++ b/integration/ethereum_helpers.go
@@ -162,13 +162,20 @@ func buildTransaction(testTx *stTransaction, dataIndex, gasIndex, valueIndex int
 			if chainID == nil {
 				chainID = big.NewInt(0)
 			}
+			r, s := auth.R, auth.S
+			if r == nil {
+				r = big.NewInt(0)
+			}
+			if s == nil {
+				s = big.NewInt(0)
+			}
 			authList[i] = types.SetCodeAuthorization{
 				ChainID: *uint256.MustFromBig(chainID),
 				Address: auth.Address,
 				Nonce:   auth.Nonce,
 				V:       auth.V,
-				R:       *uint256.MustFromBig(auth.R),
-				S:       *uint256.MustFromBig(auth.S),
+				R:       *uint256.MustFromBig(r),
+				S:       *uint256.MustFromBig(s),
 			}
 		}
 

--- a/integration/ethereum_helpers.go
+++ b/integration/ethereum_helpers.go
@@ -140,6 +140,68 @@ func buildTransaction(testTx *stTransaction, dataIndex, gasIndex, valueIndex int
 		return tx, nil
 	}
 
+	// EIP-7702 SetCodeTx (type 4); gate on presence so an empty auth list still builds a (rejectable) type-4.
+	if testTx.AuthorizationList != nil {
+		maxFeePerGas := testTx.MaxFeePerGas
+		if maxFeePerGas == nil {
+			maxFeePerGas = gasPrice
+		}
+		maxPriorityFeePerGas := testTx.MaxPriorityFeePerGas
+		if maxPriorityFeePerGas == nil {
+			maxPriorityFeePerGas = gasPrice
+		}
+
+		var accessList types.AccessList
+		if testTx.AccessLists != nil && dataIndex < len(testTx.AccessLists) && testTx.AccessLists[dataIndex] != nil {
+			accessList = *testTx.AccessLists[dataIndex]
+		}
+
+		authList := make([]types.SetCodeAuthorization, len(testTx.AuthorizationList))
+		for i, auth := range testTx.AuthorizationList {
+			chainID := auth.ChainID
+			if chainID == nil {
+				chainID = big.NewInt(0)
+			}
+			authList[i] = types.SetCodeAuthorization{
+				ChainID: *uint256.MustFromBig(chainID),
+				Address: auth.Address,
+				Nonce:   auth.Nonce,
+				V:       auth.V,
+				R:       *uint256.MustFromBig(auth.R),
+				S:       *uint256.MustFromBig(auth.S),
+			}
+		}
+
+		// SetCodeTx requires a non-nil recipient.
+		var toAddr common.Address
+		if to != nil {
+			toAddr = *to
+		}
+
+		txData := &types.SetCodeTx{
+			ChainID:    uint256.MustFromBig(config.ChainID),
+			Nonce:      nonce,
+			GasTipCap:  uint256.MustFromBig(maxPriorityFeePerGas),
+			GasFeeCap:  uint256.MustFromBig(maxFeePerGas),
+			Gas:        gasLimit,
+			To:         toAddr,
+			Value:      uint256.MustFromBig(value),
+			Data:       data,
+			AccessList: accessList,
+			AuthList:   authList,
+		}
+
+		if len(testTx.PrivateKey) > 0 {
+			key, err := crypto.ToECDSA(testTx.PrivateKey)
+			if err != nil {
+				return nil, fmt.Errorf("invalid secret key: %w", err)
+			}
+			return types.SignNewTx(key, types.LatestSignerForChainID(config.ChainID), txData)
+		}
+
+		return types.NewTx(txData), nil
+	}
+
 	// Handle EIP-1559 transactions
 	if testTx.MaxFeePerGas != nil || testTx.MaxPriorityFeePerGas != nil {
 		maxFeePerGas := testTx.MaxFeePerGas

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset"
@@ -335,10 +337,12 @@ func runEthereumTestConfig(t *testing.T, stateTest *StateTest, subtest StateSubt
 	}
 
 	if tx.Type() != types.BlobTxType && // our pre-execution validation doesn't support blob txes yet
+		tx.Type() != types.SetCodeTxType && // nor set-code (EIP-7702) txes yet
 		tx.Protected() { // our pre-execution validation only support protected transactions
 
-		// err out if we got a pre-validation error which we wouldn't get again when endorsing
-		if preExecErr != nil && execErr == nil {
+		// err out if we got a pre-validation error which we wouldn't get again when endorsing.
+		// ErrOversizedData is a mempool-only size limit, not a consensus rule, so don't fail on it.
+		if preExecErr != nil && execErr == nil && !errors.Is(preExecErr, txpool.ErrOversizedData) {
 			t.Fatalf("unexpected pre-validation error %q", preExecErr)
 		}
 	}

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -333,12 +333,13 @@ func (sp *StatePrimer) commitAndWait(end sdk.Endorsement, tx *types.Transaction,
 		}
 	}
 
-	ec, err := NewNativeEthClient(sp.gw)
-	if err != nil {
-		return err
-	}
-
+	// Only create the in-proc RPC client when we wait; the no-wait path leaked it.
 	if wait {
+		ec, err := NewNativeEthClient(sp.gw)
+		if err != nil {
+			return err
+		}
+		defer ec.Close()
 		return waitForCommit(context.Background(), ec, tx)
 	}
 

--- a/integration/state_test_util.go
+++ b/integration/state_test_util.go
@@ -176,6 +176,14 @@ func (tx *stTransaction) UnmarshalJSON(data []byte) error {
 		Sender               *common.Address
 		BlobVersionedHashes  []common.Hash
 		BlobGasFeeCap        *math.HexOrDecimal256 `json:"maxFeePerBlobGas"`
+		AuthorizationList    []*struct {
+			ChainID *math.HexOrDecimal256 `json:"chainId"`
+			Address common.Address        `json:"address"`
+			Nonce   math.HexOrDecimal64   `json:"nonce"`
+			V       math.HexOrDecimal64   `json:"v"`
+			R       *math.HexOrDecimal256 `json:"r"`
+			S       *math.HexOrDecimal256 `json:"s"`
+		} `json:"authorizationList"`
 	}
 	var dec stTransactionMarshaling
 	if err := json.Unmarshal(data, &dec); err != nil {
@@ -204,6 +212,19 @@ func (tx *stTransaction) UnmarshalJSON(data []byte) error {
 	tx.BlobVersionedHashes = dec.BlobVersionedHashes
 	if dec.BlobGasFeeCap != nil {
 		tx.BlobGasFeeCap = (*big.Int)(dec.BlobGasFeeCap)
+	}
+	if dec.AuthorizationList != nil {
+		tx.AuthorizationList = make([]*stAuthorization, len(dec.AuthorizationList))
+		for i, auth := range dec.AuthorizationList {
+			tx.AuthorizationList[i] = &stAuthorization{
+				ChainID: (*big.Int)(auth.ChainID),
+				Address: auth.Address,
+				Nonce:   uint64(auth.Nonce),
+				V:       uint8(auth.V),
+				R:       (*big.Int)(auth.R),
+				S:       (*big.Int)(auth.S),
+			}
+		}
 	}
 	return nil
 }

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -400,7 +400,6 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 		protocol = "fabric"
 	}
 
-	tname := strings.ReplaceAll(strings.ReplaceAll(t.Name(), "/", "_"), ".", "-")
 	dir := t.TempDir()
 	cfg := config.Config{
 		Network: common.Network{
@@ -412,8 +411,8 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 		},
 		Gateway: config.Gateway{
 			Database: config.DB{
-				ConnString: filepath.Join(dir, tname+"gateway.db"),
-				TriePath:   filepath.Join(dir, tname+"triedb.db"),
+				ConnString: filepath.Join(dir, "gateway.db"),
+				TriePath:   filepath.Join(dir, "triedb.db"),
 			},
 			SyncTimeout: 2 * time.Second,
 			Orderers: []common.ClientConfig{
@@ -429,7 +428,7 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 				Name:      "endorser1",
 				Database: econf.DB{
 					Database:    "memory",
-					ConnString:  filepath.Join(dir, tname+"endorser1.db"),
+					ConnString:  filepath.Join(dir, "endorser1.db"),
 					HistorySize: 1,
 				},
 			},

--- a/testdata/execution_specs_tests.skip
+++ b/testdata/execution_specs_tests.skip
@@ -1,3 +1,23 @@
-# Tests skipped for the execution-specs conformance suite (TestExecutionSpecStateTests).
-# One test path per line; blank lines and lines starting with '#' are ignored.
-# Populated in the skip/slow triage chunk (#237) — empty for now.
+# execution-specs state_tests that are skipped in ALL modes.
+# Each entry is a genuine fabric-x-evm bug (filed separately), quarantined here so the
+# conformance suite stays green in CI. Full failure evidence is in the PR description.
+#
+# --- EIP-7610 create-collision divergence (Cancun+): CREATE/CREATE2 into an account that
+#     already has storage/code produces a wrong post-state root. Known StateDB gap (cf. #193).
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
+#
+# --- nil-pointer panic in DualStateDB.Snapshot for a CREATE tx from a non-existent sender.
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json


### PR DESCRIPTION
## Addressed issue
Closes #237

## Summary
Triage of the execution-specs suite. Investigating the failures, the large
majority turned out to be **test-harness gaps, not EVM gaps** — fixing them
makes those tests pass rather than be skipped. Only two genuine StateDB gaps
remain, which are skipped and documented.

Harness fixes:
- **EIP-7702 set-code (type 4):** the fixture parser ignored `authorizationList`
  and `buildTransaction` had no type-4 branch, so set-code txs were built as
  type-2 with the auth list dropped and never exercised. Parse the list and
  build a proper `SetCodeTx` (gated on presence, so an empty list still builds a
  rejectable type-4). This also fixes the EIP-7623 calldata-cost fixtures (type-4).
- **Pre-validation:** exclude set-code (type 4) txs and the mempool-only
  oversized-data (`txMaxSize`) limit from the state-test's fatal pre-validation —
  neither is a consensus rule the reference tests apply. (Fixes EIP-7825 gas-cap
  and EIP-2537 BLS large-calldata cases.)
- **DB filenames:** stop prefixing the test SQLite DB filenames with the full
  test name — the huge EEST names exceed the OS 255-byte filename limit and
  failed ~3000 tests at harness creation. `t.TempDir()` already isolates each test.
- **RPC client:** only create the in-proc eth client in the state primer when
  it's actually used (the no-wait path leaked it).
- **Skip** (`testdata/execution_specs_tests.skip`) the only genuine StateDB gaps
  — EIP-7610 create-collision (the `GetStorageRoot` stub disables the collision
  guard) and a `CREATE` from a non-existent sender (nil-pointer panic in
  `DualStateDB.Snapshot`). Reasons documented in `docs/COMPATIBILITY.md`.
- **CI:** add a label-gated `execution-specs-tests` job (fetch fixtures + run the
  suite), parallel to the existing Ethereum tests job.

Note: EIP-4844 blob and EIP-7702 set-code txs are rejected at submission by the
gateway (documented), but the state-test path exercises EVM execution, which
passes — different layers.

## Validation done
- `make checks`, `gofmt`, `go build ./...` clean.
- `make eth-tests-execution-specs` green: exit 0, 8157 fixtures run, 0 DB errors,
  0 mismatches, 0 panics; only the 15 skip-listed fixtures excluded.
- `TestEthereumTests` (old corpus) unchanged — the shared helper is called with a
  nil allowlist.

### Skipped fixtures (evidence)
| Fixture | Reason | Failure |
|---|---|---|
| `create2_collision_storage`, `collision_with_create2_revert_in_initcode`, `init_collision_create_opcode`, `init_collision_create_tx` | EIP-7610 create-collision — `GetStorageRoot` stub disables the collision guard (see COMPATIBILITY.md) | `post state root mismatch` |
| `no_src_account_create1559` | `CREATE` from a non-existent sender | nil-pointer panic in `DualStateDB.Snapshot` |

## Screenshots

<img width="1000" height="191" alt="Screenshot 2026-07-24 at 12 46 16 AM" src="https://github.com/user-attachments/assets/528c293e-97f5-4a3c-a3e1-36375a31dab3" />
