### PR TITLE
Fix flaky test and assorted API validation issues

### DIFF
--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -8,9 +8,11 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -196,9 +198,33 @@ func (api *EthAPI) GetCode(ctx context.Context, addr common.Address, block rpc.B
 	return result, nil
 }
 
+// decodeStorageKey left-pads a quantity-encoded storage slot to 32 bytes, as geth does.
+func decodeStorageKey(s string) (common.Hash, error) {
+	key := s
+	if strings.HasPrefix(key, "0x") || strings.HasPrefix(key, "0X") {
+		key = key[2:]
+	}
+	if len(key)%2 != 0 {
+		key = "0" + key
+	}
+	if len(key) > 2*common.HashLength {
+		return common.Hash{}, rpcerr.InvalidParams("storage key too long (want at most 32 bytes): %q", s)
+	}
+	b, err := hex.DecodeString(key)
+	if err != nil {
+		return common.Hash{}, rpcerr.InvalidParams("invalid hex in storage key: %q", s)
+	}
+	return common.BytesToHash(b), nil
+}
+
 // eth_getStorageAt
-func (api *EthAPI) GetStorageAt(ctx context.Context, addr common.Address, slot common.Hash, block rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	logger.Debugf("EthAPI.GetStorageAt() called with addr=%s, slot=%s", addr.Hex(), slot.Hex())
+func (api *EthAPI) GetStorageAt(ctx context.Context, addr common.Address, hexSlot string, block rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
+	logger.Debugf("EthAPI.GetStorageAt() called with addr=%s, slot=%s", addr.Hex(), hexSlot)
+	slot, err := decodeStorageKey(hexSlot)
+	if err != nil {
+		logger.Debugf("EthAPI.GetStorageAt() returning error: %v", err)
+		return nil, err
+	}
 	blockNum, err := api.blockNumberOrHashToBlockNumber(ctx, block)
 	if err != nil {
 		logger.Debugf("EthAPI.GetStorageAt() returning error: %v", err)

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -404,9 +405,18 @@ func (api *EthAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, erro
 	return result, nil
 }
 
+// maxFeeHistory bounds eth_feeHistory's response, matching geth's default. Without it an
+// arbitrarily large blockCount would size the slices below straight into an OOM.
+const maxFeeHistory = 1024
+
 // eth_feeHistory
-func (api *EthAPI) FeeHistory(ctx context.Context, blockCount hexutil.Uint, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*FeeHistoryResult, error) {
+// blockCount is math.HexOrDecimal64, as in geth, so a decimal or unquoted count is accepted too.
+func (api *EthAPI) FeeHistory(ctx context.Context, blockCount gethmath.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*FeeHistoryResult, error) {
 	logger.Debugf("EthAPI.FeeHistory() called with blockCount=%d, lastBlock=%v", blockCount, lastBlock)
+	if blockCount > maxFeeHistory {
+		logger.Debugf("EthAPI.FeeHistory() truncating blockCount %d to %d", blockCount, maxFeeHistory)
+		blockCount = maxFeeHistory
+	}
 	zero := (*hexutil.Big)(big.NewInt(0))
 
 	baseFee := make([]*hexutil.Big, blockCount+1)
@@ -516,42 +526,89 @@ func domainLogToTypesLog(l domain.Log) *types.Log {
 	}
 }
 
+// hexArg type-asserts a call argument, so a non-string (say a JSON number) is invalid params rather than a panic.
+func hexArg(field string, v any) (string, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", rpcerr.InvalidParams("invalid %s: expected a hex string, got %T", field, v)
+	}
+	return s, nil
+}
+
+// quantityArg decodes an optional quantity-encoded call argument, absent and null alike yielding nil.
+func quantityArg(args map[string]any, field string) (*big.Int, error) {
+	v, ok := args[field]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	s, err := hexArg(field, v)
+	if err != nil {
+		return nil, err
+	}
+	n, err := hexutil.DecodeBig(s)
+	if err != nil {
+		return nil, rpcerr.InvalidParams("invalid %s: %v", field, err)
+	}
+	return n, nil
+}
+
+// addressArg decodes an address strictly, as geth does: common.HexToAddress never fails, silently
+// zero-padding a short address and truncating a long one to a different address entirely.
+func addressArg(field string, v any) (common.Address, error) {
+	s, err := hexArg(field, v)
+	if err != nil {
+		return common.Address{}, err
+	}
+	var addr common.Address
+	if err := addr.UnmarshalText([]byte(s)); err != nil {
+		return common.Address{}, rpcerr.InvalidParams("invalid %s: %v", field, err)
+	}
+	return addr, nil
+}
+
 func argsToCallMsg(args map[string]any) (ethereum.CallMsg, error) {
 	var msg ethereum.CallMsg
 
 	if v, ok := args["from"]; ok && v != nil {
-		msg.From = common.HexToAddress(v.(string))
+		from, err := addressArg("from", v)
+		if err != nil {
+			return msg, err
+		}
+		msg.From = from
 	}
 
 	// "to" may be explicitly null for contract-creation calls.
 	if v, ok := args["to"]; ok && v != nil {
-		addr := common.HexToAddress(v.(string))
-		msg.To = &addr
+		to, err := addressArg("to", v)
+		if err != nil {
+			return msg, err
+		}
+		msg.To = &to
 	}
 
 	if v, ok := args["gas"]; ok && v != nil {
-		gas, err := hexutil.DecodeUint64(v.(string))
+		s, err := hexArg("gas", v)
+		if err != nil {
+			return msg, err
+		}
+		gas, err := hexutil.DecodeUint64(s)
 		if err != nil {
 			return msg, rpcerr.InvalidParams("invalid gas: %v", err)
 		}
 		msg.Gas = gas
 	}
 
-	if v, ok := args["gasPrice"]; ok && v != nil {
-		gp, err := hexutil.DecodeBig(v.(string))
-		if err != nil {
-			return msg, rpcerr.InvalidParams("invalid gasPrice: %v", err)
-		}
-		msg.GasPrice = gp
+	gasPrice, err := quantityArg(args, "gasPrice")
+	if err != nil {
+		return msg, err
 	}
+	msg.GasPrice = gasPrice
 
-	if v, ok := args["value"]; ok && v != nil {
-		val, err := hexutil.DecodeBig(v.(string))
-		if err != nil {
-			return msg, rpcerr.InvalidParams("invalid value: %v", err)
-		}
-		msg.Value = val
+	value, err := quantityArg(args, "value")
+	if err != nil {
+		return msg, err
 	}
+	msg.Value = value
 
 	// "input" is the canonical field; "data" is the legacy alias (used by some clients)
 	inputKey := "input"
@@ -561,7 +618,11 @@ func argsToCallMsg(args map[string]any) (ethereum.CallMsg, error) {
 		}
 	}
 	if v, ok := args[inputKey]; ok && v != nil {
-		data, err := hexutil.Decode(v.(string))
+		s, err := hexArg(inputKey, v)
+		if err != nil {
+			return msg, err
+		}
+		data, err := hexutil.Decode(s)
 		if err != nil {
 			return msg, rpcerr.InvalidParams("invalid %s: %v", inputKey, err)
 		}
@@ -569,20 +630,11 @@ func argsToCallMsg(args map[string]any) (ethereum.CallMsg, error) {
 	}
 
 	// EIP-1559 (optional, ignore safely if absent)
-	if v, ok := args["maxFeePerGas"]; ok && v != nil {
-		fee, err := hexutil.DecodeBig(v.(string))
-		if err != nil {
-			return msg, rpcerr.InvalidParams("invalid maxFeePerGas: %v", err)
-		}
-		msg.GasFeeCap = fee
+	if msg.GasFeeCap, err = quantityArg(args, "maxFeePerGas"); err != nil {
+		return msg, err
 	}
-
-	if v, ok := args["maxPriorityFeePerGas"]; ok && v != nil {
-		tip, err := hexutil.DecodeBig(v.(string))
-		if err != nil {
-			return msg, rpcerr.InvalidParams("invalid maxPriorityFeePerGas: %v", err)
-		}
-		msg.GasTipCap = tip
+	if msg.GasTipCap, err = quantityArg(args, "maxPriorityFeePerGas"); err != nil {
+		return msg, err
 	}
 
 	return msg, nil

--- a/gateway/api/eth_handlers_test.go
+++ b/gateway/api/eth_handlers_test.go
@@ -9,12 +9,15 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	gethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/filters"
@@ -29,6 +32,18 @@ var (
 	latestBlockRef = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	errBoom        = errors.New("boom")
 )
+
+// assertInvalidParams fails unless err is a JSON-RPC -32602. what identifies the input under test.
+func assertInvalidParams(t *testing.T, err error, what string) {
+	t.Helper()
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("%s: error = %T (%v), want rpc.Error", what, err, err)
+	}
+	if rpcErr.ErrorCode() != -32602 {
+		t.Errorf("%s: code = %d, want -32602 (InvalidParams)", what, rpcErr.ErrorCode())
+	}
+}
 
 // mustBlock returns a fully populated domain.Block so rpcBlock() marshalling
 // can convert every []byte to common.Hash without panicking.
@@ -292,13 +307,7 @@ func TestGetStorageAt_SlotEncodings(t *testing.T) {
 			b := &stubBackend{storage: []byte{0xde, 0xad}}
 			_, err := NewEthAPI(b).GetStorageAt(context.Background(), testAddr, tt.slot, latestBlockRef)
 			if tt.wantErr {
-				var rpcErr rpc.Error
-				if !errors.As(err, &rpcErr) {
-					t.Fatalf("GetStorageAt(%q) error = %T (%v), want rpc.Error", tt.slot, err, err)
-				}
-				if rpcErr.ErrorCode() != -32602 {
-					t.Errorf("code = %d, want -32602 (InvalidParams)", rpcErr.ErrorCode())
-				}
+				assertInvalidParams(t, err, fmt.Sprintf("GetStorageAt(%q)", tt.slot))
 				return
 			}
 			if err != nil {
@@ -539,7 +548,7 @@ func TestMaxPriorityFeePerGas_ReturnsZero(t *testing.T) {
 
 func TestFeeHistory_ShapesArrays(t *testing.T) {
 	api := NewEthAPI(&stubBackend{})
-	got, err := api.FeeHistory(context.Background(), hexutil.Uint(3), rpc.LatestBlockNumber, []float64{25, 50, 75})
+	got, err := api.FeeHistory(context.Background(), 3, rpc.LatestBlockNumber, []float64{25, 50, 75})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -564,7 +573,7 @@ func TestFeeHistory_ShapesArrays(t *testing.T) {
 
 func TestFeeHistory_NoPercentiles(t *testing.T) {
 	api := NewEthAPI(&stubBackend{})
-	got, err := api.FeeHistory(context.Background(), hexutil.Uint(2), rpc.LatestBlockNumber, nil)
+	got, err := api.FeeHistory(context.Background(), 2, rpc.LatestBlockNumber, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -574,6 +583,50 @@ func TestFeeHistory_NoPercentiles(t *testing.T) {
 }
 
 // ---- Logs ----
+
+// blockCount sizes the response slices directly, so an unbounded count would OOM.
+func TestFeeHistory_ClampsBlockCount(t *testing.T) {
+	api := NewEthAPI(&stubBackend{})
+	got, err := api.FeeHistory(context.Background(), gethmath.HexOrDecimal64(1<<40), rpc.LatestBlockNumber, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got.GasUsedRatio) != maxFeeHistory {
+		t.Errorf("GasUsedRatio len = %d, want %d", len(got.GasUsedRatio), maxFeeHistory)
+	}
+	if len(got.BaseFee) != maxFeeHistory+1 {
+		t.Errorf("BaseFee len = %d, want %d", len(got.BaseFee), maxFeeHistory+1)
+	}
+}
+
+// geth takes math.HexOrDecimal64 here, so hex, decimal and unquoted counts all decode.
+func TestFeeHistory_BlockCountAcceptsHexAndDecimal(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{name: "quoted hex", raw: `"0x2"`, want: 2},
+		{name: "quoted decimal", raw: `"2"`, want: 2},
+		{name: "unquoted number", raw: `2`, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var blockCount gethmath.HexOrDecimal64
+			if err := json.Unmarshal([]byte(tt.raw), &blockCount); err != nil {
+				t.Fatalf("unmarshal %s: %v", tt.raw, err)
+			}
+			got, err := NewEthAPI(&stubBackend{}).FeeHistory(context.Background(), blockCount, rpc.LatestBlockNumber, nil)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if len(got.GasUsedRatio) != tt.want {
+				t.Errorf("GasUsedRatio len = %d, want %d", len(got.GasUsedRatio), tt.want)
+			}
+		})
+	}
+}
 
 func TestGetLogs_Happy(t *testing.T) {
 	api := NewEthAPI(&stubBackend{
@@ -753,6 +806,55 @@ func TestArgsToCallMsg_HappyPathAllFields(t *testing.T) {
 	}
 	if msg.GasFeeCap.Int64() != 3 || msg.GasTipCap.Int64() != 2 {
 		t.Errorf("EIP-1559 fields not parsed: fee=%s tip=%s", msg.GasFeeCap, msg.GasTipCap)
+	}
+}
+
+// common.HexToAddress never fails, so a malformed address used to be accepted silently
+// and the call executed against a different address than the caller asked for.
+func TestArgsToCallMsg_MalformedAddressesAreInvalidParams(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		addr  string
+	}{
+		{name: "to not hex", field: "to", addr: "0xnonsense"},
+		{name: "to too short", field: "to", addr: "0x1234"},
+		{name: "to too long", field: "to", addr: "0xff0000000000000000000000000000000000000001"},
+		{name: "to missing 0x prefix", field: "to", addr: "2222222222222222222222222222222222222222"},
+		{name: "from not hex", field: "from", addr: "0xnonsense"},
+		{name: "from too long", field: "from", addr: "0xff0000000000000000000000000000000000000001"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := argsToCallMsg(map[string]any{tt.field: tt.addr})
+			assertInvalidParams(t, err, tt.field+"="+tt.addr)
+		})
+	}
+}
+
+// Args arrive as map[string]any straight from JSON, so a number stays a float64;
+// type-asserting it to string used to panic out through the RPC layer.
+func TestArgsToCallMsg_NonStringFieldsAreInvalidParams(t *testing.T) {
+	fields := []string{"from", "to", "gas", "gasPrice", "value", "input", "data", "maxFeePerGas", "maxPriorityFeePerGas"}
+
+	for _, field := range fields {
+		t.Run(field, func(t *testing.T) {
+			// float64 is what encoding/json produces for a JSON number.
+			_, err := argsToCallMsg(map[string]any{field: float64(21000)})
+			assertInvalidParams(t, err, field+"=<number>")
+		})
+	}
+}
+
+func TestArgsToCallMsg_AbsentAndNullQuantitiesStayNil(t *testing.T) {
+	msg, err := argsToCallMsg(map[string]any{"gasPrice": nil, "value": nil})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if msg.GasPrice != nil || msg.Value != nil || msg.GasFeeCap != nil || msg.GasTipCap != nil {
+		t.Errorf("want nil quantities, got gasPrice=%v value=%v fee=%v tip=%v",
+			msg.GasPrice, msg.Value, msg.GasFeeCap, msg.GasTipCap)
 	}
 }
 

--- a/gateway/api/eth_handlers_test.go
+++ b/gateway/api/eth_handlers_test.go
@@ -236,7 +236,7 @@ func TestGetCode_BackendError(t *testing.T) {
 func TestGetStorageAt_Happy(t *testing.T) {
 	want := []byte{0xde, 0xad, 0xbe, 0xef}
 	api := NewEthAPI(&stubBackend{storage: want})
-	got, err := api.GetStorageAt(context.Background(), testAddr, common.HexToHash("0x1"), latestBlockRef)
+	got, err := api.GetStorageAt(context.Background(), testAddr, "0x1", latestBlockRef)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -247,8 +247,67 @@ func TestGetStorageAt_Happy(t *testing.T) {
 
 func TestGetStorageAt_BackendError(t *testing.T) {
 	api := NewEthAPI(&stubBackend{storageErr: errBoom})
-	if _, err := api.GetStorageAt(context.Background(), testAddr, common.HexToHash("0x1"), latestBlockRef); err == nil {
+	if _, err := api.GetStorageAt(context.Background(), testAddr, "0x1", latestBlockRef); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// Callers such as ethers quantity-encode the slot, so leading zeros may be
+// stripped and the string may be odd-length; geth accepts both.
+func TestGetStorageAt_SlotEncodings(t *testing.T) {
+	const full = "0x0000000000000000000000000000000000000000000000000000000000000001"
+
+	tests := []struct {
+		name    string
+		slot    string
+		want    common.Hash
+		wantErr bool
+	}{
+		{name: "quantity encoded odd length", slot: "0x1", want: common.HexToHash(full)},
+		{name: "short even length", slot: "0x0abc", want: common.HexToHash("0xabc")},
+		{name: "full 64 chars", slot: full, want: common.HexToHash(full)},
+		{
+			name: "full 64 chars with leading zero nibble",
+			slot: "0x0f23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want: common.HexToHash("0x0f23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+		},
+		{
+			name: "leading zero nibble stripped by quantity encoding",
+			slot: "0xf23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want: common.HexToHash("0x0f23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+		},
+		{name: "no 0x prefix", slot: "1", want: common.HexToHash(full)},
+		{name: "uppercase prefix", slot: "0X1", want: common.HexToHash(full)},
+		{name: "empty is the zero slot", slot: "0x", want: common.Hash{}},
+		{
+			name:    "over 32 bytes",
+			slot:    "0x010000000000000000000000000000000000000000000000000000000000000001",
+			wantErr: true,
+		},
+		{name: "not hex", slot: "0xzz", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &stubBackend{storage: []byte{0xde, 0xad}}
+			_, err := NewEthAPI(b).GetStorageAt(context.Background(), testAddr, tt.slot, latestBlockRef)
+			if tt.wantErr {
+				var rpcErr rpc.Error
+				if !errors.As(err, &rpcErr) {
+					t.Fatalf("GetStorageAt(%q) error = %T (%v), want rpc.Error", tt.slot, err, err)
+				}
+				if rpcErr.ErrorCode() != -32602 {
+					t.Errorf("code = %d, want -32602 (InvalidParams)", rpcErr.ErrorCode())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetStorageAt(%q) err = %v", tt.slot, err)
+			}
+			if b.lastKey != tt.want {
+				t.Errorf("backend key = %s, want %s", b.lastKey.Hex(), tt.want.Hex())
+			}
+		})
 	}
 }
 
@@ -639,7 +698,7 @@ func TestGetCode_BlockNumberByHashError(t *testing.T) {
 
 func TestGetStorageAt_BlockNumberByHashError(t *testing.T) {
 	api := NewEthAPI(&stubBackend{getBlockErr: errBoom})
-	if _, err := api.GetStorageAt(context.Background(), testAddr, common.HexToHash("0x1"), rpc.BlockNumberOrHashWithHash(testBlockHash, false)); err == nil {
+	if _, err := api.GetStorageAt(context.Background(), testAddr, "0x1", rpc.BlockNumberOrHashWithHash(testBlockHash, false)); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/gateway/api/eth_test.go
+++ b/gateway/api/eth_test.go
@@ -284,6 +284,7 @@ type stubBackend struct {
 	balanceErr error
 	storage    []byte
 	storageErr error
+	lastKey    common.Hash // captured on StorageAt for assertion
 	code       []byte
 	codeErr    error
 	nonce      uint64
@@ -375,6 +376,7 @@ func (s *stubBackend) BalanceAt(ctx context.Context, account common.Address, blo
 	return big.NewInt(0), nil
 }
 func (s *stubBackend) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	s.lastKey = key
 	return s.storage, s.storageErr
 }
 func (s *stubBackend) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -224,9 +224,6 @@
     "cause": "execution reverted"
   },
   {
-    "id": "AccessManager #execute keeps the original _executionId after finishing the call"
-  },
-  {
     "id": "AccessManager #execute restrictions when the manager is open when the call comes from the manager (msg.sender == manager) \"before each\" hook: define caller as manager for \"succeeds\"",
     "cause": "hardhat_impersonateAccount"
   },


### PR DESCRIPTION
    - allow quantity encoding for storage slots
    - reject malformed `from`/`to` in eth_call: common.HexToAddress never fails, so a
      short address was zero-padded and a long one truncated to a different address,
      silently executing the call against the wrong contract
    - return invalid params instead of panicking when a call argument is a JSON
      number; the unchecked type assertion surfaced as -32603 "method handler crashed"
    - take blockCount as math.HexOrDecimal64 in eth_feeHistory, as geth does, so
      decimal and unquoted counts are accepted and not just hex
    - clamp feeHistory blockCount to geth's 1024; it sized the response slices
      unbounded, so a large count was a trivial OOM