### PR TITLE
endorser: add pebble-backed persistent KVS as drop-in for LightKVS (#218)

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -17,6 +17,31 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/network"
 )
 
+// Supported values for Network.Protocol.
+const (
+	// ProtocolFabric is classic Hyperledger Fabric.
+	ProtocolFabric = "fabric"
+	// ProtocolFabricX is Fabric-X, the default when Network.Protocol is unset.
+	ProtocolFabricX = "fabric-x"
+)
+
+// NormalizeProtocol resolves an optionally-empty protocol string to a concrete
+// protocol, defaulting to fabric-x, and rejects unrecognized values. Components
+// should normalize once and switch on the result rather than treating "" as a
+// fallthrough case: the two spellings of the default used to diverge between the
+// gateway wiring and the endorser factory, which silently paired a fabric-x
+// synchronizer with a fabric endorsement builder.
+func NormalizeProtocol(protocol string) (string, error) {
+	switch protocol {
+	case "":
+		return ProtocolFabricX, nil
+	case ProtocolFabric, ProtocolFabricX:
+		return protocol, nil
+	default:
+		return "", fmt.Errorf("network.protocol must be %q or %q, got %q", ProtocolFabric, ProtocolFabricX, protocol)
+	}
+}
+
 // Network contains network details shared across components
 // and network participants.
 type Network struct {

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -122,3 +122,27 @@ func TestClientConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		want     string
+		wantErr  string
+	}{
+		{"empty defaults to fabric-x", "", ProtocolFabricX, ""},
+		{"fabric passes through", ProtocolFabric, ProtocolFabric, ""},
+		{"fabric-x passes through", ProtocolFabricX, ProtocolFabricX, ""},
+		{"bogus errors", "bogus", "", "network.protocol must be"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeProtocol(tt.protocol)
+			checkErr(t, err, tt.wantErr)
+			if tt.wantErr == "" && got != tt.want {
+				t.Errorf("NormalizeProtocol(%q) = %q, want %q", tt.protocol, got, tt.want)
+			}
+		})
+	}
+}

--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -37,38 +37,55 @@ func NewEndorserCore(
 	evmConfig execution.EVMConfig,
 	testImpl bool,
 ) (*core.Endorser, storage.KVS, endorsement.Builder, error) {
+	// Reject backend/protocol combinations that cannot work before opening any
+	// files. gateway config validation catches this earlier for a real
+	// deployment; this covers callers that build an endorser directly (testnode,
+	// the in-process test harness).
+	if err := config.ValidateDatabaseProtocol(dbCfg.Database, protocol); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// An unset protocol means fabric-x, matching the documented default
+	// (common.Network.Protocol) and the gateway wiring (NewNetworkSubmitters,
+	// NewGatewaySynchronizer). Normalize once so the KVS and builder choices
+	// below cannot disagree about what "" means.
+	protocol, err := common.NormalizeProtocol(protocol)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var kvs storage.KVS
 	switch dbCfg.Database {
-	case "sqlite":
+	case config.DBSQLite:
 		writeDB, err := state.NewWriteDB(channel, dbCfg.ConnString)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to initialize store: %w", err)
 		}
 		kvs = storage.NewVersionedDBWrapper(writeDB)
-	case "memory":
+	case config.DBMemory:
 		baseLightKVS := storage.NewLightKVS(dbCfg.HistorySize)
 		if testImpl {
 			kvs = storage.NewRevertibleLightKVS(baseLightKVS)
 		} else {
 			kvs = baseLightKVS
 		}
-	case "pebble":
+	case config.DBPebble:
 		pebbleKVS, err := storage.NewPebbleKVS(dbCfg.ConnString, dbCfg.HistorySize)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to initialize store: %w", err)
 		}
 		kvs = pebbleKVS
 	default:
-		return nil, nil, nil, fmt.Errorf("invalid endorser database type %s, must be sqlite, memory, or pebble", dbCfg.Database)
+		return nil, nil, nil, fmt.Errorf("invalid endorser database type %q, must be one of %q, %q, %q", dbCfg.Database, config.DBSQLite, config.DBMemory, config.DBPebble)
 	}
 
 	var builder endorsement.Builder
 	var monotonicVersions bool
 	switch protocol {
-	case "fabric-x":
+	case common.ProtocolFabricX:
 		builder = efabx.NewEndorsementBuilder(signer)
 		monotonicVersions = true
-	default: // "fabric" or ""
+	default: // "fabric"
 		builder = efab.NewEndorsementBuilder(signer)
 	}
 
@@ -107,10 +124,10 @@ func NewEndorser(
 
 	var sync *sdknet.Synchronizer
 	switch network.Protocol {
-	case "fabric-x":
-		sync, err = nfabx.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
-	default: // "fabric" or ""
+	case common.ProtocolFabric:
 		sync, err = nfab.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
+	default: // "fabric-x" or "" (the default)
+		sync, err = nfabx.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
 	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create synchronizer: %w", err)

--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -52,8 +52,14 @@ func NewEndorserCore(
 		} else {
 			kvs = baseLightKVS
 		}
+	case "pebble":
+		pebbleKVS, err := storage.NewPebbleKVS(dbCfg.ConnString, dbCfg.HistorySize)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to initialize store: %w", err)
+		}
+		kvs = pebbleKVS
 	default:
-		return nil, nil, nil, fmt.Errorf("invalid endorser database type %s, must be sqlite or memory", dbCfg.Database)
+		return nil, nil, nil, fmt.Errorf("invalid endorser database type %s, must be sqlite, memory, or pebble", dbCfg.Database)
 	}
 
 	var builder endorsement.Builder

--- a/endorser/config/config.go
+++ b/endorser/config/config.go
@@ -49,6 +49,9 @@ func (cfg Endorser) Validate() error {
 	if cfg.Database.Database == "sqlite" && cfg.Database.ConnString == "" {
 		errs = append(errs, errors.New("database.connection-string is required for sqlite"))
 	}
+	if cfg.Database.Database == "pebble" && cfg.Database.ConnString == "" {
+		errs = append(errs, errors.New("database.connection-string (data directory) is required for pebble"))
+	}
 
 	return errors.Join(errs...)
 }

--- a/endorser/config/config.go
+++ b/endorser/config/config.go
@@ -23,11 +23,45 @@ type Endorser struct {
 	DebugLogs bool `mapstructure:"debug-logs" yaml:"debug-logs"`
 }
 
+// Supported values for DB.Database.
+const (
+	// DBSQLite is the sqlite-backed VersionedDB. Persistent; supports both protocols.
+	DBSQLite = "sqlite"
+	// DBMemory is the in-memory LightKVS. Lost on restart; supports both protocols.
+	DBMemory = "memory"
+	// DBPebble is the pebble-backed PebbleKVS. Persistent; fabric-x only.
+	DBPebble = "pebble"
+)
+
 // DB holds the database path for an endorser.
 type DB struct {
 	Database    string `mapstructure:"database" yaml:"database"`
 	ConnString  string `mapstructure:"connection-string" yaml:"connection-string"`
 	HistorySize int    `mapstructure:"history_size" yaml:"history_size"` // number of historical snapshots to keep (default: 2, use 128 for test RPC)
+}
+
+// ValidateDatabaseProtocol rejects endorser backend/protocol combinations that
+// cannot work. The protocol may be empty, meaning the default (fabric-x).
+//
+// PebbleKVS assigns versions as MAX(version)+1 per key and keeps deletes as
+// tombstones, mirroring the fabric-x committer's own worldstate so that the
+// versions it puts in the MVCC read-set validate against it. Classic Fabric
+// expects the LightKVS scheme instead (one version shared across a block's
+// writes to a key, reset after a delete), so pairing pebble with fabric would
+// not fail loudly — it would produce read-sets the committer rejects, or worse,
+// silently accepts against the wrong version. Fail at config time instead.
+func ValidateDatabaseProtocol(database, protocol string) error {
+	resolved, err := common.NormalizeProtocol(protocol)
+	if err != nil {
+		return err
+	}
+	if database == DBPebble && resolved == common.ProtocolFabric {
+		return fmt.Errorf(
+			"database.database %q is only supported with network.protocol %q, not %q "+
+				"(its MVCC version scheme matches the fabric-x committer; use %q or %q for classic Fabric)",
+			DBPebble, common.ProtocolFabricX, common.ProtocolFabric, DBSQLite, DBMemory)
+	}
+	return nil
 }
 
 // Validate checks that required fields are set and values are within acceptable ranges.
@@ -46,10 +80,10 @@ func (cfg Endorser) Validate() error {
 	if cfg.Database.Database == "" {
 		errs = append(errs, errors.New("database.database is required"))
 	}
-	if cfg.Database.Database == "sqlite" && cfg.Database.ConnString == "" {
+	if cfg.Database.Database == DBSQLite && cfg.Database.ConnString == "" {
 		errs = append(errs, errors.New("database.connection-string is required for sqlite"))
 	}
-	if cfg.Database.Database == "pebble" && cfg.Database.ConnString == "" {
+	if cfg.Database.Database == DBPebble && cfg.Database.ConnString == "" {
 		errs = append(errs, errors.New("database.connection-string (data directory) is required for pebble"))
 	}
 

--- a/endorser/config/config_protocol_test.go
+++ b/endorser/config/config_protocol_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/endorser/config"
+)
+
+func TestValidateDatabaseProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		database string
+		protocol string
+		wantErr  string
+	}{
+		{"pebble with fabric-x", config.DBPebble, common.ProtocolFabricX, ""},
+		{"pebble with empty (defaults to fabric-x)", config.DBPebble, "", ""},
+		{"pebble with fabric", config.DBPebble, common.ProtocolFabric, "only supported with"},
+		{"sqlite with fabric", config.DBSQLite, common.ProtocolFabric, ""},
+		{"memory with fabric", config.DBMemory, common.ProtocolFabric, ""},
+		{"sqlite with empty", config.DBSQLite, "", ""},
+		{"pebble with bogus", config.DBPebble, "bogus", "network.protocol must be"},
+		{"sqlite with bogus", config.DBSQLite, "bogus", "network.protocol must be"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.ValidateDatabaseProtocol(tt.database, tt.protocol)
+			checkErr(t, err, tt.wantErr)
+		})
+	}
+}

