### PR TITLE
drain the tx queue on evm_snapshot/evm_revert

### DIFF
--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -165,7 +165,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 		// Wrap the chain's store with SnapshotStore for snapshot/revert functionality
 		snapshotStore := storage.NewSnapshotStore(chain.Store)
 
-		rpcServer, err = testimpl.NewTestServer(gateway, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, revertibleKVS, snapshotStore)
+		rpcServer, err = testimpl.NewTestServer(gateway, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, revertibleKVS, snapshotStore, gateway.TxQueue)
 		if err != nil {
 			return nil, err
 		}

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -48,6 +48,11 @@ type TxQueueInterface interface {
 	// IsPending checks if a transaction is currently in the queue or being processed
 	IsPending(txHash common.Hash) *types.Transaction
 
+	// InFlight returns how many transactions are queued or being processed, i.e.
+	// how many IsPending would answer for. Zero means everything submitted so far
+	// has reached a block.
+	InFlight() int
+
 	// Complete removes a transaction from tracking. Safe to call for a hash
 	// that is not currently tracked.
 	Complete(txHash common.Hash)

--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -122,6 +122,13 @@ func (q *TxQueue) IsPending(txHash common.Hash) *types.Transaction {
 	return nil
 }
 
+// InFlight returns how many transactions are queued or being processed.
+func (q *TxQueue) InFlight() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.pendingQueue) + len(q.inProgressMap)
+}
+
 // Complete removes a transaction from the in-progress map after it has been committed.
 // This should be called by the Gateway's callback when a block containing the transaction
 // is committed to the ledger. This method is idempotent - safe to call multiple times.

--- a/gateway/core/txqueue_test.go
+++ b/gateway/core/txqueue_test.go
@@ -67,6 +67,24 @@ func TestTxQueue_DequeueMovesTxToInProgressMap(t *testing.T) {
 	assert.Equal(t, tx.Hash(), inProgressTx.Hash())
 }
 
