### PR TITLE
fix: register hardhat_impersonateAccount stub in the test RPC

### DIFF
--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -56,6 +56,20 @@ func (api *HardhatAPI) Mine(ctx context.Context, blocks *hexutil.Uint64, interva
 	return nil
 }
 
+// ImpersonateAccount accepts hardhat_impersonateAccount for RPC compatibility.
+// It does not enable signing or sending as the given address.
+func (api *HardhatAPI) ImpersonateAccount(ctx context.Context, address common.Address) error {
+	hardhatLogger.Debugf("HardhatAPI.ImpersonateAccount() called address=%s (stub; no state change)", address.Hex())
+	return nil
+}
+
+// StopImpersonatingAccount accepts hardhat_stopImpersonatingAccount for RPC
+// compatibility. It is a no-op companion to ImpersonateAccount.
+func (api *HardhatAPI) StopImpersonatingAccount(ctx context.Context, address common.Address) error {
+	hardhatLogger.Debugf("HardhatAPI.StopImpersonatingAccount() called address=%s (stub; no state change)", address.Hex())
+	return nil
+}
+
 // EvmAPI provides EVM-specific RPC methods for testing, particularly snapshot/revert.
 // Uses LightKVS history mechanism to capture and restore ledger state, and Store
 // for database snapshot/revert.

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -18,14 +18,19 @@ import (
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
-func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
+func dialHardhat(t *testing.T) *rpc.Client {
+	t.Helper()
 	srv := rpc.NewServer()
 	if err := srv.RegisterName("hardhat", NewHardhatAPI()); err != nil {
 		t.Fatalf("RegisterName hardhat: %v", err)
 	}
-
 	client := rpc.DialInProc(srv)
-	defer client.Close()
+	t.Cleanup(client.Close)
+	return client
+}
+
+func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
+	client := dialHardhat(t)
 
 	// Hardhat accepts zero, one, or two optional hex quantities.
 	cases := []struct {
@@ -166,5 +171,37 @@ func TestEvmAPI_RevertWaitsForInFlightTransaction(t *testing.T) {
 	want := []string{"committed", "revert"}
 	if len(events) != len(want) || events[0] != want[0] || events[1] != want[1] {
 		t.Fatalf("event order = %v, want %v", events, want)
+	}
+}
+
+func TestHardhatAPI_ImpersonateAccount_RPCRegistration(t *testing.T) {
+	client := dialHardhat(t)
+	const addr = "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
+
+	var result any
+	if err := client.CallContext(context.Background(), &result, "hardhat_impersonateAccount", addr); err != nil {
+		t.Fatalf("hardhat_impersonateAccount: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
+	}
+
+	if err := client.CallContext(context.Background(), &result, "hardhat_stopImpersonatingAccount", addr); err != nil {
+		t.Fatalf("hardhat_stopImpersonatingAccount: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
+	}
+}
+
+func TestHardhatAPI_ImpersonateAccount_MissingAddress(t *testing.T) {
+	client := dialHardhat(t)
+
+	var result any
+	if err := client.CallContext(context.Background(), &result, "hardhat_impersonateAccount"); err == nil {
+		t.Fatal("expected error for missing address")
+	}
+	if err := client.CallContext(context.Background(), &result, "hardhat_stopImpersonatingAccount"); err == nil {
+		t.Fatal("expected error for missing address")
 	}
 }

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -206,11 +206,11 @@
   },
   {
     "id": "AccessManaged \"before each\" hook for \"sets authority and emits AuthorityUpdated event during construction\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager #consumeScheduledOp \"before each\" hook: define scheduling parameters for \"reverts as AccessManagerUnauthorizedConsume\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager #execute cannot execute a setAuthority call when a target admin delay is set"
@@ -228,7 +228,7 @@
   },
   {
     "id": "AccessManager #execute restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -267,7 +267,7 @@
   },
   {
     "id": "AccessManager #schedule restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"reverts as AccessManagerUnauthorizedCall\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager #schedule restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect succeeds",
@@ -281,7 +281,7 @@
   },
   {
     "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -313,7 +313,7 @@
   },
   {
     "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -345,7 +345,7 @@
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -391,7 +391,7 @@
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -437,7 +437,7 @@
   },
   {
     "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -483,7 +483,7 @@
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -548,7 +548,7 @@
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -583,7 +583,7 @@
   },
   {
     "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -629,7 +629,7 @@
   },
   {
     "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -681,7 +681,7 @@
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -727,7 +727,7 @@
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -773,7 +773,7 @@
   },
   {
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled"
@@ -825,7 +825,7 @@
   },
   {
     "id": "AccessManager getters #canCall when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"should return true and no delay\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled should return false and execution delay"
@@ -1049,15 +1049,15 @@
   },
   {
     "id": "CrosschainBridgeERC1155 \"before each\" hook for \"token getters\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "CrosschainBridgeERC20 \"before each\" hook for \"token getters\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "CrosschainBridgeERC721 \"before each\" hook for \"token getters\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "ECDSA parse signature 65 and 64 bytes signatures",
@@ -1093,7 +1093,7 @@
   },
   {
     "id": "ERC1155Crosschain \"before each\" hook for \"bridge setup\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "ERC1155Holder ERC165 when the interfaceId is not supported uses less than 30k",
@@ -1225,7 +1225,7 @@
   },
   {
     "id": "ERC20Crosschain \"before each\" hook for \"bridge setup\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "ERC20Permit permit accepts owner signature",
@@ -1767,7 +1767,7 @@
   },
   {
     "id": "ERC2771Context \"before each\" hook for \"recognize trusted forwarder\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "ERC2771Forwarder execute bubbles out of gas",
@@ -2019,7 +2019,7 @@
   },
   {
     "id": "ERC721Crosschain \"before each\" hook for \"bridge setup\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "ERC721Royalty ERC165 when the interfaceId is not supported uses less than 30k",
@@ -2163,11 +2163,11 @@
   },
   {
     "id": "GovernorProposalGuardian using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "GovernorProposalGuardian using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "GovernorSequentialProposalId using $ERC20Votes \"before each\" hook for \"sequential proposal ids\"",
@@ -3381,14 +3381,14 @@
   },
   {
     "id": "RelayedCall default (zero) salt relayer input format",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "RelayedCall random salt direct call to the relayer"
   },
   {
     "id": "RelayedCall random salt input format",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "RelayedCall random salt relayed call target success (with value)",
@@ -3506,7 +3506,7 @@
   },
   {
     "id": "TransparentUpgradeableProxy \"before each\" hook for \"cannot be initialized with a non-contract address\"",
-    "cause": "hardhat_impersonateAccount"
+    "cause": "hardhat_setBalance"
   },
   {
     "id": "TrieProof process invalid proofs fails to process proof with invalid internal large hash",


### PR DESCRIPTION
Closes #252 Part of #248

Same registration gap as hardhat_mine (see the sibling issue) hardhat_impersonateAccount is not registered in gateway/testimpl/server.go / hardhat_helpers.go. The OpenZeppelin Hardhat suite calls this method early in a bunch of test setup paths (AccessManaged, GovernorTimelockAccess, RelayedCall, TransparentUpgradeableProxy, etc.), and those tests immediately die with "method not found" before they can reach the actual assertion.

This PR adds both hardhat_impersonateAccount and hardhat_stopImpersonatingAccount as no-op stubs on the HardhatAPI struct. The calls succeed and return nil, which is enough for the test harness to move past the method-not-found barrier. No actual impersonation logic is added  Fabric doesn't expose an unlocked-account concept the way Hardhat does, so real impersonation is out of scope here (same boundary the hardhat_mine stub follows). @arner flagged hardhat_stopImpersonatingAccount in the issue thread as well, so both are covered.

Code
gateway/testimpl/hardhat_helpers.go  adds two new methods on HardhatAPI:

ImpersonateAccount(ctx, address) accepts the address parameter for signature compatibility, logs at DEBUG level, returns nil. The go-ethereum RPC layer maps hardhat_impersonateAccount to this automatically via the hardhat namespace already registered in server.go through NewHardhatAPI(), so no wiring change was needed.
StopImpersonatingAccount(ctx, address)  mirror companion, same approach.
gateway/testimpl/hardhat_helpers_test.go  refactored and extended:

Extracted the server setup (rpc.NewServer + RegisterName + DialInProc) from the existing TestHardhatAPI_Mine_RPCRegistration into a shared dialHardhat(t) helper with t.Cleanup for client teardown. This keeps the test file DRY now that we have multiple test functions hitting the same namespace.
TestHardhatAPI_ImpersonateAccount_RPCRegistration calls both hardhat_impersonateAccount and hardhat_stopImpersonatingAccount through the in-process RPC client with a valid hex address, asserts the result is nil and no error is returned.
TestHardhatAPI_ImpersonateAccount_MissingAddress  confirms the RPC layer itself rejects calls that omit the required address parameter (the go-ethereum server returns an error for missing args before our handler is even invoked).
Baseline
After a full compatible-set run (make hardhat-tests-full / scripts/run_hardhat_test.sh --full), testdata/oz_known_failures.json was reconciled so the scoreboard matches the stub being present:

All 29 prior failures tagged hardhat_impersonateAccount are reclassified  those tests now get past the missing-method error but still fail downstream on hardhat_setBalance (the next unimplemented Hardhat method in the call chain). The impersonation stub succeeds, then the test tries to set the impersonated account's balance, and that call is what fails now.
Zero remaining hardhat_impersonateAccount cause tags in the baseline.
No tests moved from failing to passing this time (unlike the hardhat_mine stub where 52 tests started passing). That's expected  every test that calls hardhat_impersonateAccount also calls hardhat_setBalance right after, so they just hit the next wall.
cmd/baseline check against that run is clean (no regressions, no stale entries).

Verification
go test ./gateway/testimpl/ new and existing Hardhat tests pass
go test ./... -short
go vet / staticcheck on the tree
full OZ compatible set + cmd/baseline check  no regressions, no stale entries

Happy to adjust cause tags or split the commits differently if preferred.