--- a/endorser/storage/bench_test.go
+++ b/endorser/storage/bench_test.go
@@ -1,0 +1,540 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package storage_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hyperledger/fabric-x-evm/endorser/storage"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/state"
+)
+
+const (
+	benchChannel   = "bench"
+	benchNamespace = "evm"
+)
+
+// benchValue is a fixed 32-byte storage word reused across all writes to
+// avoid allocation overhead polluting the DB benchmarks.
+var benchValue = [32]byte{
+	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+}
+
+// hexKey formats a uint64 as a 64-character hex string.
+func hexKey(i uint64) string {
+	return fmt.Sprintf("%064x", i)
+}
+
+// keyGen generates key indices using Zipf distribution (s=1.2), modelling
+// access patterns where a small number of keys dominate reads.
+type keyGen struct {
+	rng     *rand.Rand
+	zipf    *rand.Zipf
+	numKeys uint64
+}
+
+func newKeyGen(numKeys uint64) *keyGen {
+	rng := rand.New(rand.NewSource(42))
+	return &keyGen{rng: rng, zipf: rand.NewZipf(rng, 1.2, 1.0, numKeys-1), numKeys: numKeys}
+}
+
+func (kg *keyGen) next() uint64 {
+	return kg.zipf.Uint64()
+}
+
+// --- Backend table ---
+
+type benchBackend struct {
+	name   string
+	newKVS func(b *testing.B) storage.KVS
+}
+
+func allBackends() []benchBackend {
+	return []benchBackend{
+		{
+			name: "memory",
+			newKVS: func(b *testing.B) storage.KVS {
+				b.Helper()
+				kvs := storage.NewLightKVS(128)
+				b.Cleanup(func() { _ = kvs.Close() })
+				return kvs
+			},
+		},
+		{
+			name: "pebble",
+			newKVS: func(b *testing.B) storage.KVS {
+				b.Helper()
+				kvs, err := storage.NewPebbleKVS(b.TempDir(), 128)
+				if err != nil {
+					b.Fatalf("new pebble kvs: %v", err)
+				}
+				b.Cleanup(func() { _ = kvs.Close() })
+				return kvs
+			},
+		},
+		{
+			name: "sqlite:file",
+			newKVS: func(b *testing.B) storage.KVS {
+				b.Helper()
+				connStr := fmt.Sprintf("file:%s/bench.db", b.TempDir())
+				db, err := state.NewWriteDB(benchChannel, connStr)
+				if err != nil {
+					b.Skipf("sqlite unavailable (likely missing cgo): %v", err)
+					return nil
+				}
+				kvs := storage.NewVersionedDBWrapper(db)
+				b.Cleanup(func() { _ = kvs.Close() })
+				return kvs
+			},
+		},
+	}
+}
+
+// --- Data helpers ---
+
+// makeBlock builds a block with txCount valid transactions each containing writesPerTx writes.
+// Keys are drawn from kg and deduplicated within each transaction to satisfy the
+// PRIMARY KEY constraint (channel, namespace, key, version_block, version_tx).
+func makeBlock(blockNum uint64, txCount, writesPerTx int, kg *keyGen) blocks.Block {
+	txs := make([]blocks.Transaction, txCount)
+	for i := range txs {
+		seen := make(map[uint64]struct{}, writesPerTx)
+		writes := make([]blocks.KVWrite, 0, writesPerTx)
+		for len(writes) < writesPerTx {
+			idx := kg.next()
+			if _, dup := seen[idx]; dup {
+				continue
+			}
+			seen[idx] = struct{}{}
+			writes = append(writes, blocks.KVWrite{Key: hexKey(idx), Value: benchValue[:]})
+		}
+		txs[i] = blocks.Transaction{
+			ID:     fmt.Sprintf("%d-%d", blockNum, i),
+			Number: int64(i),
+			Valid:  true,
+			NsRWS: []blocks.NsReadWriteSet{{
+				Namespace: benchNamespace,
+				RWS:       blocks.ReadWriteSet{Writes: writes},
+			}},
+		}
+	}
+	return blocks.Block{Number: blockNum, Transactions: txs}
+}
+
+// preloadDB inserts numKeys unique keys into kvs in batches of writesPerBlock per block.
+// Call before b.ResetTimer() to exclude setup from measurements.
+func preloadDB(b *testing.B, kvs storage.KVS, numKeys, writesPerBlock int) {
+	b.Helper()
+	ctx := context.Background()
+	blockNum := uint64(0)
+	for offset := 0; offset < numKeys; offset += writesPerBlock {
+		count := writesPerBlock
+		if offset+count > numKeys {
+			count = numKeys - offset
+		}
+		writes := make([]blocks.KVWrite, count)
+		for j := range writes {
+			writes[j] = blocks.KVWrite{Key: hexKey(uint64(offset + j)), Value: benchValue[:]}
+		}
+		bl := blocks.Block{
+			Number: blockNum,
+			Transactions: []blocks.Transaction{{
+				ID:     fmt.Sprintf("preload-%d", blockNum),
+				Number: 0,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{{
+					Namespace: benchNamespace,
+					RWS:       blocks.ReadWriteSet{Writes: writes},
+				}},
+			}},
+		}
+		if err := kvs.Handle(ctx, bl); err != nil {
+			b.Fatalf("preload block %d: %v", blockNum, err)
+		}
+		blockNum++
+	}
+}
+
+// --- Summary table helper ---
+
+// report collects (row, col) → value pairs during a benchmark run and prints a
+// formatted table to the benchmark log after all sub-benchmarks complete.
+type report struct {
+	title string
+	rows  []string
+	cols  []string
+	cells map[string]map[string]string
+}
+
+func newReport(title string) *report {
+	return &report{title: title, cells: make(map[string]map[string]string)}
+}
+
+func (r *report) set(row, col, val string) {
+	if _, ok := r.cells[row]; !ok {
+		r.cells[row] = make(map[string]string)
+		r.rows = append(r.rows, row)
+	}
+	if !slices.Contains(r.cols, col) {
+		r.cols = append(r.cols, col)
+	}
+	r.cells[row][col] = val
+}
+
+func (r *report) log() {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
+
+	// header
+	fmt.Fprintf(w, "\nbackend\t")
+	for _, col := range r.cols {
+		fmt.Fprintf(w, "%s\t", col)
+	}
+	fmt.Fprintln(w)
+
+	// rows
+	for _, row := range r.rows {
+		fmt.Fprintf(w, "%s\t", row)
+		for _, col := range r.cols {
+			fmt.Fprintf(w, "%s\t", r.cells[row][col])
+		}
+		fmt.Fprintln(w)
+	}
+	w.Flush()
+
+	fmt.Fprintln(os.Stdout, "\n── "+r.title+" "+strings.Repeat("─", max(0, 60-len(r.title)))+buf.String())
+}
+
+// --- Benchmarks ---
+
+// BenchmarkUpdateWorldState measures write throughput through Handle.
+// b.N counts blocks processed. Reports tx/s and writes/s per backend.
+//
+// Run: go test -bench=BenchmarkUpdateWorldState -benchtime=5s ./endorser/storage/
+func BenchmarkUpdateWorldState(b *testing.B) {
+	type cfg struct{ txs, writes int }
+	configs := []cfg{
+		{50, 3},  // ERC-20-realistic: 3 writes/tx (nonce + 2 token slots)
+		{100, 3}, // ERC-20-realistic, larger block
+		{50, 5},
+		{100, 5},
+		{100, 20}, // heavier contracts
+	}
+
+	backends := allBackends()
+	rep := newReport("UpdateWorldState  (tx/s | writes/s)")
+	for _, be := range backends {
+		b.Run(be.name, func(b *testing.B) {
+			for _, c := range configs {
+				col := fmt.Sprintf("txs=%d/w=%d", c.txs, c.writes)
+				var txPerS, writesPerS float64
+				b.Run(col, func(b *testing.B) {
+					kvs := be.newKVS(b)
+					if kvs == nil {
+						return // skipped
+					}
+					kg := newKeyGen(100_000)
+					ctx := context.Background()
+
+					b.ResetTimer()
+					b.ReportAllocs()
+					for i := range b.N {
+						if err := kvs.Handle(ctx, makeBlock(uint64(i), c.txs, c.writes, kg)); err != nil {
+							b.Fatal(err)
+						}
+					}
+					elapsed := b.Elapsed().Seconds()
+					txPerS = float64(b.N*c.txs) / elapsed
+					writesPerS = float64(b.N*c.txs*c.writes) / elapsed
+					b.ReportMetric(txPerS, "tx/s")
+					b.ReportMetric(writesPerS, "writes/s")
+				})
+				rep.set(be.name, col, fmt.Sprintf("%s | %s", fmtRate(txPerS), fmtRate(writesPerS)))
+			}
+		})
+	}
+	rep.log()
+}
+
+// BenchmarkUpdateWorldStateAtScale measures write throughput as a function of
+// *pre-existing state size*, isolating the cost model difference: LightKVS clones
+// the entire state map on every block — O(state size) per block — while PebbleKVS is
+// O(1) per write and flat in state size. This finds the crossover where the
+// in-memory clone cost overtakes pebble's per-write cost, bounding the
+// "keep the LightKVS" approach.
+//
+// Blocks are ERC-20-realistic (100 tx × 3 writes). State is bulk-loaded in large
+// blocks (numKeys/10 writes each) so the preload's own clone cost stays
+// O(n²/blocks) rather than the O(n²) of small-block loading.
+//
+// Run: go test -bench=BenchmarkUpdateWorldStateAtScale -benchtime=20x ./endorser/storage/
+func BenchmarkUpdateWorldStateAtScale(b *testing.B) {
+	const txs, writes = 100, 3
+	sizes := []struct {
+		n     int
+		label string
+	}{
+		{100_000, "100K"},
+		{1_000_000, "1M"},
+		{5_000_000, "5M"},
+		{10_000_000, "10M"},
+	}
+	// memory and pebble are the two fundamentally different cost models.
+	base := allBackends()
+	backends := []benchBackend{base[0], base[1]}
+
+	rep := newReport("UpdateWorldState @ scale  (blocks/s | writes/s)  —  100tx×3w")
+	for _, be := range backends {
+		b.Run(be.name, func(b *testing.B) {
+			for _, sz := range sizes {
+				var blocksPerS, writesPerS float64
+				b.Run(sz.label, func(b *testing.B) {
+					kvs := be.newKVS(b)
+					if kvs == nil {
+						return
+					}
+					writesPerBlock := sz.n / 10
+					preloadDB(b, kvs, sz.n, writesPerBlock)
+					// Continue block numbering contiguously after the preload.
+					startBlock := uint64(sz.n / writesPerBlock)
+					kg := newKeyGen(uint64(sz.n))
+					ctx := context.Background()
+
+					b.ResetTimer()
+					for i := range b.N {
+						if err := kvs.Handle(ctx, makeBlock(startBlock+uint64(i), txs, writes, kg)); err != nil {
+							b.Fatal(err)
+						}
+					}
+					elapsed := b.Elapsed().Seconds()
+					blocksPerS = float64(b.N) / elapsed
+					writesPerS = float64(b.N*txs*writes) / elapsed
+					b.ReportMetric(blocksPerS, "blocks/s")
+					b.ReportMetric(writesPerS, "writes/s")
+				})
+				rep.set(be.name, sz.label, fmt.Sprintf("%s | %s", fmtRate(blocksPerS), fmtRate(writesPerS)))
+			}
+		})
+	}
+	rep.log()
+}
+
+// BenchmarkGetState measures raw KVS.Get latency against a pre-populated DB.
+//
+// Run: go test -bench=BenchmarkGetState -benchtime=5s ./endorser/storage/
+func BenchmarkGetState(b *testing.B) {
+	const (
+		numKeys          = 100_000
+		writesPerBlock   = 100
+		preloadLastBlock = uint64(numKeys/writesPerBlock - 1)
+	)
+
+	rep := newReport("GetState  (ns/op | reads/s)")
+	for _, be := range allBackends() {
+		var nsPerOp float64
+		b.Run(be.name, func(b *testing.B) {
+			kvs := be.newKVS(b)
+			if kvs == nil {
+				return // skipped
+			}
+			preloadDB(b, kvs, numKeys, writesPerBlock)
+			kg := newKeyGen(numKeys)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				if _, err := kvs.Get(benchNamespace, hexKey(kg.next()), preloadLastBlock); err != nil {
+					b.Fatal(err)
+				}
+			}
+			nsPerOp = float64(b.Elapsed().Nanoseconds()) / float64(b.N)
+		})
+		rep.set(be.name, "ns/op", fmt.Sprintf("%.0f ns", nsPerOp))
+		rep.set(be.name, "reads/s", fmtRate(1e9/nsPerOp))
+	}
+	rep.log()
+}
+
+// BenchmarkSimulation benchmarks snapshot-based reads — the hot path for
+// transaction endorsement. Each b.N iteration models one transaction: create a
+// snapshot via NewSnapshot, perform readsPerSim Get calls, and close the reader.
+//
+// Note: The SDK's SimulationStore also performs 5 PutState writes per simulation,
+// but the KVS interface applies writes at block granularity via Handle, not
+// per-transaction. This benchmark focuses on the read path; writes are measured
+// in BenchmarkUpdateWorldState.
+//
+// Run: go test -bench=BenchmarkSimulation -benchtime=5s ./endorser/storage/
+func BenchmarkSimulation(b *testing.B) {
+	const (
+		numKeys          = 100_000
+		writesPerBlock   = 100
+		preloadLastBlock = uint64(numKeys/writesPerBlock - 1)
+	)
+
+	rep := newReport("Simulation  (sim/s | reads/s)  —  snapshot-based reads only")
+	for _, be := range allBackends() {
+		b.Run(be.name, func(b *testing.B) {
+			kvs := be.newKVS(b)
+			if kvs == nil {
+				return // skipped
+			}
+			preloadDB(b, kvs, numKeys, writesPerBlock)
+
+			for _, readsPerSim := range []int{20, 50, 100} {
+				col := fmt.Sprintf("reads=%d", readsPerSim)
+				var simPerS, readsPerS float64
+				b.Run(col, func(b *testing.B) {
+					kg := newKeyGen(numKeys)
+
+					b.ResetTimer()
+					b.ReportAllocs()
+					for range b.N {
+						reader, err := kvs.NewSnapshot(preloadLastBlock)
+						if err != nil {
+							b.Fatal(err)
+						}
+						for range readsPerSim {
+							if _, err := reader.Get(benchNamespace, hexKey(kg.next())); err != nil {
+								b.Fatal(err)
+							}
+						}
+						reader.Close()
+					}
+
+					elapsed := b.Elapsed().Seconds()
+					simPerS = float64(b.N) / elapsed
+					readsPerS = float64(b.N*readsPerSim) / elapsed
+					b.ReportMetric(simPerS, "sim/s")
+					b.ReportMetric(readsPerS, "reads/s")
+				})
+				rep.set(be.name, col, fmt.Sprintf("%s | %s", fmtRate(simPerS), fmtRate(readsPerS)))
+			}
+		})
+	}
+	rep.log()
+}
+
+// BenchmarkMixed measures read latency under concurrent write pressure — the closest
+// approximation to production load. A background goroutine writes blocks at ~2K tx/sec
+// while the benchmark loop drives snapshot reads.
+//
+// 500 extra blocks are written synchronously during setup (before b.ResetTimer) so that
+// every calibration iteration sees the same large DB. Without this pre-population the
+// first calibration iteration is fast (small DB), Go estimates a large b.N, and then all
+// those iterations run against a much larger DB — causing runtimes up to 10× longer than
+// -benchtime.
+//
+// Run: go test -bench=BenchmarkMixed -benchtime=5s ./endorser/storage/
+func BenchmarkMixed(b *testing.B) {
+	const (
+		numKeys            = 100_000
+		writesPerBlock     = 100
+		readsPerSim        = 50
+		extraBlocks        = 500                   // written during setup: 500 × 50 tx × 5 writes = 125K rows
+		writerTickInterval = 50 * time.Millisecond // 20 blocks/sec ≈ 1000 tps
+	)
+
+	rep := newReport("Mixed  (reads/s under concurrent writes at ~1K tps)")
+	for _, be := range allBackends() {
+		var readsPerS float64
+		// Outer b.Run calls an inner b.Run, so the framework runs this function exactly
+		// once (no calibration re-runs). This keeps exactly one background writer alive
+		// and avoids repeated preload attempts against the same in-memory database.
+		b.Run(be.name, func(b *testing.B) {
+			kvs := be.newKVS(b)
+			if kvs == nil {
+				return // skipped
+			}
+			preloadDB(b, kvs, numKeys, writesPerBlock)
+
+			// Write extra blocks during setup so calibration always starts against a
+			// stable, production-sized DB (100K preloaded + 125K extra = 225K rows).
+			setupCtx := context.Background()
+			setupKg := newKeyGen(numKeys)
+			baseBlock := uint64(numKeys / writesPerBlock)
+			for i := range extraBlocks {
+				if err := kvs.Handle(setupCtx, makeBlock(baseBlock+uint64(i), 50, 5, setupKg)); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			var lastBlock atomic.Uint64
+			lastBlock.Store(baseBlock + extraBlocks - 1)
+
+			// Force GC to collect allocations from setup before measurement starts.
+			runtime.GC()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			b.Cleanup(cancel)
+
+			// Background writer keeps running during measurement to simulate live commits.
+			go func() {
+				ticker := time.NewTicker(writerTickInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						n := lastBlock.Add(1)
+						_ = kvs.Handle(ctx, makeBlock(n, 50, 5, setupKg))
+					}
+				}
+			}()
+
+			// Single-goroutine reader: each snapshot releases before the next one begins,
+			// giving the writer time to commit between bursts.
+			b.Run("sim", func(b *testing.B) {
+				kg := newKeyGen(numKeys)
+				b.ResetTimer()
+				for range b.N {
+					n := lastBlock.Load()
+					reader, err := kvs.NewSnapshot(n)
+					if err != nil {
+						b.Fatal(err)
+					}
+					for range readsPerSim {
+						if _, err := reader.Get(benchNamespace, hexKey(kg.next())); err != nil {
+							b.Fatal(err)
+						}
+					}
+					reader.Close()
+				}
+				readsPerS = float64(b.N*readsPerSim) / b.Elapsed().Seconds()
+				b.ReportMetric(readsPerS, "reads/s")
+			})
+		})
+		rep.set(be.name, "reads/s", fmtRate(readsPerS))
+	}
+	rep.log()
+}
+
+// fmtRate formats a rate (per second) as a human-readable string with K/M suffix.
+func fmtRate(v float64) string {
+	switch {
+	case v >= 1_000_000:
+		return fmt.Sprintf("%.1fM", v/1_000_000)
+	case v >= 1_000:
+		return fmt.Sprintf("%.1fK", v/1_000)
+	default:
+		return fmt.Sprintf("%.0f", v)
+	}
+}