+// InFlight must count exactly what IsPending would find, across both stages.
+func TestTxQueue_InFlight_CountsQueuedAndInProgress(t *testing.T) {
+	q := NewTxQueue()
+	assert.Equal(t, 0, q.InFlight())
+
+	q.Enqueue(testTx(1))
+	q.Enqueue(testTx(2))
+	assert.Equal(t, 2, q.InFlight())
+
+	// Moving to in-progress keeps it in flight; only committing clears it.
+	tx, ok := q.Dequeue()
+	require.True(t, ok)
+	assert.Equal(t, 2, q.InFlight())
+
+	q.Complete(tx.Hash())
+	assert.Equal(t, 1, q.InFlight())
+}
+
 func TestTxQueue_IsPending_FindsInPendingQueue(t *testing.T) {
 	q := NewTxQueue()
 	tx := testTx(1)

--- a/gateway/core/txqueue_v2.go
+++ b/gateway/core/txqueue_v2.go
@@ -358,6 +358,15 @@ func (q *TxQueueV2) completeUnlocked(hash common.Hash) int {
 	return numPromoted
 }
 
+// InFlight returns how many transactions are queued or being processed. hashMap
+// holds every entry from Enqueue until Complete, including the ones Dequeue moved
+// into pendingMap, so it alone is the count.
+func (q *TxQueueV2) InFlight() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.hashMap)
+}
+
 // IsPending checks if a transaction is in the queue (ready, waiting, or being processed).
 // Returns the transaction if found in any location, nil otherwise.
 func (q *TxQueueV2) IsPending(txHash common.Hash) *types.Transaction {

--- a/gateway/core/txqueue_v2_test.go
+++ b/gateway/core/txqueue_v2_test.go
@@ -95,6 +95,24 @@ func TestNewTxQueueV2_Initialization(t *testing.T) {
 	assert.Equal(t, 0, q.invalid)
 }
 
+// InFlight must count exactly what IsPending would find, across both stages.
+func TestTxQueueV2_InFlight_CountsQueuedAndInProgress(t *testing.T) {
+	q := NewTxQueueV2()
+	assert.Equal(t, 0, q.InFlight())
+
+	q.Enqueue(testTxV2(1))
+	q.Enqueue(testTxV2(2))
+	assert.Equal(t, 2, q.InFlight())
+
+	// Moving to in-progress keeps it in flight; only committing clears it.
+	tx, ok := q.Dequeue()
+	require.True(t, ok)
+	assert.Equal(t, 2, q.InFlight())
+
+	q.Complete(tx.Hash())
+	assert.Equal(t, 1, q.InFlight())
+}
+
 func TestTxQueueV2_Enqueue_SingleTransaction(t *testing.T) {
 	q := NewTxQueueV2()
 	tx := testTxV2(1)

--- a/gateway/testimpl/accounts_test.go
+++ b/gateway/testimpl/accounts_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// The accounts JSON is embedded, so the default set needs no file on disk.
+func TestDefaultTestAccounts_AreEmbedded(t *testing.T) {
+	mgr, err := DefaultTestAccounts()
+	if err != nil {
+		t.Fatalf("DefaultTestAccounts: %v", err)
+	}
+	if len(mgr.Addresses) == 0 {
+		t.Fatal("no accounts")
+	}
+	if len(mgr.PrivateKeys) != len(mgr.Addresses) {
+		t.Fatalf("got %d keys for %d addresses", len(mgr.PrivateKeys), len(mgr.Addresses))
+	}
+	// Every address must be the one its own key derives to, or signing lookups miss.
+	for _, addr := range mgr.Addresses {
+		key, ok := mgr.PrivateKeys[addr]
+		if !ok {
+			t.Fatalf("no key for %s", addr.Hex())
+		}
+		if got := crypto.PubkeyToAddress(key.PublicKey); got != addr {
+			t.Errorf("key for %s derives to %s", addr.Hex(), got.Hex())
+		}
+	}
+}
+
+func TestLoadTestAccounts(t *testing.T) {
+	// A written-out file, so the test carries its own fixture.
+	good := filepath.Join(t.TempDir(), "accounts.json")
+	const key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	contents := `{"accounts":[{"address":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","privateKey":"0x` + key + `"}]}`
+	if err := os.WriteFile(good, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	malformed := filepath.Join(t.TempDir(), "malformed.json")
+	if err := os.WriteFile(malformed, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    int
+		wantErr bool
+	}{
+		{name: "from file", path: good, want: 1},
+		{name: "empty path falls back to embedded", path: "", want: len(mustDefaultAccounts(t).Addresses)},
+		{name: "missing file", path: filepath.Join(t.TempDir(), "nope.json"), wantErr: true},
+		{name: "malformed file", path: malformed, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, err := LoadTestAccounts(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("LoadTestAccounts(%q) err = nil, want error", tt.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadTestAccounts(%q): %v", tt.path, err)
+			}
+			if len(mgr.Addresses) != tt.want {
+				t.Errorf("got %d accounts, want %d", len(mgr.Addresses), tt.want)
+			}
+		})
+	}
+}
+
+func mustDefaultAccounts(t *testing.T) *TestAccountManager {
+	t.Helper()
+	mgr, err := DefaultTestAccounts()
+	if err != nil {
+		t.Fatalf("DefaultTestAccounts: %v", err)
+	}
+	return mgr
+}

--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -66,9 +66,7 @@ type EvmAPI struct {
 	mu       sync.Mutex
 	lightKVS estorage.Revertible
 	store    storage.Revertible
-	// Taken exclusively for the duration of a snapshot or revert, so neither
-	// runs with transactions still in flight behind it. Distinct from mu, which
-	// only guards the fields below.
+	// Drained before a snapshot or revert touches the ledger; see txFence.
 	fence *txFence
 	// Map snapshot IDs (hex strings) to block numbers
 	snapshots map[string]uint64
@@ -89,13 +87,17 @@ func NewEvmAPI(lightKVS estorage.Revertible, store storage.Revertible, fence *tx
 // Snapshots both the LightKVS state and the Store database.
 func (api *EvmAPI) Snapshot(ctx context.Context) (string, error) {
 	hardhatLogger.Debugf("EvmAPI.Snapshot() called")
-	// Wait out anything still in flight, so the block number recorded below is
-	// one the ledger has actually settled on.
-	api.fence.Lock()
-	defer api.fence.Unlock()
-
+	// mu first, so only one rewind is ever draining the fence at a time.
 	api.mu.Lock()
 	defer api.mu.Unlock()
+
+	// Wait out anything still in flight, so the block number recorded below is
+	// one the ledger has actually settled on.
+	if err := api.fence.beginRewind(ctx); err != nil {
+		hardhatLogger.Debugf("EvmAPI.Snapshot() returning error: %v", err)
+		return "", err
+	}
+	defer api.fence.endRewind()
 
 	// Snapshot the Store database - this returns the current block number
 	hardhatLogger.Debugf("EvmAPI.Snapshot() creating Store snapshot")
@@ -130,16 +132,20 @@ func (api *EvmAPI) Snapshot(ctx context.Context) (string, error) {
 // to restore the database state.
 func (api *EvmAPI) Revert(ctx context.Context, snapshotID string) (bool, error) {
 	hardhatLogger.Debugf("EvmAPI.Revert() called with snapshotID=%s", snapshotID)
+	// mu first, so only one rewind is ever draining the fence at a time.
+	api.mu.Lock()
+	defer api.mu.Unlock()
+
 	// Waits out transactions already accepted and holds off new ones; see
 	// txFence. Waiting on the gateway alone suffices only because handlers run
 	// [endorser KVS, chain, gateway] on one synchronizer (see buildApp), so a
 	// transaction the gateway calls committed is already in the endorser's
 	// state. Giving the endorser its own synchronizer would break that.
-	api.fence.Lock()
-	defer api.fence.Unlock()
-
-	api.mu.Lock()
-	defer api.mu.Unlock()
+	if err := api.fence.beginRewind(ctx); err != nil {
+		hardhatLogger.Debugf("EvmAPI.Revert() returning error: %v", err)
+		return false, err
+	}
+	defer api.fence.endRewind()
 
 	hardhatLogger.Debugf("EvmAPI.Revert() all snapshots before revert: %v", api.snapshots)
 

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
@@ -81,24 +82,28 @@ func (m *mockRevertibleStore) RevertToBlock(context.Context, uint64) error { ret
 // first and the transaction commits into the state the next test believes it
 // just reset.
 func TestEvmAPI_RevertWaitsForInFlightTransaction(t *testing.T) {
-	testAccountMgr, err := LoadTestAccounts("../../testdata/test_accounts.json")
-	if err != nil {
-		t.Fatalf("LoadTestAccounts: %v", err)
-	}
+	testAccountMgr := testSigner(t)
 	from := testAccountMgr.Addresses[0]
-	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	to := testToAddr
 
-	// The transaction stays pending until commit is closed, standing in for a
-	// tx sitting in the gateway's queue.
+	// The transaction sits in the queue until commit is closed, standing in for a
+	// tx the gateway has taken but not yet put in a block.
+	pool := &fakePool{}
 	commit := make(chan struct{})
 	polled := make(chan struct{})
 	var polledOnce sync.Once
+	var committedOnce sync.Once
 
 	backend := &mockBackend{
+		sendTxFunc: func(*types.Transaction) error {
+			pool.enqueue()
+			return nil
+		},
 		txByHashFunc: func(common.Hash) (*domain.Transaction, error) {
 			polledOnce.Do(func() { close(polled) })
 			select {
 			case <-commit:
+				committedOnce.Do(pool.commit)
 				return &domain.Transaction{BlockNumber: 1}, nil
 			default:
 				time.Sleep(time.Millisecond) // keep the poll loop off a hot spin
@@ -115,7 +120,7 @@ func TestEvmAPI_RevertWaitsForInFlightTransaction(t *testing.T) {
 		events = append(events, what)
 	}
 
-	fence := &txFence{}
+	fence := &txFence{pool: pool}
 	kvs := &mockRevertibleKVS{onRevert: func(uint64) { record("revert") }}
 	testAPI := NewTestEthAPI(api.NewEthAPI(backend), backend, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, fence)
 	evmAPI := NewEvmAPI(kvs, &mockRevertibleStore{}, fence)

--- a/gateway/testimpl/server.go
+++ b/gateway/testimpl/server.go
@@ -12,8 +12,6 @@ package testimpl
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -21,26 +19,6 @@ import (
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage"
 )
-
-// txFence keeps evm_snapshot/evm_revert from moving the ledger out from under
-// transactions the test RPC has accepted but not yet seen committed.
-//
-// Submissions hold it shared for their whole accept-to-commit window; snapshot
-// and revert take it exclusively, which both waits out what is already in
-// flight and holds off anything new for the duration.
-//
-// Test-only, only for evm_snapshot/evm_revert. The production gateway has no
-// revert and must never wait for the queue to drain on the submit path.
-type txFence struct {
-	sync.RWMutex
-}
-
-// errFenced rejects a submission that arrives while a snapshot or revert holds
-// the fence. Queueing it instead would just admit it the instant the rewind
-// finished, recreating the contamination one step later. A real test never hits
-// this - loadFixture awaits evm_revert before sending - only requests it
-// abandoned, whose results nobody reads.
-var errFenced = errors.New("transaction rejected: a snapshot or revert is in progress")
 
 // NewTestServer creates an RPC server with test-only methods enabled.
 // This wraps the production server and adds eth_accounts and eth_sendTransaction
@@ -51,11 +29,11 @@ var errFenced = errors.New("transaction rejected: a snapshot or revert is in pro
 // SECURITY WARNING: This server performs server-side transaction signing,
 // which is inherently insecure. Use ONLY for development and testing.
 // NEVER use in production environments.
-func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys map[common.Address]*ecdsa.PrivateKey, lightKVS estorage.Revertible, store storage.Revertible) (*rpc.Server, error) {
+func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys map[common.Address]*ecdsa.PrivateKey, lightKVS estorage.Revertible, store storage.Revertible, pool TxPool) (*rpc.Server, error) {
 	srv := rpc.NewServer()
 
 	// Shared by the submit path and the snapshot/revert path; see txFence.
-	fence := &txFence{}
+	fence := &txFence{pool: pool}
 
 	// Create production API
 	prodAPI := api.NewEthAPI(b)

--- a/gateway/testimpl/test_eth_api.go
+++ b/gateway/testimpl/test_eth_api.go
@@ -16,7 +16,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
-	"runtime"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -62,13 +62,23 @@ func (api *TestEthAPI) Accounts(ctx context.Context) ([]common.Address, error) {
 // which means the server has access to private keys. This is acceptable for
 // development/testing but is a critical security vulnerability in production.
 func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs) (common.Hash, error) {
-	// Held from the nonce read through to the commit, so a revert can't land in
-	// between and leave us signing against a nonce that no longer exists.
-	if !api.fence.TryRLock() {
-		return common.Hash{}, errFenced
+	txHash, err := api.signAndEnqueue(ctx, args)
+	if err != nil {
+		return common.Hash{}, err
 	}
-	defer api.fence.RUnlock()
+	return txHash, api.awaitCommit(ctx, txHash)
+}
 
+// signAndEnqueue signs args and hands the transaction to the gateway. The fence
+// spans the nonce read as well, so a rewind can't land in between and leave us
+// signing against a nonce that no longer exists.
+func (api *TestEthAPI) signAndEnqueue(ctx context.Context, args TransactionArgs) (common.Hash, error) {
+	return api.fence.submit(func() (common.Hash, error) {
+		return api.signAndEnqueueLocked(ctx, args)
+	})
+}
+
+func (api *TestEthAPI) signAndEnqueueLocked(ctx context.Context, args TransactionArgs) (common.Hash, error) {
 	// Validate from address
 	if args.From == nil {
 		return common.Hash{}, fmt.Errorf("missing 'from' field")
@@ -142,73 +152,60 @@ func (api *TestEthAPI) SendTransaction(ctx context.Context, args TransactionArgs
 		return common.Hash{}, fmt.Errorf("failed to marshal transaction: %w", err)
 	}
 
-	// Send synchronously. The unexported form, because the fence is already held
-	// above and RWMutex read locks must not be taken recursively.
-	txHash, err := api.sendRawTransaction(ctx, hexutil.Bytes(txBytes))
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	return txHash, nil
+	// Enqueue only: the caller waits for the commit outside the fence.
+	return api.EthAPI.SendRawTransaction(ctx, hexutil.Bytes(txBytes))
 }
 
 // SendRawTransaction overrides the base implementation to make it synchronous for Hardhat compatibility.
 // It sends the transaction and polls until it's committed to a block, mimicking Hardhat's auto-mining behavior.
 func (api *TestEthAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
-	// Held until the transaction has committed, so evm_snapshot/evm_revert can't
-	// move the ledger while it is still in flight - including when the client
-	// gives up on the request and the transaction commits anyway. See txFence.
-	if !api.fence.TryRLock() {
-		return common.Hash{}, errFenced
-	}
-	defer api.fence.RUnlock()
-
-	return api.sendRawTransaction(ctx, input)
-}
-
-// sendRawTransaction is SendRawTransaction without the fence, for callers that already hold it.
-func (api *TestEthAPI) sendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
-	// Call the underlying SendRawTransaction
-	txHash, err := api.EthAPI.SendRawTransaction(ctx, input)
+	txHash, err := api.fence.submit(func() (common.Hash, error) {
+		return api.EthAPI.SendRawTransaction(ctx, input)
+	})
 	if err != nil {
 		return common.Hash{}, err
 	}
+	return txHash, api.awaitCommit(ctx, txHash)
+}
 
-	// Poll until the transaction is committed (has a block number > 0)
-	// This mimics Hardhat's auto-mining behavior where transactions are mined immediately
+// commitPollInterval paces the wait below; sleeping rather than spinning keeps a
+// hot loop from starving the gateway workers we are waiting on.
+const commitPollInterval = time.Millisecond
+
+// commitTimeout bounds the wait for a single transaction. The fence is already
+// released by now, so a transaction that never commits delays only its own caller.
+const commitTimeout = 30 * time.Second
+
+// awaitCommit blocks until the transaction reaches a block, mimicking Hardhat's
+// auto-mining. Deliberately outside the fence; see txFence.
+func (api *TestEthAPI) awaitCommit(ctx context.Context, txHash common.Hash) error {
+	deadline := time.NewTimer(commitTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(commitPollInterval)
+	defer poll.Stop()
+
 	for {
+		tx, err := api.backend.TransactionByHash(ctx, txHash)
+		switch {
+		case err != nil:
+			// Not visible yet; keep waiting.
+			hardhatLogger.Debugf("polling TransactionByHash for %s: %v", txHash, err)
+		case tx == nil:
+			// Gone from both the queue and the store: the gateway worker failed it and
+			// dropped it (gateway/core.Gateway.worker), so no block will ever carry it.
+			// TODO: delete once a worker-failed transaction gets a terminal state of its
+			// own in gateway/core, rather than becoming indistinguishable from unknown.
+			return fmt.Errorf("transaction %s was dropped before it committed", txHash)
+		case tx.BlockNumber > 0:
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
-			return common.Hash{}, ctx.Err()
-		default:
-			// Check if transaction is committed
-			tx, err := api.backend.TransactionByHash(ctx, txHash)
-			if err != nil {
-				// Transaction not found yet, continue polling. Yield like the
-				// pending case below does: spinning flat out here starves the
-				// very gateway workers we're waiting on, which on a loaded
-				// two-core CI runner is the difference between committing in
-				// milliseconds and not committing at all.
-				hardhatLogger.Debugf("got error %w while polling TransactionByHash for hash %s", err, txHash)
-				runtime.Gosched()
-				continue
-			}
-
-			// this should never happen: `api.EthAPI.SendRawTransaction` synchronously enqueues the transaction
-			// and so `api.backend.TransactionByHash` must for sure find it in the pending queue or inprogress map
-			if tx == nil {
-				panic("programming error - synchronously enqueued transaction was not found")
-			}
-
-			// Check if transaction has been included in a block
-			// BlockNumber is 0 for pending transactions, > 0 for committed
-			if tx.BlockNumber > 0 {
-				// Transaction is committed
-				return txHash, nil
-			}
-
-			// Transaction is still pending, continue polling
-			runtime.Gosched()
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("transaction %s did not commit within %s", txHash, commitTimeout)
+		case <-poll.C:
 		}
 	}
 }

--- a/gateway/testimpl/test_eth_api_test.go
+++ b/gateway/testimpl/test_eth_api_test.go
@@ -11,12 +11,15 @@ package testimpl
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
@@ -75,16 +78,10 @@ func TestTestEthAPI_Accounts(t *testing.T) {
 }
 
 func TestTestEthAPI_SendTransaction_Validation(t *testing.T) {
-	// Load test accounts from JSON file
-	testAccountMgr, err := LoadTestAccounts("../../testdata/test_accounts.json")
-	if err != nil {
-		t.Fatalf("Failed to load test accounts: %v", err)
-	}
-
-	// Use first account for testing
+	testAccountMgr := testSigner(t)
 	testAddr := testAccountMgr.Addresses[0]
 	unknownAddr := common.HexToAddress("0x0000000000000000000000000000000000000000")
-	toAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	toAddr := testToAddr
 
 	tests := []struct {
 		name    string
@@ -150,6 +147,29 @@ func TestTestEthAPI_SendTransaction_Validation(t *testing.T) {
 	}
 }
 
+// testAccountKey is Hardhat's first well-known dev account.
+const testAccountKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+// testSigner returns a single hardcoded account, so these tests carry their own
+// signing material rather than tracking test_accounts.json. The address is derived
+// from the key, so the two cannot drift apart.
+func testSigner(t *testing.T) *TestAccountManager {
+	t.Helper()
+	key, err := crypto.HexToECDSA(testAccountKey)
+	if err != nil {
+		t.Fatalf("HexToECDSA: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return &TestAccountManager{
+		Addresses:   []common.Address{addr},
+		PrivateKeys: map[common.Address]*ecdsa.PrivateKey{addr: key},
+	}
+}
+
+// testToAddr is an arbitrary recipient, for transactions whose destination is
+// beside the point.
+var testToAddr = common.HexToAddress("0x1234567890123456789012345678901234567890")
+
 // mockBackend is a minimal Backend implementation for testing
 type mockBackend struct {
 	api.Backend
@@ -180,4 +200,34 @@ func (m *mockBackend) TransactionByHash(_ context.Context, hash common.Hash) (*d
 	return &domain.Transaction{
 		BlockNumber: 1,
 	}, nil
+}
+
+// A transaction the gateway worker fails is deleted from the in-progress map and
+// never stored, so TransactionByHash reports it as simply absent. That used to hit
+// a "should never happen" panic, which the RPC layer turned into -32603; it must
+// surface as an ordinary error rather than stalling until the deadline.
+func TestTestEthAPI_DroppedTransactionErrors(t *testing.T) {
+	testAccountMgr := testSigner(t)
+	from := testAccountMgr.Addresses[0]
+	to := testToAddr
+
+	// Neither pending nor stored: the worker failed it and dropped it.
+	backend := &mockBackend{
+		txByHashFunc: func(common.Hash) (*domain.Transaction, error) { return nil, nil },
+	}
+
+	pool := &fakePool{}
+	testAPI := NewTestEthAPI(api.NewEthAPI(backend), backend, testAccountMgr.Addresses, testAccountMgr.PrivateKeys, &txFence{pool: pool})
+
+	start := time.Now()
+	_, err := testAPI.SendTransaction(context.Background(), TransactionArgs{From: &from, To: &to})
+	if err == nil {
+		t.Fatal("SendTransaction returned nil for a dropped transaction")
+	}
+	if !strings.Contains(err.Error(), "dropped") {
+		t.Errorf("error = %q, want it to say the transaction was dropped", err)
+	}
+	if elapsed := time.Since(start); elapsed > commitTimeout/2 {
+		t.Errorf("took %s, want a prompt error rather than waiting out commitTimeout", elapsed)
+	}
 }

--- a/gateway/testimpl/txfence.go
+++ b/gateway/testimpl/txfence.go
@@ -1,0 +1,103 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+
+WARNING: This package contains test-only/unsafe RPC implementations.
+DO NOT use in production environments.
+*/
+
+package testimpl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TxPool is the gateway's view of what it still owes a block, so a rewind can
+// drain the real queue instead of a count kept alongside it.
+type TxPool interface {
+	// InFlight returns how many transactions are queued or being processed.
+	InFlight() int
+}
+
+// txFence keeps evm_snapshot/evm_revert from moving the ledger out from under
+// transactions the test RPC has accepted but not yet seen committed.
+//
+// It guards the submit path only up to the enqueue, not all the way to the
+// commit. Once a rewind sets rewinding, nothing further can reach the queue, so
+// draining the queue drains everything that could still land - and a transaction
+// that never commits delays nobody, because the fence is long since released.
+//
+// The zero value needs a TxPool. Test-only: the production gateway has no revert
+// and must never wait for the queue to drain on the submit path.
+type txFence struct {
+	mu        sync.Mutex
+	rewinding bool
+	pool      TxPool
+}
+
+// errFenced rejects a submission arriving mid-rewind. Queueing it would admit it
+// the instant the rewind finished, applying a transaction built against the old
+// state to the new one.
+var errFenced = errors.New("transaction rejected: a snapshot or revert is in progress")
+
+// errDrainTimeout fails a rewind whose queued transactions never commit.
+var errDrainTimeout = errors.New("timed out waiting for in-flight transactions to commit")
+
+const (
+	// drainTimeout bounds the wait, under Hardhat's 60s request timeout and Mocha's
+	// 40s test timeout so the error surfaces instead of a hook timeout.
+	drainTimeout = 30 * time.Second
+	// drainPollInterval paces it; InFlight is a couple of map reads under a lock.
+	drainPollInterval = time.Millisecond
+)
+
+// submit runs enqueue under the fence, so a rewind either sees the transaction in
+// the queue afterwards or turns it away. enqueue must return once the gateway has
+// taken the transaction, and must not wait for it to commit.
+func (f *txFence) submit(enqueue func() (common.Hash, error)) (common.Hash, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.rewinding {
+		return common.Hash{}, errFenced
+	}
+	return enqueue()
+}
+
+// beginRewind locks out new submissions, then waits for the queue to drain. Pair a
+// nil return with endRewind; callers must serialise their own rewinds.
+func (f *txFence) beginRewind(ctx context.Context) error {
+	f.mu.Lock()
+	f.rewinding = true
+	f.mu.Unlock()
+
+	deadline := time.NewTimer(drainTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(drainPollInterval)
+	defer poll.Stop()
+
+	for f.pool.InFlight() > 0 {
+		select {
+		case <-ctx.Done():
+			f.endRewind()
+			return ctx.Err()
+		case <-deadline.C:
+			f.endRewind()
+			return errDrainTimeout
+		case <-poll.C:
+		}
+	}
+	return nil
+}
+
+// endRewind reopens the fence to submissions.
+func (f *txFence) endRewind() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rewinding = false
+}

--- a/gateway/testimpl/txfence_test.go
+++ b/gateway/testimpl/txfence_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// fakePool stands in for the gateway's transaction queue.
+type fakePool struct{ inFlight atomic.Int64 }
+
+func (p *fakePool) InFlight() int { return int(p.inFlight.Load()) }
+func (p *fakePool) enqueue()      { p.inFlight.Add(1) }
+func (p *fakePool) commit()       { p.inFlight.Add(-1) }
+func newFencedPool() (*txFence, *fakePool) {
+	pool := &fakePool{}
+	return &txFence{pool: pool}, pool
+}
+
+// enqueueOK is a submission that reaches the queue.
+func enqueueOK(pool *fakePool) func() (common.Hash, error) {
+	return func() (common.Hash, error) {
+		pool.enqueue()
+		return common.Hash{0x1}, nil
+	}
+}
+
+// A rewind must not rewind the ledger while a transaction it admitted is still
+// waiting for a block - the invariant the fence exists for.
+func TestTxFence_RewindWaitsForQueueToDrain(t *testing.T) {
+	fence, pool := newFencedPool()
+
+	if _, err := fence.submit(enqueueOK(pool)); err != nil {
+		t.Fatalf("submit on an idle fence: %v", err)
+	}
+
+	rewinding := make(chan error, 1)
+	go func() { rewinding <- fence.beginRewind(context.Background()) }()
+
+	select {
+	case <-rewinding:
+		t.Fatal("rewind proceeded with a transaction still queued")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	pool.commit()
+	select {
+	case err := <-rewinding:
+		if err != nil {
+			t.Fatalf("beginRewind: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rewind did not proceed after the queue drained")
+	}
+}
+
+// The reject window: once a rewind is under way, a submission built against the
+// pre-rewind state must be turned away, never queued to run after it.
+func TestTxFence_RejectsWhileRewinding(t *testing.T) {
+	fence, pool := newFencedPool()
+
+	if err := fence.beginRewind(context.Background()); err != nil {
+		t.Fatalf("beginRewind on an idle fence: %v", err)
+	}
+	if _, err := fence.submit(enqueueOK(pool)); !errors.Is(err, errFenced) {
+		t.Fatalf("submit during a rewind = %v, want errFenced", err)
+	}
+	if got := pool.InFlight(); got != 0 {
+		t.Fatalf("rejected submission still reached the queue (InFlight=%d)", got)
+	}
+
+	fence.endRewind()
+	if _, err := fence.submit(enqueueOK(pool)); err != nil {
+		t.Fatalf("submit after the rewind finished: %v", err)
+	}
+}
+
+// A queue that never drains must not pin the fence; the rewind returns on
+// whichever bound fires first and reopens the fence on its way out.
+func TestTxFence_BeginRewindTimesOutOnStuckQueue(t *testing.T) {
+	fence, pool := newFencedPool()
+	if _, err := fence.submit(enqueueOK(pool)); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// drainTimeout is 30s, so the context bound is the one that fires here.
+	if err := fence.beginRewind(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("beginRewind = %v, want the context bound to fire", err)
+	}
+
+	// A failed rewind must not leave the fence closed for everyone else.
+	if _, err := fence.submit(enqueueOK(pool)); err != nil {
+		t.Fatalf("submit after a failed rewind: %v", err)
+	}
+}
+
+// The fence covers the enqueue, so a rewind either sees a transaction in the
+// queue or rejects it; it can never slip past into the post-rewind state.
+func TestTxFence_RewindNeverRacesAnEnqueue(t *testing.T) {
+	fence, pool := newFencedPool()
+
+	// Block inside the enqueue, so the rewind arrives mid-submission.
+	enqueueStarted := make(chan struct{})
+	releaseEnqueue := make(chan struct{})
+	submitted := make(chan error, 1)
+	go func() {
+		_, err := fence.submit(func() (common.Hash, error) {
+			close(enqueueStarted)
+			<-releaseEnqueue
+			pool.enqueue()
+			return common.Hash{0x1}, nil
+		})
+		submitted <- err
+	}()
+	<-enqueueStarted
+
+	rewinding := make(chan error, 1)
+	go func() { rewinding <- fence.beginRewind(context.Background()) }()
+
+	// The rewind cannot even start while the enqueue holds the fence.
+	select {
+	case <-rewinding:
+		t.Fatal("rewind started while an enqueue was in progress")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseEnqueue)
+	if err := <-submitted; err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	// It is now in the queue, so the rewind must wait for it rather than miss it.
+	select {
+	case <-rewinding:
+		t.Fatal("rewind proceeded without draining the transaction it raced")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	pool.commit()
+	select {
+	case err := <-rewinding:
+		if err != nil {
+			t.Fatalf("beginRewind: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rewind did not proceed after the queue drained")
+	}
+}


### PR DESCRIPTION
Sorry for the churn; apparently there was still an intermittent race because we were rejecting too strictly. This change uses shorter locks and reads state from the existing queue, so we can be smarter about what we reject and what we let in.

- fence the submit path up to the enqueue rather than the commit: a rewind now either sees a transaction in the queue or turns it away, and one that never commits no longer stalls every later rewind
- drain the gateway's own queue via a new TxQueueInterface.InFlight, instead of a count kept alongside it in the test RPC
- still reject only while a rewind is actually running; queueing there would apply a transaction built against the old state to the new one
- bound the drain and commit waits, and error instead of panicking when a transaction is dropped before it commits

Fixes some of the intermittent "before each" hook failures in the OpenZeppelin tests.