### PR TITLE
fix: fence hardhat transactions to keep reverted state clean

### DIFF
--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -66,15 +66,20 @@ type EvmAPI struct {
 	mu       sync.Mutex
 	lightKVS estorage.Revertible
 	store    storage.Revertible
+	// Taken exclusively for the duration of a snapshot or revert, so neither
+	// runs with transactions still in flight behind it. Distinct from mu, which
+	// only guards the fields below.
+	fence *txFence
 	// Map snapshot IDs (hex strings) to block numbers
 	snapshots map[string]uint64
 }
 
 // NewEvmAPI creates a new EVM API instance with LightKVS and Store for state management.
-func NewEvmAPI(lightKVS estorage.Revertible, store storage.Revertible) *EvmAPI {
+func NewEvmAPI(lightKVS estorage.Revertible, store storage.Revertible, fence *txFence) *EvmAPI {
 	return &EvmAPI{
 		lightKVS:  lightKVS,
 		store:     store,
+		fence:     fence,
 		snapshots: make(map[string]uint64),
 	}
 }
@@ -84,6 +89,11 @@ func NewEvmAPI(lightKVS estorage.Revertible, store storage.Revertible) *EvmAPI {
 // Snapshots both the LightKVS state and the Store database.
 func (api *EvmAPI) Snapshot(ctx context.Context) (string, error) {
 	hardhatLogger.Debugf("EvmAPI.Snapshot() called")
+	// Wait out anything still in flight, so the block number recorded below is
+	// one the ledger has actually settled on.
+	api.fence.Lock()
+	defer api.fence.Unlock()
+
 	api.mu.Lock()
 	defer api.mu.Unlock()
 
@@ -120,6 +130,14 @@ func (api *EvmAPI) Snapshot(ctx context.Context) (string, error) {
 // to restore the database state.
 func (api *EvmAPI) Revert(ctx context.Context, snapshotID string) (bool, error) {
 	hardhatLogger.Debugf("EvmAPI.Revert() called with snapshotID=%s", snapshotID)
+	// Waits out transactions already accepted and holds off new ones; see
+	// txFence. Waiting on the gateway alone suffices only because handlers run
+	// [endorser KVS, chain, gateway] on one synchronizer (see buildApp), so a
+	// transaction the gateway calls committed is already in the endorser's
+	// state. Giving the endorser its own synchronizer would break that.
+	api.fence.Lock()
+	defer api.fence.Unlock()
+
 	api.mu.Lock()
 	defer api.mu.Unlock()
 

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -8,9 +8,14 @@ package testimpl
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/hyperledger/fabric-x-evm/gateway/api"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
 func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
@@ -47,5 +52,119 @@ func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
 				t.Fatalf("result = %#v, want nil", result)
 			}
 		})
+	}
+}
+
+// mockRevertibleKVS / mockRevertibleStore are the two halves of the ledger that
+// evm_revert rewinds, stubbed down to what EvmAPI actually calls.
+type mockRevertibleKVS struct {
+	onRevert func(blockNumber uint64)
+}
+
+func (m *mockRevertibleKVS) BlockNumber(context.Context) (uint64, error) { return 1, nil }
+
+func (m *mockRevertibleKVS) RevertToBlock(blockNumber uint64) error {
+	if m.onRevert != nil {
+		m.onRevert(blockNumber)
+	}
+	return nil
+}
+
+type mockRevertibleStore struct{}
+
+func (m *mockRevertibleStore) Snapshot(context.Context) (uint64, error)    { return 1, nil }
+func (m *mockRevertibleStore) RevertToBlock(context.Context, uint64) error { return nil }
+
+// TestEvmAPI_RevertWaitsForInFlightTransaction pins the invariant the txFence
+// exists for: a transaction the test RPC has accepted must finish committing
+// before evm_revert rewinds the ledger. Without the fence the revert lands
+// first and the transaction commits into the state the next test believes it
+// just reset.
+func TestEvmAPI_RevertWaitsForInFlightTransaction(t *testing.T) {
+	testAccountMgr, err := LoadTestAccounts("../../testdata/test_accounts.json")
+	if err != nil {
+		t.Fatalf("LoadTestAccounts: %v", err)
+	}
+	from := testAccountMgr.Addresses[0]
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// The transaction stays pending until commit is closed, standing in for a
+	// tx sitting in the gateway's queue.
+	commit := make(chan struct{})
+	polled := make(chan struct{})
+	var polledOnce sync.Once
+
+	backend := &mockBackend{
+		txByHashFunc: func(common.Hash) (*domain.Transaction, error) {
+			polledOnce.Do(func() { close(polled) })
+			select {
+			case <-commit:
+				return &domain.Transaction{BlockNumber: 1}, nil
+			default:
+				time.Sleep(time.Millisecond) // keep the poll loop off a hot spin
+				return &domain.Transaction{BlockNumber: 0}, nil
+			}
+		},
+	}
+
+	var mu sync.Mutex
+	var events []string
+	record := func(what string) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, what)
+	}
+
+	fence := &txFence{}
+	kvs := &mockRevertibleKVS{onRevert: func(uint64) { record("revert") }}
+	testAPI := NewTestEthAPI(api.NewEthAPI(backend), backend, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, fence)
+	evmAPI := NewEvmAPI(kvs, &mockRevertibleStore{}, fence)
+
+	snapshotID, err := evmAPI.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	sent := make(chan error, 1)
+	go func() {
+		_, err := testAPI.SendTransaction(context.Background(), TransactionArgs{From: &from, To: &to})
+		record("committed")
+		sent <- err
+	}()
+
+	<-polled // the send is in flight and holding the fence
+
+	reverted := make(chan error, 1)
+	go func() {
+		_, err := evmAPI.Revert(context.Background(), snapshotID)
+		reverted <- err
+	}()
+
+	// The revert must not get through while the transaction is still in flight.
+	select {
+	case err := <-reverted:
+		t.Fatalf("Revert completed with a transaction still in flight (err=%v)", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(commit)
+
+	if err := <-sent; err != nil {
+		t.Fatalf("SendTransaction: %v", err)
+	}
+	select {
+	case err := <-reverted:
+		if err != nil {
+			t.Fatalf("Revert: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Revert did not complete after the transaction committed")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"committed", "revert"}
+	if len(events) != len(want) || events[0] != want[0] || events[1] != want[1] {
+		t.Fatalf("event order = %v, want %v", events, want)
 	}
 }

--- a/gateway/testimpl/server.go
+++ b/gateway/testimpl/server.go
@@ -12,6 +12,8 @@ package testimpl
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -19,6 +21,26 @@ import (
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage"
 )
+
+// txFence keeps evm_snapshot/evm_revert from moving the ledger out from under
+// transactions the test RPC has accepted but not yet seen committed.
+//
+// Submissions hold it shared for their whole accept-to-commit window; snapshot
+// and revert take it exclusively, which both waits out what is already in
+// flight and holds off anything new for the duration.
+//
+// Test-only, only for evm_snapshot/evm_revert. The production gateway has no
+// revert and must never wait for the queue to drain on the submit path.
+type txFence struct {
+	sync.RWMutex
+}
+
+// errFenced rejects a submission that arrives while a snapshot or revert holds
+// the fence. Queueing it instead would just admit it the instant the rewind
+// finished, recreating the contamination one step later. A real test never hits
+// this - loadFixture awaits evm_revert before sending - only requests it
+// abandoned, whose results nobody reads.
+var errFenced = errors.New("transaction rejected: a snapshot or revert is in progress")
 
 // NewTestServer creates an RPC server with test-only methods enabled.
 // This wraps the production server and adds eth_accounts and eth_sendTransaction
@@ -32,11 +54,14 @@ import (
 func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys map[common.Address]*ecdsa.PrivateKey, lightKVS estorage.Revertible, store storage.Revertible) (*rpc.Server, error) {
 	srv := rpc.NewServer()
 
+	// Shared by the submit path and the snapshot/revert path; see txFence.
+	fence := &txFence{}
+
 	// Create production API
 	prodAPI := api.NewEthAPI(b)
 
 	// Wrap with test API that adds unsafe methods
-	testAPI := NewTestEthAPI(prodAPI, b, testAccounts, testAccountKeys)
+	testAPI := NewTestEthAPI(prodAPI, b, testAccounts, testAccountKeys, fence)
 
 	// Register the test-enabled API
 	if err := srv.RegisterName("eth", testAPI); err != nil {
@@ -61,7 +86,7 @@ func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys
 	if err := srv.RegisterName("hardhat", NewHardhatAPI()); err != nil {
 		return nil, err
 	}
-	if err := srv.RegisterName("evm", NewEvmAPI(lightKVS, store)); err != nil {
+	if err := srv.RegisterName("evm", NewEvmAPI(lightKVS, store, fence)); err != nil {
 		return nil, err
 	}
 

--- a/gateway/testimpl/test_eth_api.go
+++ b/gateway/testimpl/test_eth_api.go
@@ -34,16 +34,18 @@ type TestEthAPI struct {
 	backend         api.Backend
 	testAccounts    []common.Address
 	testAccountKeys map[common.Address]*ecdsa.PrivateKey
+	fence           *txFence
 }
 
 // NewTestEthAPI creates a test-enabled Ethereum API wrapper.
 // It embeds the production API and adds unsafe test-only methods.
-func NewTestEthAPI(prodAPI *api.EthAPI, backend api.Backend, accounts []common.Address, keys map[common.Address]*ecdsa.PrivateKey) *TestEthAPI {
+func NewTestEthAPI(prodAPI *api.EthAPI, backend api.Backend, accounts []common.Address, keys map[common.Address]*ecdsa.PrivateKey, fence *txFence) *TestEthAPI {
 	return &TestEthAPI{
 		EthAPI:          prodAPI,
 		backend:         backend,
 		testAccounts:    accounts,
 		testAccountKeys: keys,
+		fence:           fence,
 	}
 }
 
@@ -60,6 +62,13 @@ func (api *TestEthAPI) Accounts(ctx context.Context) ([]common.Address, error) {
 // which means the server has access to private keys. This is acceptable for
 // development/testing but is a critical security vulnerability in production.
 func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs) (common.Hash, error) {
+	// Held from the nonce read through to the commit, so a revert can't land in
+	// between and leave us signing against a nonce that no longer exists.
+	if !api.fence.TryRLock() {
+		return common.Hash{}, errFenced
+	}
+	defer api.fence.RUnlock()
+
 	// Validate from address
 	if args.From == nil {
 		return common.Hash{}, fmt.Errorf("missing 'from' field")
@@ -133,8 +142,9 @@ func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs
 		return common.Hash{}, fmt.Errorf("failed to marshal transaction: %w", err)
 	}
 
-	// Call our overridden SendRawTransaction which makes it synchronous
-	txHash, err := api.SendRawTransaction(ctx, hexutil.Bytes(txBytes))
+	// Send synchronously. The unexported form, because the fence is already held
+	// above and RWMutex read locks must not be taken recursively.
+	txHash, err := api.sendRawTransaction(ctx, hexutil.Bytes(txBytes))
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -145,6 +155,19 @@ func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs
 // SendRawTransaction overrides the base implementation to make it synchronous for Hardhat compatibility.
 // It sends the transaction and polls until it's committed to a block, mimicking Hardhat's auto-mining behavior.
 func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+	// Held until the transaction has committed, so evm_snapshot/evm_revert can't
+	// move the ledger while it is still in flight - including when the client
+	// gives up on the request and the transaction commits anyway. See txFence.
+	if !api.fence.TryRLock() {
+		return common.Hash{}, errFenced
+	}
+	defer api.fence.RUnlock()
+
+	return api.sendRawTransaction(ctx, input)
+}
+
+// sendRawTransaction is SendRawTransaction without the fence, for callers that already hold it.
+func (api *TestEthAPI) sendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
 	// Call the underlying SendRawTransaction
 	txHash, err := api.EthAPI.SendRawTransaction(ctx, input)
 	if err != nil {
@@ -161,8 +184,13 @@ func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Byt
 			// Check if transaction is committed
 			tx, err := api.backend.TransactionByHash(ctx, txHash)
 			if err != nil {
-				// Transaction not found yet, continue polling
+				// Transaction not found yet, continue polling. Yield like the
+				// pending case below does: spinning flat out here starves the
+				// very gateway workers we're waiting on, which on a loaded
+				// two-core CI runner is the difference between committing in
+				// milliseconds and not committing at all.
 				hardhatLogger.Debugf("got error %w while polling TransactionByHash for hash %s", err, txHash)
+				runtime.Gosched()
 				continue
 			}
 

--- a/gateway/testimpl/test_eth_api_test.go
+++ b/gateway/testimpl/test_eth_api_test.go
@@ -53,7 +53,7 @@ func TestTestEthAPI_Accounts(t *testing.T) {
 			// Create production API
 			prodAPI := api.NewEthAPI(nil)
 			// Wrap with test API
-			testAPI := NewTestEthAPI(prodAPI, nil, tt.testAccounts, nil)
+			testAPI := NewTestEthAPI(prodAPI, nil, tt.testAccounts, nil, &txFence{})
 
 			accounts, err := testAPI.Accounts(context.TODO())
 			if err != nil {
@@ -131,7 +131,7 @@ func TestTestEthAPI_SendTransaction_Validation(t *testing.T) {
 			// Create production API
 			prodAPI := api.NewEthAPI(mockBackend)
 			// Wrap with test API
-			testAPI := NewTestEthAPI(prodAPI, mockBackend, testAccountMgr.Addresses, testAccountMgr.PrivateKeys)
+			testAPI := NewTestEthAPI(prodAPI, mockBackend, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, &txFence{})
 
 			_, err := testAPI.SendTransaction(context.TODO(), tt.args)
 


### PR DESCRIPTION
A data race is breaking the openzeppelin tests on main. It's caused by old asynchronous transactions committing after a revert.

Gating the sendTransaction API with a mutex and dropping late transactions should resolve the issue.