--- a/endorser/storage/kvs_parity_test.go
+++ b/endorser/storage/kvs_parity_test.go
@@ -9,6 +9,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
@@ -525,5 +526,300 @@ func TestPebbleHandleTxMultiBlock(t *testing.T) {
 		t.Fatalf("Get as of block 1: %v", err)
 	} else if rec == nil || string(rec.Value) != "block1" {
 		t.Errorf("as of block 1 expected \"block1\", got %+v", rec)
+	}
+}
+
+// TestPebbleReplayIdempotency verifies that replaying an already-applied block
+// is a no-op: the second Handle of the same block number does not modify state.
+func TestPebbleReplayIdempotency(t *testing.T) {
+	ctx := context.Background()
+	kvs, err := NewPebbleKVS(t.TempDir(), 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer kvs.Close()
+
+	// Handle block 1 writing "v1".
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v1")})); err != nil {
+		t.Fatalf("Handle block 1: %v", err)
+	}
+
+	rec, err := kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get after first apply: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" || rec.Version != 0 {
+		t.Fatalf("expected v1 version 0, got %+v", rec)
+	}
+
+	// Replay block 1 with different content ("v2"). It should be skipped.
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1-replay", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v2")})); err != nil {
+		t.Fatalf("Handle block 1 replay: %v", err)
+	}
+
+	rec, err = kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get after replay: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" || rec.Version != 0 {
+		t.Errorf("replay changed state: expected v1 version 0, got %+v", rec)
+	}
+
+	// Block 2 should apply normally.
+	if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v3")})); err != nil {
+		t.Fatalf("Handle block 2: %v", err)
+	}
+
+	rec, err = kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get after block 2: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v3" || rec.Version != 1 {
+		t.Errorf("expected v3 version 1, got %+v", rec)
+	}
+}
+
+// TestPebbleReplayAcrossReopen verifies replay idempotency survives a close/reopen.
+func TestPebbleReplayAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	kvs, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	// Handle blocks 1 and 2.
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v1")})); err != nil {
+		t.Fatalf("Handle block 1: %v", err)
+	}
+	if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v2")})); err != nil {
+		t.Fatalf("Handle block 2: %v", err)
+	}
+	if err := kvs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen and replay block 2 with different content.
+	kvs2, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer kvs2.Close()
+
+	if err := kvs2.Handle(ctx, mkBlock(2, 0, "tx2-replay", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v2-changed")})); err != nil {
+		t.Fatalf("Handle block 2 replay: %v", err)
+	}
+
+	// Version should not have advanced.
+	rec, err := kvs2.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v2" || rec.Version != 1 {
+		t.Errorf("replay changed state: expected v2 version 1, got %+v", rec)
+	}
+
+	n, err := kvs2.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected block 2, got %d", n)
+	}
+
+	// Block 3 should apply.
+	if err := kvs2.Handle(ctx, mkBlock(3, 0, "tx3", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v3")})); err != nil {
+		t.Fatalf("Handle block 3: %v", err)
+	}
+
+	rec, err = kvs2.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get after block 3: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v3" || rec.Version != 2 {
+		t.Errorf("expected v3 version 2, got %+v", rec)
+	}
+}
+
+// TestPebbleUpdateRejectsMultiBlockBatch verifies that Update errors when given
+// a batch spanning multiple block numbers.
+func TestPebbleUpdateRejectsMultiBlockBatch(t *testing.T) {
+	kvs, err := NewPebbleKVS(t.TempDir(), 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer kvs.Close()
+
+	updates := []KeyValueVersion{
+		{Key: "ns1:a", BlockNum: 1, TxNum: 0, Value: []byte("a")},
+		{Key: "ns1:b", BlockNum: 2, TxNum: 0, Value: []byte("b")},
+	}
+
+	err = kvs.Update(updates)
+	if err == nil {
+		t.Fatal("expected error for multi-block batch, got nil")
+	}
+	if !strings.Contains(err.Error(), "spans multiple blocks") {
+		t.Errorf("error should mention 'spans multiple blocks', got: %v", err)
+	}
+
+	// Nothing should have been committed.
+	ctx := context.Background()
+	n, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected block 0 (nothing committed), got %d", n)
+	}
+}
+
+// TestPebbleEmptyBlockAdvancesCheckpoint verifies that a block with no writes
+// still advances the persisted checkpoint.
+func TestPebbleEmptyBlockAdvancesCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	kvs, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	// Block 1 with a write.
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v1")})); err != nil {
+		t.Fatalf("Handle block 1: %v", err)
+	}
+
+	// Block 2 with no transactions.
+	emptyBlock := blocks.Block{Number: 2, Transactions: nil}
+	if err := kvs.Handle(ctx, emptyBlock); err != nil {
+		t.Fatalf("Handle empty block 2: %v", err)
+	}
+
+	n, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected block 2 after empty block, got %d", n)
+	}
+
+	// The write from block 1 should still be readable.
+	rec, err := kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" {
+		t.Errorf("expected v1 still readable, got %+v", rec)
+	}
+
+	if err := kvs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen and verify checkpoint survived.
+	kvs2, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer kvs2.Close()
+
+	n, err = kvs2.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber after reopen: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected block 2 after reopen, got %d", n)
+	}
+}
+
+// TestPebbleInvalidTxBlockAdvancesCheckpoint verifies that a block whose only
+// transaction is invalid still advances the checkpoint.
+func TestPebbleInvalidTxBlockAdvancesCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	kvs, err := NewPebbleKVS(t.TempDir(), 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer kvs.Close()
+
+	// Block 1 with a valid write.
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("v1")})); err != nil {
+		t.Fatalf("Handle block 1: %v", err)
+	}
+
+	// Block 2 with only an invalid transaction.
+	if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", false, "ns1",
+		blocks.KVWrite{Key: "k2", Value: []byte("invalid")})); err != nil {
+		t.Fatalf("Handle block 2: %v", err)
+	}
+
+	n, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected block 2, got %d", n)
+	}
+
+	// The invalid write should not be applied.
+	rec, err := kvs.Get("ns1", "k2", 0)
+	if err != nil {
+		t.Fatalf("Get invalid key: %v", err)
+	}
+	if !absent(rec) {
+		t.Errorf("invalid tx write should not be visible, got %+v", rec)
+	}
+
+	// The valid write from block 1 should still be readable.
+	rec, err = kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get valid key: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" {
+		t.Errorf("expected v1, got %+v", rec)
+	}
+}
+
+// TestPebbleBlock0OnFreshStore verifies that block 0 on a fresh store is applied,
+// not mistaken for "already applied".
+func TestPebbleBlock0OnFreshStore(t *testing.T) {
+	ctx := context.Background()
+	kvs, err := NewPebbleKVS(t.TempDir(), 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer kvs.Close()
+
+	// Handle block 0 with a write.
+	if err := kvs.Handle(ctx, mkBlock(0, 0, "tx0", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("block0")})); err != nil {
+		t.Fatalf("Handle block 0: %v", err)
+	}
+
+	rec, err := kvs.Get("ns1", "k", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "block0" {
+		t.Errorf("expected block0 value, got %+v", rec)
+	}
+
+	n, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected block 0, got %d", n)
 	}
 }

--- a/endorser/storage/kvs_parity_test.go
+++ b/endorser/storage/kvs_parity_test.go
@@ -1,0 +1,529 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+)
+
+// kvsBackend names a KVS implementation and a constructor for it. The parity
+// suite runs the same black-box assertions against every backend so that
+// PebbleKVS is verified to be a drop-in replacement for LightKVS at the KVS
+// interface boundary (the white-box tests in lightkvs_test.go exercise
+// LightKVS-internal structure and are not part of this contract).
+type kvsBackend struct {
+	name string
+	// make builds a fresh, empty KVS. historySize is honored by LightKVS and
+	// ignored by PebbleKVS (which keeps full history).
+	make func(t *testing.T, historySize int) KVS
+}
+
+func kvsBackends() []kvsBackend {
+	return []kvsBackend{
+		{
+			name: "LightKVS",
+			make: func(t *testing.T, historySize int) KVS {
+				return NewLightKVS(historySize)
+			},
+		},
+		{
+			name: "PebbleKVS",
+			make: func(t *testing.T, historySize int) KVS {
+				kvs, err := NewPebbleKVS(t.TempDir(), historySize)
+				if err != nil {
+					t.Fatalf("NewPebbleKVS failed: %v", err)
+				}
+				t.Cleanup(func() { _ = kvs.Close() })
+				return kvs
+			},
+		},
+	}
+}
+
+// forEachBackend runs fn as a subtest against every KVS backend.
+func forEachBackend(t *testing.T, historySize int, fn func(t *testing.T, kvs KVS)) {
+	t.Helper()
+	for _, b := range kvsBackends() {
+		b := b
+		t.Run(b.name, func(t *testing.T) {
+			fn(t, b.make(t, historySize))
+		})
+	}
+}
+
+// absent reports whether a read result represents an absent key. LightKVS
+// returns nil for a deleted/missing key; PebbleKVS returns a tombstone record
+// with IsDelete=true. Both mean "no live value", which is how the execution
+// layer interprets them.
+func absent(rec *blocks.WriteRecord) bool {
+	return rec == nil || rec.IsDelete
+}
+
+// mkBlock builds a single-tx block writing the given ns/key/value writes.
+func mkBlock(number uint64, txNum int64, txID string, valid bool, ns string, writes ...blocks.KVWrite) blocks.Block {
+	return blocks.Block{
+		Number: number,
+		Transactions: []blocks.Transaction{{
+			ID:     txID,
+			Number: txNum,
+			Valid:  valid,
+			NsRWS: []blocks.NsReadWriteSet{{
+				Namespace: ns,
+				RWS:       blocks.ReadWriteSet{Writes: writes},
+			}},
+		}},
+	}
+}
+
+// mkMultiTxBlock builds a block whose i-th transaction (Number i) contributes
+// writes[i], all valid. It exercises multiple writes to the same key within one
+// block — each in a distinct tx — which the per-key version logic must order.
+func mkMultiTxBlock(number uint64, ns string, writes ...blocks.KVWrite) blocks.Block {
+	txs := make([]blocks.Transaction, len(writes))
+	for i, w := range writes {
+		txs[i] = blocks.Transaction{
+			ID:     fmt.Sprintf("tx%d", i),
+			Number: int64(i),
+			Valid:  true,
+			NsRWS: []blocks.NsReadWriteSet{{
+				Namespace: ns,
+				RWS:       blocks.ReadWriteSet{Writes: []blocks.KVWrite{w}},
+			}},
+		}
+	}
+	return blocks.Block{Number: number, Transactions: txs}
+}
+
+func TestParityGetAndVersionIncrement(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+
+		// Block 1: initial write.
+		if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+			blocks.KVWrite{Key: "key1", Value: []byte("v1")})); err != nil {
+			t.Fatalf("Handle block 1: %v", err)
+		}
+
+		rec, err := kvs.Get("ns1", "key1", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "v1" {
+			t.Fatalf("expected v1, got %+v", rec)
+		}
+		if rec.Version != 0 {
+			t.Errorf("expected version 0 on first write, got %d", rec.Version)
+		}
+		if rec.Namespace != "ns1" || rec.Key != "key1" {
+			t.Errorf("expected ns1/key1 echoed back, got %s/%s", rec.Namespace, rec.Key)
+		}
+
+		// Blocks 2 and 3: overwrite same key, version must increment.
+		if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", true, "ns1",
+			blocks.KVWrite{Key: "key1", Value: []byte("v2")})); err != nil {
+			t.Fatalf("Handle block 2: %v", err)
+		}
+		if err := kvs.Handle(ctx, mkBlock(3, 0, "tx3", true, "ns1",
+			blocks.KVWrite{Key: "key1", Value: []byte("v3")})); err != nil {
+			t.Fatalf("Handle block 3: %v", err)
+		}
+
+		rec, err = kvs.Get("ns1", "key1", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "v3" {
+			t.Fatalf("expected v3, got %+v", rec)
+		}
+		if rec.Version != 2 {
+			t.Errorf("expected version 2 after 3 writes, got %d", rec.Version)
+		}
+
+		// Missing key reads as absent.
+		rec, err = kvs.Get("ns1", "nope", 0)
+		if err != nil {
+			t.Fatalf("Get missing: %v", err)
+		}
+		if !absent(rec) {
+			t.Errorf("expected absent for missing key, got %+v", rec)
+		}
+	})
+}
+
+func TestParityNilValueRoundTrip(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+			blocks.KVWrite{Key: "key1", Value: nil})); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		rec, err := kvs.Get("ns1", "key1", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil {
+			t.Fatal("expected record for nil-value write, got nil")
+		}
+		if rec.IsDelete {
+			t.Fatal("nil value must not be a delete")
+		}
+		if rec.Value != nil {
+			t.Errorf("expected nil value preserved, got %v", rec.Value)
+		}
+	})
+}
+
+func TestParityMultipleNamespacesAndColonKeys(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		// Include a key containing ':' to prove ns/key composition is
+		// unambiguous (the namespace has no colon, so the split point is well
+		// defined; PebbleKVS length-prefixes the composed key).
+		block := blocks.Block{
+			Number: 1,
+			Transactions: []blocks.Transaction{{
+				ID: "tx1", Number: 0, Valid: true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{Namespace: "ns1", RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+						{Key: "a", Value: []byte("ns1-a")},
+						{Key: "b:c:d", Value: []byte("ns1-bcd")},
+					}}},
+					{Namespace: "ns2", RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+						{Key: "a", Value: []byte("ns2-a")},
+					}}},
+				},
+			}},
+		}
+		if err := kvs.Handle(ctx, block); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+
+		cases := map[[2]string]string{
+			{"ns1", "a"}:     "ns1-a",
+			{"ns1", "b:c:d"}: "ns1-bcd",
+			{"ns2", "a"}:     "ns2-a",
+		}
+		for k, want := range cases {
+			rec, err := kvs.Get(k[0], k[1], 0)
+			if err != nil {
+				t.Fatalf("Get %v: %v", k, err)
+			}
+			if rec == nil || string(rec.Value) != want {
+				t.Errorf("Get %v: expected %q, got %+v", k, want, rec)
+			}
+		}
+	})
+}
+
+func TestParityInvalidTransactionsSkipped(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		block := blocks.Block{
+			Number: 1,
+			Transactions: []blocks.Transaction{
+				{ID: "bad", Number: 0, Valid: false, NsRWS: []blocks.NsReadWriteSet{
+					{Namespace: "ns1", RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+						{Key: "k", Value: []byte("bad")},
+					}}},
+				}},
+				{ID: "good", Number: 1, Valid: true, NsRWS: []blocks.NsReadWriteSet{
+					{Namespace: "ns1", RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+						{Key: "k2", Value: []byte("good")},
+					}}},
+				}},
+			},
+		}
+		if err := kvs.Handle(ctx, block); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+
+		rec, err := kvs.Get("ns1", "k", 0)
+		if err != nil {
+			t.Fatalf("Get invalid: %v", err)
+		}
+		if !absent(rec) {
+			t.Errorf("write from invalid tx must not be visible, got %+v", rec)
+		}
+
+		rec, err = kvs.Get("ns1", "k2", 0)
+		if err != nil {
+			t.Fatalf("Get valid: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "good" {
+			t.Errorf("expected good, got %+v", rec)
+		}
+	})
+}
+
+func TestParityDeleteTombstoneContract(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+
+		// Block 1: create.
+		if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+			blocks.KVWrite{Key: "key1", Value: []byte("v1")})); err != nil {
+			t.Fatalf("Handle create: %v", err)
+		}
+		// Block 2: delete.
+		if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", true, "ns1",
+			blocks.KVWrite{Key: "key1", IsDelete: true})); err != nil {
+			t.Fatalf("Handle delete: %v", err)
+		}
+
+		// As of the latest block the key is effectively absent for both
+		// backends (LightKVS: nil; PebbleKVS: IsDelete tombstone).
+		rec, err := kvs.Get("ns1", "key1", 0)
+		if err != nil {
+			t.Fatalf("Get after delete: %v", err)
+		}
+		if !absent(rec) {
+			t.Errorf("expected key absent after delete, got %+v", rec)
+		}
+	})
+}
+
+func TestParityTimeTravelReads(t *testing.T) {
+	// historySize large enough that LightKVS retains blocks 1..3 in its ring.
+	forEachBackend(t, 128, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		for i := uint64(1); i <= 3; i++ {
+			val := []byte{byte('0' + i)}
+			if err := kvs.Handle(ctx, mkBlock(i, 0, "tx", true, "ns1",
+				blocks.KVWrite{Key: "k", Value: val})); err != nil {
+				t.Fatalf("Handle block %d: %v", i, err)
+			}
+		}
+
+		// Reading as of each block returns that block's value.
+		for i := uint64(1); i <= 3; i++ {
+			rec, err := kvs.Get("ns1", "k", i)
+			if err != nil {
+				t.Fatalf("Get as of block %d: %v", i, err)
+			}
+			want := string([]byte{byte('0' + i)})
+			if rec == nil || string(rec.Value) != want {
+				t.Errorf("as of block %d: expected %q, got %+v", i, want, rec)
+			}
+		}
+
+		// A snapshot pins its block: writes after it are invisible.
+		snap, err := kvs.NewSnapshot(2)
+		if err != nil {
+			t.Fatalf("NewSnapshot(2): %v", err)
+		}
+		defer snap.Close()
+		rec, err := snap.Get("ns1", "k")
+		if err != nil {
+			t.Fatalf("snapshot Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "2" {
+			t.Errorf("snapshot at block 2 expected \"2\", got %+v", rec)
+		}
+	})
+}
+
+func TestParityBlockNumber(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		if n, err := kvs.BlockNumber(ctx); err != nil || n != 0 {
+			t.Fatalf("initial block number: got %d, err %v", n, err)
+		}
+		if err := kvs.Handle(ctx, mkBlock(5, 0, "tx", true, "ns1",
+			blocks.KVWrite{Key: "k", Value: []byte("v")})); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if n, err := kvs.BlockNumber(ctx); err != nil || n != 5 {
+			t.Errorf("after block 5: got %d, err %v", n, err)
+		}
+	})
+}
+
+// TestPebblePersistenceAcrossReopen verifies the persistence win that motivated
+// #218: after closing and reopening the store, committed state and the block
+// checkpoint survive.
+func TestPebblePersistenceAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	kvs, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := kvs.Handle(ctx, mkBlock(7, 0, "tx1", true, "ns1",
+		blocks.KVWrite{Key: "key1", Value: []byte("persisted")})); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if err := kvs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen the same directory.
+	kvs2, err := NewPebbleKVS(dir, 8)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer kvs2.Close()
+
+	n, err := kvs2.BlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("BlockNumber: %v", err)
+	}
+	if n != 7 {
+		t.Errorf("expected block 7 to survive restart, got %d", n)
+	}
+
+	rec, err := kvs2.Get("ns1", "key1", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "persisted" {
+		t.Errorf("expected persisted value after restart, got %+v", rec)
+	}
+}
+
+// TestParityMultiWritePerBlockValue asserts both backends agree that the
+// highest-tx write to a key within a block wins the read. They intentionally
+// differ only on the resulting version number (see
+// TestPebbleVersionSemanticsMatchVersionedDB), not on the value.
+func TestParityMultiWritePerBlockValue(t *testing.T) {
+	forEachBackend(t, 8, func(t *testing.T, kvs KVS) {
+		ctx := context.Background()
+		if err := kvs.Handle(ctx, mkMultiTxBlock(1, "ns1",
+			blocks.KVWrite{Key: "k", Value: []byte("lo")},
+			blocks.KVWrite{Key: "k", Value: []byte("hi")})); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		rec, err := kvs.Get("ns1", "k", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "hi" {
+			t.Errorf("expected highest-tx value \"hi\", got %+v", rec)
+		}
+	})
+}
+
+// TestPebbleVersionSemanticsMatchVersionedDB pins the two intentional version
+// divergences from LightKVS (see the PebbleKVS doc comment): PebbleKVS mirrors
+// the sqlite VersionedDB's MAX(version)+1 rule — the store the fabric-x MVCC
+// read-set is validated against — rather than LightKVS's per-block-shared,
+// reset-on-delete numbering.
+func TestPebbleVersionSemanticsMatchVersionedDB(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("consecutive versions for multiple writes to one key in a block", func(t *testing.T) {
+		kvs, err := NewPebbleKVS(t.TempDir(), 8)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer kvs.Close()
+
+		// One block, two txs both writing key "k": tx0 → version 0, tx1 →
+		// version 1 (consecutive, VersionedDB-style). The highest-tx write wins.
+		if err := kvs.Handle(ctx, mkMultiTxBlock(1, "ns1",
+			blocks.KVWrite{Key: "k", Value: []byte("from-tx0")},
+			blocks.KVWrite{Key: "k", Value: []byte("from-tx1")})); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		rec, err := kvs.Get("ns1", "k", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "from-tx1" {
+			t.Fatalf("expected highest-tx value from-tx1, got %+v", rec)
+		}
+		if rec.Version != 1 {
+			t.Errorf("expected version 1 (tx0→0, tx1→1), got %d", rec.Version)
+		}
+	})
+
+	t.Run("version is monotonic across a tombstone", func(t *testing.T) {
+		kvs, err := NewPebbleKVS(t.TempDir(), 8)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer kvs.Close()
+
+		// write (v0) @1, delete (v1 tombstone) @2, rewrite (v2) @3: the per-key
+		// counter does not reset after the delete, unlike LightKVS (which would
+		// restart the rewrite at version 0).
+		if err := kvs.Handle(ctx, mkBlock(1, 0, "tx1", true, "ns1",
+			blocks.KVWrite{Key: "k", Value: []byte("v0")})); err != nil {
+			t.Fatalf("Handle write: %v", err)
+		}
+		if err := kvs.Handle(ctx, mkBlock(2, 0, "tx2", true, "ns1",
+			blocks.KVWrite{Key: "k", IsDelete: true})); err != nil {
+			t.Fatalf("Handle delete: %v", err)
+		}
+		if err := kvs.Handle(ctx, mkBlock(3, 0, "tx3", true, "ns1",
+			blocks.KVWrite{Key: "k", Value: []byte("again")})); err != nil {
+			t.Fatalf("Handle rewrite: %v", err)
+		}
+		rec, err := kvs.Get("ns1", "k", 0)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec == nil || string(rec.Value) != "again" {
+			t.Fatalf("expected latest value \"again\", got %+v", rec)
+		}
+		if rec.Version != 2 {
+			t.Errorf("expected version 2 (monotonic across tombstone), got %d", rec.Version)
+		}
+	})
+}
+
+// TestPebbleHandleTxMultiBlock exercises the HandleTx notification path with
+// writes spanning two blocks delivered out of block order, covering PebbleKVS's
+// group-by-block + ascending-commit logic (LightKVS instead collapses a batch
+// into one snapshot, so this is a PebbleKVS-specific contract).
+func TestPebbleHandleTxMultiBlock(t *testing.T) {
+	ctx := context.Background()
+	kvs, err := NewPebbleKVS(t.TempDir(), 8)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer kvs.Close()
+
+	mkNotif := func(block, tx uint64, id, val string) common.TxNotification {
+		return common.TxNotification{
+			BlockNum: block, TxNum: tx, FabricTxID: id,
+			Status: committerpb.Status_COMMITTED,
+			NsRWS: []blocks.NsReadWriteSet{{Namespace: "ns1", RWS: blocks.ReadWriteSet{
+				Writes: []blocks.KVWrite{{Key: "k", Value: []byte(val)}},
+			}}},
+		}
+	}
+	// Deliver block 2 before block 1 to prove the store commits in ascending
+	// block order (the checkpoint must advance monotonically to 2).
+	if err := kvs.HandleTx(ctx, []common.TxNotification{
+		mkNotif(2, 0, "b2", "block2"),
+		mkNotif(1, 0, "b1", "block1"),
+	}); err != nil {
+		t.Fatalf("HandleTx: %v", err)
+	}
+
+	if n, err := kvs.BlockNumber(ctx); err != nil || n != 2 {
+		t.Errorf("expected head block 2, got %d (err %v)", n, err)
+	}
+	if rec, err := kvs.Get("ns1", "k", 0); err != nil {
+		t.Fatalf("Get latest: %v", err)
+	} else if rec == nil || string(rec.Value) != "block2" {
+		t.Errorf("expected latest \"block2\", got %+v", rec)
+	}
+	// Time-travel to block 1 sees the earlier write.
+	if rec, err := kvs.Get("ns1", "k", 1); err != nil {
+		t.Fatalf("Get as of block 1: %v", err)
+	} else if rec == nil || string(rec.Value) != "block1" {
+		t.Errorf("as of block 1 expected \"block1\", got %+v", rec)
+	}
+}

--- a/endorser/storage/pebblekvs.go
+++ b/endorser/storage/pebblekvs.go
@@ -1,0 +1,517 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package storage
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble"
+	gethpebble "github.com/ethereum/go-ethereum/ethdb/pebble"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+)
+
+// PebbleKVS is a persistent, MVCC key-value store that implements the KVS
+// interface as a drop-in replacement for the in-memory LightKVS. Unlike
+// LightKVS it survives process restarts: every block's writes are committed
+// atomically alongside a persisted block-number checkpoint, so on reopen the
+// store resumes from the last committed block.
+//
+// # Storage model (multi-version, insert-only)
+//
+// Each write is stored under its own versioned key rather than overwriting a
+// single latest slot. The data key layout is:
+//
+//	'd' | be32(len(fullKey)) | fullKey | be64(^block) | be64(^tx)
+//
+// where fullKey is the "namespace:key" string used throughout the endorser and
+// ^x == math.MaxUint64-x. Length-prefixing fullKey makes the per-key prefix
+// unambiguous, and encoding (block, tx) in descending order means a forward
+// scan starting at be64(^lastBlock) lands first on the highest block <=
+// lastBlock (and, within it, the highest tx). geth's ethdb.Iterator is
+// forward-only, so this descending encoding is what makes a "read as of block
+// N" query a single Next().
+//
+// A reserved meta key 'm'|"block" holds be64(lastCommittedBlock) and is written
+// in the same batch as the block's data keys, giving an atomic checkpoint for
+// crash recovery.
+//
+// # Durability
+//
+// Each block commits as one atomic pebble batch, so a crash leaves either the
+// whole block applied or none of it. Commits use geth's default (NoSync): the
+// data survives a process restart, but an OS crash or power loss can lose the
+// most recently committed blocks. Those are recoverable from the ledger — the
+// persisted checkpoint tells the synchronizer where to resume — so this is safe
+// for the endorser, whose state is always reconstructible from committed blocks.
+//
+// # Parity notes vs LightKVS
+//
+//   - Time-travel reads: a snapshot at block N returns, for each key, the record
+//     with the highest version whose block <= N (mirroring the sqlite-backed
+//     VersionedDB, see fabric-x-sdk state.VersionedDB.Get). LightKVS instead
+//     keeps only a small ring buffer of recent snapshots and errors for evicted
+//     blocks; PebbleKVS can serve any historical block. This is a strict
+//     superset of LightKVS's read behavior.
+//   - Deletes are stored as tombstone records (IsDelete=true), matching the
+//     VersionedDB, rather than removing the key as LightKVS does. The execution
+//     layer already treats IsDelete=true records as absent (nil value, nil
+//     version in the read-set), so this is behaviorally equivalent for callers
+//     but preserves the version chain for MVCC validation.
+//   - Version numbers mirror the VersionedDB, not LightKVS: each write's Version
+//     is MAX(version)+1 for its key, so multiple writes to one key within a block
+//     get consecutive versions and the counter is monotonic across a tombstone
+//     (a rewrite after a delete does not reset to 0). LightKVS instead shares one
+//     version across a block's writes to a key and resets after a delete. Because
+//     the fabric-x read-set carries this Version to the committer for MVCC
+//     validation, matching the VersionedDB — the committer's own store — is the
+//     correct behavior; the two divergences from LightKVS are intentional.
+type PebbleKVS struct {
+	db *gethpebble.Database
+
+	// writeMu serializes Update calls. The KVS contract already assumes a
+	// single writer, but the per-key version lookup performs a read against
+	// committed state that must not interleave with a concurrent commit.
+	writeMu sync.Mutex
+
+	// currentBlock is the last committed block number, cached in memory for
+	// cheap BlockNumber() reads and seeded from the meta checkpoint on open.
+	currentBlock atomic.Uint64
+}
+
+const (
+	// prefixData tags versioned data keys.
+	prefixData = 'd'
+	// prefixMeta tags reserved metadata keys.
+	prefixMeta = 'm'
+)
+
+// metaBlockKey holds the last committed block number.
+var metaBlockKey = []byte{prefixMeta, 'b', 'l', 'o', 'c', 'k'}
+
+// Compile-time assertion that PebbleKVS satisfies the KVS interface.
+var _ KVS = (*PebbleKVS)(nil)
+
+// NewPebbleKVS opens (or creates) a pebble-backed KVS rooted at dir. The
+// historySize parameter is accepted for interface symmetry with NewLightKVS but
+// is currently unused: PebbleKVS retains full history (that is the point of a
+// persistent store). It is reserved for a future disk-bounding pruning pass.
+func NewPebbleKVS(dir string, historySize int) (*PebbleKVS, error) {
+	if dir == "" {
+		return nil, errors.New("pebble kvs requires a non-empty data directory (connection-string)")
+	}
+	_ = historySize // reserved for optional pruning; see doc comment.
+
+	// cache is in MB; handles is the max open-file budget. Modest defaults
+	// that keep the working set in memory without a large FD footprint.
+	db, err := gethpebble.New(dir, 128, 512, "endorser/pebblekvs", false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open pebble db at %q: %w", dir, err)
+	}
+
+	kvs := &PebbleKVS{db: db}
+
+	// Recover the last committed block number from the atomic checkpoint.
+	block, err := kvs.readMetaBlock()
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to read block checkpoint: %w", err)
+	}
+	kvs.currentBlock.Store(block)
+
+	return kvs, nil
+}
+
+// readMetaBlock returns the persisted last-committed block, or 0 if the store
+// is fresh.
+func (p *PebbleKVS) readMetaBlock() (uint64, error) {
+	raw, err := p.db.Get(metaBlockKey)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if len(raw) != 8 {
+		return 0, fmt.Errorf("corrupt block checkpoint: got %d bytes, want 8", len(raw))
+	}
+	return binary.BigEndian.Uint64(raw), nil
+}
+
+// Update atomically applies a batch of writes for a single block. All writes
+// carry the same block number (they come from the same block); the block's data
+// keys and the meta checkpoint are committed in one pebble batch, so a crash
+// either leaves the whole block applied or none of it.
+func (p *PebbleKVS) Update(updates []KeyValueVersion) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+
+	blockNum := updates[0].BlockNum
+	batch := p.db.NewBatch()
+	defer batch.Close()
+
+	// nextVersion holds the version to assign to the *next* write of each key
+	// within this batch. VersionedDB computes COALESCE(MAX(version)+1, 0) live
+	// per insert, so successive writes to the same key in one block receive
+	// consecutive versions (fabric-x-sdk state.VersionedDB.UpdateWorldState).
+	// We mirror that exactly: the first write to a key seeds from the committed
+	// latest, and each subsequent write in the same batch increments — so the
+	// highest-tx write wins the read with the highest version, matching the
+	// committer's worldstate that the fabric-x MVCC read-set is validated
+	// against. Seeding from a single point-read also avoids re-reading committed
+	// state for a key written multiple times in one block.
+	nextVersion := make(map[string]uint64, len(updates))
+
+	for i := range updates {
+		u := &updates[i]
+
+		version, seen := nextVersion[u.Key]
+		if !seen {
+			latest, err := p.latestVersion(u.Key)
+			if err != nil {
+				return fmt.Errorf("failed to read latest version for %q: %w", u.Key, err)
+			}
+			version = uint64(latest + 1) // latest is -1 for a fresh key → version 0
+		}
+		nextVersion[u.Key] = version + 1
+
+		value := encodeRecord(record{
+			BlockNum: u.BlockNum,
+			TxNum:    u.TxNum,
+			Version:  version,
+			TxID:     u.TxID,
+			IsDelete: u.IsDelete,
+			Value:    u.Value,
+		})
+
+		if err := batch.Put(dataKey(u.Key, u.BlockNum, u.TxNum), value); err != nil {
+			return fmt.Errorf("failed to stage write for %q: %w", u.Key, err)
+		}
+	}
+
+	// Checkpoint the block number in the same batch for an atomic commit.
+	if err := batch.Put(metaBlockKey, u64be(blockNum)); err != nil {
+		return fmt.Errorf("failed to stage block checkpoint: %w", err)
+	}
+
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("failed to commit block %d: %w", blockNum, err)
+	}
+
+	p.currentBlock.Store(blockNum)
+	return nil
+}
+
+// latestVersion returns the version of the most recent committed record for
+// fullKey, or -1 if the key has never been written. The most recent record is
+// the first hit of a forward scan over the key's prefix (descending version
+// encoding puts the highest block/tx first).
+func (p *PebbleKVS) latestVersion(fullKey string) (int64, error) {
+	it := p.db.NewIterator(dataPrefix(fullKey), nil)
+	defer it.Release()
+
+	if it.Next() {
+		rec, err := decodeRecord(it.Value())
+		if err != nil {
+			return 0, err
+		}
+		return int64(rec.Version), nil
+	}
+	return -1, it.Error()
+}
+
+// NewSnapshot returns a read view of the store as of blockNumber. A blockNumber
+// of 0 resolves to the latest committed block at call time, pinning the view so
+// later commits (higher block numbers) are naturally excluded. Any historical
+// block is serviceable; unlike LightKVS this never errors for an "evicted"
+// block.
+func (p *PebbleKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
+	if blockNumber == 0 {
+		blockNumber = p.currentBlock.Load()
+	}
+	return &pebbleSnapshot{
+		db:        p.db,
+		lastBlock: blockNumber,
+	}, nil
+}
+
+// Get returns the record for (namespace, key) as of lastBlock, or nil if no
+// such record exists at or before that block. A lastBlock of 0 resolves to the
+// latest committed block.
+func (p *PebbleKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error) {
+	r, err := p.NewSnapshot(lastBlock)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return r.Get(namespace, key)
+}
+
+// Handle implements blocks.BlockHandler: it extracts all valid transaction
+// writes from a block and applies them atomically. Called by the synchronizer.
+func (p *PebbleKVS) Handle(ctx context.Context, b blocks.Block) error {
+	var updates []KeyValueVersion
+	for _, tx := range b.Transactions {
+		collectWrites(&updates, tx.NsRWS, b.Number, uint64(tx.Number), tx.ID, tx.Valid)
+	}
+	if len(updates) > 0 {
+		return p.Update(updates)
+	}
+	return nil
+}
+
+// HandleTx implements the notification write path: it extracts writes from a
+// batch of committed transaction notifications and applies them. Notifications
+// may span multiple blocks, so writes are grouped by block and each block is
+// committed atomically.
+func (p *PebbleKVS) HandleTx(ctx context.Context, notifs []common.TxNotification) error {
+	if len(notifs) == 0 {
+		return nil
+	}
+
+	// Group by block so each block commits as one atomic batch, then apply
+	// blocks in ascending order.
+	byBlock := make(map[uint64][]KeyValueVersion)
+	var order []uint64
+	for _, notif := range notifs {
+		valid := notif.Status == committerpb.Status_COMMITTED
+		before := len(byBlock[notif.BlockNum])
+		updates := byBlock[notif.BlockNum]
+		collectWrites(&updates, notif.NsRWS, notif.BlockNum, notif.TxNum, notif.FabricTxID, valid)
+		if before == 0 && len(updates) > 0 {
+			order = append(order, notif.BlockNum)
+		}
+		byBlock[notif.BlockNum] = updates
+	}
+
+	// Apply in ascending block order so the persisted checkpoint advances
+	// monotonically.
+	sortUint64(order)
+	for _, blockNum := range order {
+		if err := p.Update(byBlock[blockNum]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// BlockNumber returns the last committed block number.
+func (p *PebbleKVS) BlockNumber(ctx context.Context) (uint64, error) {
+	return p.currentBlock.Load(), nil
+}
+
+// Close closes the underlying pebble database.
+func (p *PebbleKVS) Close() error {
+	return p.db.Close()
+}
+
+// pebbleSnapshot is a point-in-time read view pinned to a block number. It
+// implements execution.ReadStore. Isolation is inherent to the insert-only MVCC
+// model: existing records never mutate, and later commits have higher block
+// numbers that the descending-version seek skips.
+type pebbleSnapshot struct {
+	db        *gethpebble.Database
+	lastBlock uint64
+	closed    bool
+}
+
+// Get returns the record for (namespace, key) as of the snapshot's block, or
+// nil if none exists at or before it. Tombstone records are returned as-is
+// (IsDelete=true); the execution layer treats them as absent.
+func (s *pebbleSnapshot) Get(namespace, key string) (*blocks.WriteRecord, error) {
+	if s.closed {
+		return nil, errors.New("reader is closed")
+	}
+
+	fullKey := namespace + ":" + key
+
+	// Seek to the first record whose block <= lastBlock. start = be64(^lastBlock)
+	// is <= any key at block == lastBlock and > any key at block > lastBlock.
+	it := s.db.NewIterator(dataPrefix(fullKey), u64be(^s.lastBlock))
+	defer it.Release()
+
+	if it.Next() {
+		rec, err := decodeRecord(it.Value())
+		if err != nil {
+			return nil, err
+		}
+		rec.Namespace = namespace
+		rec.Key = key
+		return rec, nil
+	}
+	return nil, it.Error()
+}
+
+// Close releases the snapshot. After Close the snapshot cannot be used.
+func (s *pebbleSnapshot) Close() error {
+	s.closed = true
+	return nil
+}
+
+// --- key/value encoding ---------------------------------------------------
+
+// record is the decoded form of a stored value. Namespace and Key are not
+// stored (they are recoverable from the query) and are filled in by the reader.
+type record struct {
+	BlockNum uint64
+	TxNum    uint64
+	Version  uint64
+	TxID     string
+	IsDelete bool
+	Value    []byte
+}
+
+// dataPrefix returns the unambiguous per-key prefix: 'd' | be32(len) | fullKey.
+// The returned slice has len == cap so geth's NewIterator, which does
+// append(prefix, start...), reallocates instead of clobbering our buffer.
+func dataPrefix(fullKey string) []byte {
+	b := make([]byte, 0, 1+4+len(fullKey))
+	b = append(b, prefixData)
+	b = binary.BigEndian.AppendUint32(b, uint32(len(fullKey)))
+	b = append(b, fullKey...)
+	return b
+}
+
+// dataKey returns the full versioned key for a write: the per-key prefix
+// followed by the descending-encoded (block, tx) version suffix.
+func dataKey(fullKey string, block, tx uint64) []byte {
+	b := dataPrefix(fullKey)
+	b = binary.BigEndian.AppendUint64(b, ^block)
+	b = binary.BigEndian.AppendUint64(b, ^tx)
+	return b
+}
+
+// u64be returns the 8-byte big-endian encoding of v.
+func u64be(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+// record value layout (compact, varint-based; encoding cost is on the hot path
+// so JSON is deliberately avoided):
+//
+//	flags byte      : bit0 = IsDelete, bit1 = value is non-nil
+//	uvarint BlockNum
+//	uvarint TxNum
+//	uvarint Version
+//	uvarint len(TxID) | TxID bytes
+//	[ uvarint len(Value) | Value bytes ]   -- present iff value non-nil
+const (
+	flagIsDelete    = 1 << 0
+	flagValueNonNil = 1 << 1
+)
+
+// encodeRecord serializes a record into a compact binary value.
+func encodeRecord(r record) []byte {
+	var flags byte
+	if r.IsDelete {
+		flags |= flagIsDelete
+	}
+	if r.Value != nil {
+		flags |= flagValueNonNil
+	}
+
+	// Rough capacity estimate: flags + 3 uvarints + txid + value.
+	buf := make([]byte, 0, 1+3*binary.MaxVarintLen64+len(r.TxID)+len(r.Value)+2*binary.MaxVarintLen64)
+	buf = append(buf, flags)
+	buf = binary.AppendUvarint(buf, r.BlockNum)
+	buf = binary.AppendUvarint(buf, r.TxNum)
+	buf = binary.AppendUvarint(buf, r.Version)
+	buf = binary.AppendUvarint(buf, uint64(len(r.TxID)))
+	buf = append(buf, r.TxID...)
+	if r.Value != nil {
+		buf = binary.AppendUvarint(buf, uint64(len(r.Value)))
+		buf = append(buf, r.Value...)
+	}
+	return buf
+}
+
+// decodeRecord parses a stored value. The returned WriteRecord's Namespace and
+// Key are left empty for the caller to populate. Value bytes are copied out so
+// the result is safe to retain after the iterator advances.
+func decodeRecord(raw []byte) (*blocks.WriteRecord, error) {
+	if len(raw) < 1 {
+		return nil, errors.New("corrupt record: empty value")
+	}
+	flags := raw[0]
+	pos := 1
+
+	blockNum, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("corrupt record: block num")
+	}
+	pos += n
+
+	txNum, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("corrupt record: tx num")
+	}
+	pos += n
+
+	version, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("corrupt record: version")
+	}
+	pos += n
+
+	txIDLen, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("corrupt record: txid length")
+	}
+	pos += n
+	if pos+int(txIDLen) > len(raw) {
+		return nil, errors.New("corrupt record: txid overruns value")
+	}
+	txID := string(raw[pos : pos+int(txIDLen)])
+	pos += int(txIDLen)
+
+	var value []byte
+	if flags&flagValueNonNil != 0 {
+		valLen, n := binary.Uvarint(raw[pos:])
+		if n <= 0 {
+			return nil, errors.New("corrupt record: value length")
+		}
+		pos += n
+		if pos+int(valLen) > len(raw) {
+			return nil, errors.New("corrupt record: value overruns value")
+		}
+		// Copy so the result survives the next iterator step.
+		value = make([]byte, valLen)
+		copy(value, raw[pos:pos+int(valLen)])
+	}
+
+	return &blocks.WriteRecord{
+		BlockNum: blockNum,
+		TxNum:    txNum,
+		Version:  version,
+		Value:    value,
+		IsDelete: flags&flagIsDelete != 0,
+		TxID:     txID,
+	}, nil
+}
+
+// sortUint64 sorts a small slice of block numbers ascending (insertion sort;
+// notification batches span very few distinct blocks).
+func sortUint64(s []uint64) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/endorser/storage/pebblekvs.go
+++ b/endorser/storage/pebblekvs.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	gethpebble "github.com/ethereum/go-ethereum/ethdb/pebble"
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
@@ -69,6 +70,12 @@ import (
 //     layer already treats IsDelete=true records as absent (nil value, nil
 //     version in the read-set), so this is behaviorally equivalent for callers
 //     but preserves the version chain for MVCC validation.
+//   - Block height tracks the ledger exactly: a block that yields no writes still
+//     advances the persisted checkpoint, where LightKVS leaves its height at the
+//     last block that contained writes. See Handle.
+//   - The write path is idempotent per block: re-applying a block at or below the
+//     checkpoint is a no-op, where LightKVS would apply it again and bump every
+//     touched key's version. See commitBlock.
 //   - Version numbers mirror the VersionedDB, not LightKVS: each write's Version
 //     is MAX(version)+1 for its key, so multiple writes to one key within a block
 //     get consecutive versions and the counter is monotonic across a tombstone
@@ -88,7 +95,15 @@ type PebbleKVS struct {
 	// currentBlock is the last committed block number, cached in memory for
 	// cheap BlockNumber() reads and seeded from the meta checkpoint on open.
 	currentBlock atomic.Uint64
+
+	// hasCheckpoint records whether currentBlock reflects an actual commit, as
+	// opposed to the zero value of a fresh store. currentBlock alone cannot
+	// distinguish the two, and the replay guard in commitBlock would otherwise
+	// treat block 0 of a fresh store as already applied.
+	hasCheckpoint atomic.Bool
 }
+
+var pebbleLogger = flogging.MustGetLogger("endorser.storage.pebblekvs")
 
 const (
 	// prefixData tags versioned data keys.
@@ -123,45 +138,92 @@ func NewPebbleKVS(dir string, historySize int) (*PebbleKVS, error) {
 	kvs := &PebbleKVS{db: db}
 
 	// Recover the last committed block number from the atomic checkpoint.
-	block, err := kvs.readMetaBlock()
+	block, found, err := kvs.readMetaBlock()
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to read block checkpoint: %w", err)
 	}
 	kvs.currentBlock.Store(block)
+	kvs.hasCheckpoint.Store(found)
+	if found {
+		pebbleLogger.Infof("opened pebble kvs at %q, resuming from block %d", dir, block)
+	} else {
+		pebbleLogger.Infof("opened fresh pebble kvs at %q", dir)
+	}
 
 	return kvs, nil
 }
 
-// readMetaBlock returns the persisted last-committed block, or 0 if the store
-// is fresh.
-func (p *PebbleKVS) readMetaBlock() (uint64, error) {
+// readMetaBlock returns the persisted last-committed block and whether a
+// checkpoint was found at all. The two are distinct: a fresh store and a store
+// whose last commit was block 0 both report block 0.
+func (p *PebbleKVS) readMetaBlock() (uint64, bool, error) {
 	raw, err := p.db.Get(metaBlockKey)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
-			return 0, nil
+			return 0, false, nil
 		}
-		return 0, err
+		return 0, false, err
 	}
 	if len(raw) != 8 {
-		return 0, fmt.Errorf("corrupt block checkpoint: got %d bytes, want 8", len(raw))
+		return 0, false, fmt.Errorf("corrupt block checkpoint: got %d bytes, want 8", len(raw))
 	}
-	return binary.BigEndian.Uint64(raw), nil
+	return binary.BigEndian.Uint64(raw), true, nil
 }
 
 // Update atomically applies a batch of writes for a single block. All writes
-// carry the same block number (they come from the same block); the block's data
-// keys and the meta checkpoint are committed in one pebble batch, so a crash
-// either leaves the whole block applied or none of it.
+// must carry the same block number (they come from the same block); the block's
+// data keys and the meta checkpoint are committed in one pebble batch, so a
+// crash either leaves the whole block applied or none of it.
+//
+// Blocks at or below the persisted checkpoint are skipped as already applied —
+// see commitBlock.
 func (p *PebbleKVS) Update(updates []KeyValueVersion) error {
 	if len(updates) == 0 {
 		return nil
 	}
 
+	// A batch spanning several blocks would be committed under a single
+	// checkpoint, so a crash could leave the store claiming a height whose
+	// blocks are only partly applied. Both write paths group by block before
+	// calling Update, so this is a broken-invariant check, not a runtime
+	// condition.
+	blockNum := updates[0].BlockNum
+	for i := range updates {
+		if updates[i].BlockNum != blockNum {
+			return fmt.Errorf(
+				"pebble kvs: update batch spans multiple blocks (%d at index 0, %d at index %d); "+
+					"writes must be grouped by block before committing",
+				blockNum, updates[i].BlockNum, i)
+		}
+	}
+
+	return p.commitBlock(blockNum, updates)
+}
+
+// commitBlock applies a single block's writes (possibly none) and advances the
+// persisted checkpoint to blockNum, in one atomic pebble batch.
+//
+// Blocks at or below the current checkpoint are skipped. This is what makes the
+// write path idempotent under replay, which is required rather than merely nice:
+// the synchronizer resumes at lastBlock+1 of whichever store it was given as its
+// height reader, and in the gateway topology that store is the block DB, not
+// this KVS (see integration/test_helpers.go, where handlers run in the order
+// [endorser KVSs..., chain, gateway]). A crash between this KVS's commit and the
+// block DB's therefore replays a block this KVS has already applied. Applying a
+// block's writes twice would advance every touched key's version an extra step
+// and permanently desynchronize this store from the committer's worldstate, so
+// the read-sets built from it would fail MVCC validation. The block DB tolerates
+// the same replay via ON CONFLICT DO NOTHING (gateway/storage/query.sql).
+func (p *PebbleKVS) commitBlock(blockNum uint64, updates []KeyValueVersion) error {
 	p.writeMu.Lock()
 	defer p.writeMu.Unlock()
 
-	blockNum := updates[0].BlockNum
+	if p.hasCheckpoint.Load() && blockNum <= p.currentBlock.Load() {
+		pebbleLogger.Debugf("skipping already-applied block %d (checkpoint at %d)", blockNum, p.currentBlock.Load())
+		return nil
+	}
+
 	batch := p.db.NewBatch()
 	defer batch.Close()
 
@@ -214,6 +276,7 @@ func (p *PebbleKVS) Update(updates []KeyValueVersion) error {
 	}
 
 	p.currentBlock.Store(blockNum)
+	p.hasCheckpoint.Store(true)
 	return nil
 }
 
@@ -264,21 +327,33 @@ func (p *PebbleKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteR
 
 // Handle implements blocks.BlockHandler: it extracts all valid transaction
 // writes from a block and applies them atomically. Called by the synchronizer.
+//
+// A block that yields no writes — empty, config-only, or carrying nothing but
+// invalid transactions — still advances the persisted checkpoint. LightKVS can
+// leave its height behind in that case because its state does not outlive the
+// process, but for a persistent store the checkpoint is the resume point: were
+// it to lag, a restart would re-deliver every block since the last one that
+// happened to contain writes, and the store's reported height would disagree
+// with the block DB's, which does log empty blocks. Keeping height equal to
+// ledger height is what lets this KVS serve as the synchronizer's height reader.
 func (p *PebbleKVS) Handle(ctx context.Context, b blocks.Block) error {
 	var updates []KeyValueVersion
 	for _, tx := range b.Transactions {
 		collectWrites(&updates, tx.NsRWS, b.Number, uint64(tx.Number), tx.ID, tx.Valid)
 	}
-	if len(updates) > 0 {
-		return p.Update(updates)
-	}
-	return nil
+	return p.commitBlock(b.Number, updates)
 }
 
 // HandleTx implements the notification write path: it extracts writes from a
 // batch of committed transaction notifications and applies them. Notifications
 // may span multiple blocks, so writes are grouped by block and each block is
 // committed atomically.
+//
+// Each call must carry all of a block's notifications. AllTxBatchDispatcher
+// satisfies this — the SDK delivers one AllTxBatch per block and the dispatcher
+// forwards each batch as one call — and the replay guard in commitBlock depends
+// on it: a block arriving in two calls would have its second half skipped as
+// already applied rather than merged.
 func (p *PebbleKVS) HandleTx(ctx context.Context, notifs []common.TxNotification) error {
 	if len(notifs) == 0 {
 		return nil

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -75,8 +75,9 @@ func (cfg Config) Validate() error {
 	if cfg.Network.Namespace == "" {
 		errs = append(errs, errors.New("network.namespace is required"))
 	}
-	if p := cfg.Network.Protocol; p != "" && p != "fabric" && p != "fabric-x" {
-		errs = append(errs, errors.New("network.protocol must be 'fabric' or 'fabric-x'"))
+	_, protocolErr := common.NormalizeProtocol(cfg.Network.Protocol)
+	if protocolErr != nil {
+		errs = append(errs, protocolErr)
 	}
 	if cfg.Gateway.Listen == "" {
 		errs = append(errs, errors.New("gateway.listen is required"))
@@ -105,6 +106,15 @@ func (cfg Config) Validate() error {
 	}
 	for i := range cfg.Endorsers {
 		errs = append(errs, cfg.Endorsers[i].Validate())
+		// Checked here rather than in Endorser.Validate because the backend and
+		// the protocol it has to agree with live at different config levels.
+		// Skipped when the protocol itself is already invalid, so one bad
+		// protocol value is not also reported once per endorser.
+		if protocolErr == nil {
+			if err := endorser.ValidateDatabaseProtocol(cfg.Endorsers[i].Database.Database, cfg.Network.Protocol); err != nil {
+				errs = append(errs, fmt.Errorf("endorsers[%d]: %w", i, err))
+			}
+		}
 	}
 
 	return errors.Join(errs...)

--- a/gateway/config/validate_test.go
+++ b/gateway/config/validate_test.go
@@ -111,3 +111,57 @@ func TestConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigValidateProtocolEndorserCompatibility(t *testing.T) {
+	t.Run("pebble with fabric protocol fails", func(t *testing.T) {
+		cfg := validConfig(t)
+		cfg.Network.Protocol = common.ProtocolFabric
+		cfg.Endorsers[0].Database.Database = endorsercfg.DBPebble
+		cfg.Endorsers[0].Database.ConnString = t.TempDir()
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for pebble with fabric protocol, got nil")
+		}
+		errStr := err.Error()
+		if !strings.Contains(errStr, "pebble") {
+			t.Errorf("error should mention 'pebble', got: %v", err)
+		}
+		if !strings.Contains(errStr, "endorsers[0]") {
+			t.Errorf("error should mention 'endorsers[0]', got: %v", err)
+		}
+	})
+
+	t.Run("pebble with fabric-x protocol passes", func(t *testing.T) {
+		cfg := validConfig(t)
+		cfg.Network.Protocol = common.ProtocolFabricX
+		cfg.Endorsers[0].Database.Database = endorsercfg.DBPebble
+		cfg.Endorsers[0].Database.ConnString = t.TempDir()
+
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("unexpected error for pebble with fabric-x: %v", err)
+		}
+	})
+
+	t.Run("invalid protocol reported once with multiple pebble endorsers", func(t *testing.T) {
+		cfg := validConfig(t)
+		cfg.Network.Protocol = "bogus"
+		// Add a second pebble endorser.
+		cfg.Endorsers = append(cfg.Endorsers, cfg.Endorsers[0])
+		cfg.Endorsers[0].Database.Database = endorsercfg.DBPebble
+		cfg.Endorsers[0].Database.ConnString = t.TempDir()
+		cfg.Endorsers[1].Database.Database = endorsercfg.DBPebble
+		cfg.Endorsers[1].Database.ConnString = t.TempDir()
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid protocol, got nil")
+		}
+
+		errStr := err.Error()
+		count := strings.Count(errStr, "network.protocol")
+		if count != 1 {
+			t.Errorf("expected 'network.protocol' to appear exactly once, got %d times in: %v", count, err)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ tool (
 )
 
 require (
+	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.3
 	github.com/holiman/uint256 v1.3.2
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
@@ -50,7 +51,6 @@ require (
 	github.com/cockroachdb/errors v1.14.0 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
-	github.com/cockroachdb/pebble v1.1.5 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/consensys/gnark-crypto v0.20.1 // indirect


### PR DESCRIPTION
Closes #218.

Adds `PebbleKVS`, a persistent MVCC store behind the existing `storage.KVS` interface, as a drop-in for the in-memory `LightKVS` (lost on restart). New implementation plus a factory `switch` case; no executor, StateDB or synchronizer changes.

Each block commits as one atomic pebble batch with a persisted block number, so a reopened store resumes from the last committed block. Where it differs from `LightKVS` it follows the sqlite `VersionedDB` the committer validates against: `MAX(version)+1` per key, deletes kept as tombstones. Enable with `database.database: pebble` and `connection-string` as the data directory.
