### PR TITLE
test: add go-test-json baseline support for execution-specs suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,12 +202,11 @@ jobs:
   eth-tests:
     name: Ethereum Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: quick-tests
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'want-integration-tests'))
+    # A cache hit finishes in ~3-4 minutes (just the test run), but a cache
+    # miss (first run, or a fixture version bump) pays for the ~400 MB
+    # download + extracting it into ~8 GB of small files too -- can take more
+    # than 15 minutes.
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -220,5 +219,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Cache execution-specs fixtures
+        uses: actions/cache@v4
+        with:
+          path: testdata/execution-specs-tests
+          key: ${{ runner.os }}-execution-specs-tests-${{ hashFiles('scripts/fetch_execution_specs_tests.sh') }}
+
       - name: Ethereum tests
         run: make eth-tests
+
+      - name: Ethereum tests baseline check (gate)
+        run: go run ./cmd/baseline check --suite eth-tests

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ testdata/*
 !testdata/eth_tests.skip
 !testdata/eth_tests.slow
 !testdata/oz_known_failures.json
+!testdata/eth_known_failures.json
 !testdata/shared_config.yaml
 *.un~
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ fetch-execution-specs-tests:
 
 .PHONY: eth-tests
 eth-tests: fetch-execution-specs-tests
-	@go test -test.fullpath=true -timeout 2000s -run '^(TestEthereumTests|TestTransactionTests)$$' github.com/hyperledger/fabric-x-evm/integration
+	@./scripts/run_eth_tests.sh
 
 # Single-file smoke test — CI runs hardhat-tests-full (below) instead.
 .PHONY: hardhat-tests

--- a/cmd/baseline/README.md
+++ b/cmd/baseline/README.md
@@ -10,19 +10,25 @@ enough to run on every PR, but not every test in it passes today, and some never
 design choices. Without a record of which specific tests are expected to fail, a CI gate on the full
 suite either stays permanently red or has no teeth at all.
 
-We're already skipping known-failing tests via hardcoded lists `testdata/eth_tests.skip`/`.slow`,
-with flat file-path lists checked directly in
-[`integration/ethereum_test.go`](../../integration/ethereum_test.go) - inspired by `go-ethereum`.
-`cmd/baseline` generalizes that same idiom to per-test granularity (not whole files) with an actual
-diff: new unlisted failure → regression; listed test that now passes → stale entry, remove it —
-instead of a list someone has to remember to prune by hand. It makes the approach consistent and
-measurable.
+Similarly, we capture known-failing tests for the ethereum test suite. That means we get clear
+diffs: new unlisted failure → regression; listed test that now passes → stale entry, remove it —
+It makes the approach consistent and measurable.
 
-**Currently wired up for OpenZeppelin only** — gates every PR via the `oz-hardhat-compat` job in
-[`tests.yml`](../../.github/workflows/tests.yml). The `--format` flag exists so a `go test -json`
-adapter can be added later for `TestEthereumTests`, replacing `eth_tests.skip`/`.slow` with the same
-mechanism at per-subtest granularity — not built yet, but the reason the result model and CLI are
-format-agnostic rather than Mocha-specific.
+Two suites are wired up today, one per `--format`:
+
+- **`oz-hardhat`** (`--format mocha-json`) — gates every PR via the `oz-hardhat-compat` job in
+  [`tests.yml`](../../.github/workflows/tests.yml).
+- **`eth-tests`** (`--format go-test-json`) — the execution-spec-tests conformance suite
+  (`TestEthereumTests`, run via `make eth-tests` / [`run_eth_tests.sh`](../../scripts/run_eth_tests.sh)),
+  gated by the `eth-tests` job in [`tests.yml`](../../.github/workflows/tests.yml), at per-subtest
+  granularity (`fork/index`) — a bug's blast radius is visible instead of a whole file being silently
+  excluded. Two other lists remain for what the baseline can't cover: `testdata/eth_tests.skip` for
+  failures that *panic* (an unrecovered panic crashes the whole `go test` process, unlike a normal
+  assertion failure, so it's excluded before it ever runs rather than tracked as a baseline entry), and
+  `testdata/eth_tests.slow` for tests excluded purely for *runtime cost*, not correctness.
+
+The result model and CLI stayed format-agnostic from the start specifically so a second adapter would
+be "write a parser," not "redesign the tool" — `go-test-json` is the proof.
 
 ## After bumping `testdata/openzeppelin-contracts`
 
@@ -48,7 +54,9 @@ One thing this tool *can't* see: whether the compatible-set **exclusions** thems
 
 ## Generate results
 
-Currently supports Mocha's JSON reporter (`--format mocha-json`, the default).
+Two formats are supported: `--format mocha-json` (the default) and `--format go-test-json`.
+
+### `mocha-json` (OpenZeppelin / Hardhat)
 
 ```shell
 cd testdata/openzeppelin-contracts
@@ -61,16 +69,29 @@ HARDHAT_JSON_OUTPUT=../oz-hardhat-results/erc20.json npx hardhat test test/token
 the usual pass/fail console view still prints live, and the JSON lands at the given path —
 one run gives both, instead of picking one or the other.
 
+### `go-test-json` (execution-spec-tests / any Go suite)
+
+`go test`'s own `-json` flag (implies `-v`) is the reporter — no wrapper needed:
+
+```shell
+go test -run ^TestEthereumTests$ -json ./integration | tee testdata/eth-tests-results/eth-tests.json
+```
+
+[`run_eth_tests.sh`](../../scripts/run_eth_tests.sh) (`make eth-tests`) does exactly this.
+`ParseGoTestJSON` (in `baseline.go`) reads the per-line event stream test2json produces: every
+`t.Run` subtest gets a hierarchical name (`TestEthereumTests/add11.json/Prague/0`), and only the
+leaves are reported as results — a parent's own pass/fail event just aggregates its children and
+would otherwise show up as a redundant extra entry.
+
 ## Check (the CI gate)
 
 ```shell
 go run ./cmd/baseline check --suite oz-hardhat
 ```
 
-A known `--suite` (currently just `oz-hardhat`) already implies `--baseline testdata/oz_known_failures.json`
-and `--results 'testdata/oz-hardhat-results/*.json'` — pass either flag explicitly to override, e.g.
-against a scratch baseline or a single results file (see the worked examples below, which do exactly
-that).
+A known `--suite` (`oz-hardhat` or `eth-tests`) already implies `--baseline`,
+`--results`, and `--format` — pass any of the three explicitly to override, e.g. against a scratch
+baseline or a single results file (see the worked examples below, which do exactly that).
 
 Prints a summary and exits non-zero if anything regressed:
 - a failure that isn't in the baseline (a real regression), or

--- a/cmd/baseline/baseline.go
+++ b/cmd/baseline/baseline.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -146,6 +147,117 @@ func ParseMochaJSON(data []byte) ([]Result, error) {
 		results = append(results, Result{ID: f.FullTitle, Status: StatusFail, Message: f.Err.Message, File: f.File})
 	}
 	return results, nil
+}
+
+// goTestEvent mirrors the fields we need from `go test -json`'s event stream
+// (Go's test2json format): one JSON object per line. Test is set for every
+// event scoped to a specific test (empty for package-level events, e.g. the
+// final build/pass/fail line for the whole package, which we ignore). Output
+// carries one verbatim line of that test's -v output; -json implies -v, so
+// this is present even though we never pass -v ourselves.
+type goTestEvent struct {
+	Action string `json:"Action"`
+	Test   string `json:"Test"`
+	Output string `json:"Output"`
+}
+
+// ParseGoTestJSON converts `go test -json` output into []Result — the Go
+// analogue of ParseMochaJSON, for suites like TestEthereumTests.
+//
+// go test reports a hierarchical name for every t.Run subtest (parent/child
+// joined by "/") and emits its own pass/fail/skip event for every level.
+// We skip the parents.
+func ParseGoTestJSON(data []byte) ([]Result, error) {
+	type testInfo struct {
+		status Status
+		output strings.Builder
+	}
+	infos := make(map[string]*testInfo)
+	var order []string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var ev goTestEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return nil, fmt.Errorf("parse go test json: %w", err)
+		}
+		if ev.Test == "" {
+			continue // package-level event, not a specific test
+		}
+
+		info, ok := infos[ev.Test]
+		if !ok {
+			info = &testInfo{}
+			infos[ev.Test] = info
+			order = append(order, ev.Test)
+		}
+		switch ev.Action {
+		case "output":
+			info.output.WriteString(ev.Output)
+		case "pass":
+			info.status = StatusPass
+		case "fail":
+			info.status = StatusFail
+		case "skip":
+			info.status = StatusSkip
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan go test json: %w", err)
+	}
+
+	// Mark every ancestor of every reported name as "has children" so the
+	// pass below can skip aggregating parent nodes and keep only leaves.
+	hasChildren := make(map[string]bool, len(order))
+	for _, name := range order {
+		for i := 0; i < len(name); i++ {
+			if name[i] == '/' {
+				hasChildren[name[:i]] = true
+			}
+		}
+	}
+
+	results := make([]Result, 0, len(order))
+	for _, name := range order {
+		if hasChildren[name] {
+			continue
+		}
+		info := infos[name]
+		r := Result{ID: name, Status: info.status}
+		switch {
+		case r.Status == "":
+			// No terminal action ever arrived — e.g. the binary crashed or was
+			// killed mid-run. Surface it as a failure rather than silently
+			// dropping it; an incomplete run must never look clean.
+			r.Status = StatusFail
+			r.Message = "test did not complete (no pass/fail/skip event — binary may have crashed)"
+		case r.Status == StatusFail:
+			r.Message = cleanGoTestOutput(info.output.String())
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// cleanGoTestOutput strips go test's own verbose-mode banner lines (=== RUN,
+// --- FAIL, etc.) from a test's captured output, leaving just the t.Error /
+// t.Fatal text — the Go analogue of Mocha's err.message.
+func cleanGoTestOutput(raw string) string {
+	lines := strings.Split(raw, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "=== ") || strings.HasPrefix(trimmed, "--- ") {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	return strings.Join(kept, "\n")
 }
 
 // LoadBaseline reads a baseline file. A missing file is an empty baseline, not an

--- a/cmd/baseline/baseline_test.go
+++ b/cmd/baseline/baseline_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -72,6 +73,115 @@ func TestParseMochaJSON_HookFailure(t *testing.T) {
 	}
 	if !reflect.DeepEqual(results, want) {
 		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func mustParseGoTest(t *testing.T, path string) []Result {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	results, err := ParseGoTestJSON(data)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return results
+}
+
+func TestParseGoTestJSON_AllPass(t *testing.T) {
+	results := mustParseGoTest(t, "testdata/gotest-allpass.json")
+	want := []Result{
+		{ID: "TestFoo", Status: StatusPass},
+		{ID: "TestBar", Status: StatusPass},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseGoTestJSON_AllFail(t *testing.T) {
+	results := mustParseGoTest(t, "testdata/gotest-allfail.json")
+	want := []Result{
+		{ID: "TestFoo", Status: StatusFail, Message: "foo_test.go:10: boom A"},
+		{ID: "TestBar", Status: StatusFail, Message: "bar_test.go:20: boom B"},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseGoTestJSON_Mixed(t *testing.T) {
+	results := mustParseGoTest(t, "testdata/gotest-mixed.json")
+	want := []Result{
+		{ID: "TestA", Status: StatusPass},
+		{ID: "TestB", Status: StatusFail, Message: "b_test.go:5: boom B"},
+		{ID: "TestC", Status: StatusSkip},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseGoTestJSON_NestedSubtestsOnlyLeavesReported(t *testing.T) {
+	// go test emits its own pass/fail event for every level of a t.Run tree,
+	// including the parent, which merely aggregates its children -- only the
+	// leaves are meaningful baseline entries.
+	results := mustParseGoTest(t, "testdata/gotest-nested.json")
+	want := []Result{
+		{ID: "TestParent/child_pass", Status: StatusPass},
+		{ID: "TestParent/child_fail", Status: StatusFail, Message: "nested_test.go:42: root mismatch"},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+func TestParseGoTestJSON_IncompleteTestTreatedAsFailure(t *testing.T) {
+	// No pass/fail/skip event ever arrived for this test (e.g. the binary
+	// panicked mid-run) -- must surface as a failure, not vanish silently.
+	results := mustParseGoTest(t, "testdata/gotest-incomplete.json")
+	want := []Result{
+		{ID: "TestCrashes", Status: StatusFail, Message: "test did not complete (no pass/fail/skip event — binary may have crashed)"},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("got %+v, want %+v", results, want)
+	}
+}
+
+// TestParseGoTestJSON_RealCapture replays an actual `go test -json` stream
+// (captured from a package with the same TestParent/child_pass, child_fail,
+// TestSkipped, TestCrashy shapes as the hand-written fixtures above, panic
+// trace trimmed of machine-specific paths) — confirms the hand-written
+// fixtures aren't just testing our own assumptions about test2json's shape.
+func TestParseGoTestJSON_RealCapture(t *testing.T) {
+	results := mustParseGoTest(t, "testdata/gotest-real-capture.json")
+
+	byID := make(map[string]Result, len(results))
+	for _, r := range results {
+		byID[r.ID] = r
+	}
+	if len(results) != 4 {
+		t.Fatalf("expected 4 leaf results (TestParent itself excluded), got %+v", results)
+	}
+
+	if r := byID["TestParent/child_pass"]; r.Status != StatusPass {
+		t.Errorf("child_pass = %+v", r)
+	}
+	if r := byID["TestParent/child_fail"]; r.Status != StatusFail || r.Message != "sample_test.go:11: root mismatch: got 0xabc want 0xdef" {
+		t.Errorf("child_fail = %+v", r)
+	}
+	if r := byID["TestSkipped"]; r.Status != StatusSkip {
+		t.Errorf("TestSkipped = %+v", r)
+	}
+	// TestCrashy's own "--- FAIL: TestCrashy" banner is printed *before* the
+	// panic trace output arrives, unlike a normal t.Errorf failure -- exercises
+	// that cleanGoTestOutput strips the banner wherever it falls, not just at
+	// the end.
+	if r := byID["TestCrashy"]; r.Status != StatusFail ||
+		!strings.Contains(r.Message, "panic: boom") ||
+		strings.Contains(r.Message, "--- FAIL") {
+		t.Errorf("TestCrashy = %+v", r)
 	}
 }
 

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -19,25 +19,33 @@ import (
 // parsers maps a --format value to the adapter that turns a runner's raw output
 // into []Result. Adding a runner later is "add one entry here."
 var parsers = map[string]func([]byte) ([]Result, error){
-	"mocha-json": ParseMochaJSON,
+	"mocha-json":   ParseMochaJSON,
+	"go-test-json": ParseGoTestJSON,
 }
 
-// suiteDefaults gives --baseline/--results a sensible default from --suite alone, so
-// the common case (CI, docs, day-to-day invocations) doesn't need to repeat both
-// paths every time. Explicit --baseline/--results always override; an unrecognized
-// --suite is still fine, it just doesn't unlock defaults (--suite is otherwise only
-// a report-header label).
+// suiteDefaults gives --baseline/--results/--format a sensible default from --suite
+// alone, so the common case (CI, docs, day-to-day invocations) doesn't need to
+// repeat all three every time. Explicit --baseline/--results/--format always
+// override; an unrecognized --suite is still fine, it just doesn't unlock
+// defaults (--suite is otherwise only a report-header label).
 var suiteDefaults = map[string]struct {
 	baselinePath string
 	resultsGlob  string
+	format       string
 }{
 	"oz-hardhat": {
 		baselinePath: "testdata/oz_known_failures.json",
 		resultsGlob:  "testdata/oz-hardhat-results/*.json",
+		format:       "mocha-json",
+	},
+	"eth-tests": {
+		baselinePath: "testdata/eth_known_failures.json",
+		resultsGlob:  "testdata/eth-tests-results/*.json",
+		format:       "go-test-json",
 	},
 }
 
-func applySuiteDefaults(suite string, baselinePath, resultsGlob *string) {
+func applySuiteDefaults(suite string, baselinePath, resultsGlob, format *string) {
 	d, ok := suiteDefaults[suite]
 	if !ok {
 		return
@@ -47,6 +55,9 @@ func applySuiteDefaults(suite string, baselinePath, resultsGlob *string) {
 	}
 	if *resultsGlob == "" {
 		*resultsGlob = d.resultsGlob
+	}
+	if *format == "" {
+		*format = d.format
 	}
 }
 
@@ -82,15 +93,18 @@ type commonFlags struct {
 func parseCommonFlags(name string, args []string) (*commonFlags, error) {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	f := &commonFlags{}
-	fs.StringVar(&f.suite, "suite", "", "suite name, for the report header; a known suite (e.g. oz-hardhat) also supplies --baseline/--results defaults")
-	fs.StringVar(&f.format, "format", "mocha-json", "raw results format (mocha-json)")
+	fs.StringVar(&f.suite, "suite", "", "suite name, for the report header; a known suite (e.g. oz-hardhat) also supplies --baseline/--results/--format defaults")
+	fs.StringVar(&f.format, "format", "", "raw results format (mocha-json, go-test-json); a known --suite supplies a default, otherwise mocha-json")
 	fs.StringVar(&f.baselinePath, "baseline", "", "path to the baseline JSON file (defaults from --suite if known)")
 	fs.StringVar(&f.resultsGlob, "results", "", "glob of raw results files to parse (defaults from --suite if known)")
 	fs.BoolVar(&f.jsonOutput, "json", false, "(check only) print a machine-readable Summary as JSON instead of the human-readable report")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
-	applySuiteDefaults(f.suite, &f.baselinePath, &f.resultsGlob)
+	applySuiteDefaults(f.suite, &f.baselinePath, &f.resultsGlob, &f.format)
+	if f.format == "" {
+		f.format = "mocha-json"
+	}
 	if f.baselinePath == "" {
 		return nil, fmt.Errorf("--baseline is required")
 	}
@@ -274,10 +288,10 @@ func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, 
 
 func runTag(args []string) int {
 	fs := flag.NewFlagSet("tag", flag.ContinueOnError)
-	suite := fs.String("suite", "", "suite name; a known suite (e.g. oz-hardhat) supplies --baseline/--results defaults")
+	suite := fs.String("suite", "", "suite name; a known suite (e.g. oz-hardhat) supplies --baseline/--results/--format defaults")
 	baselinePath := fs.String("baseline", "", "path to the baseline JSON file (defaults from --suite if known)")
 	resultsGlob := fs.String("results", "", "glob of raw results files to parse (defaults from --suite if known)")
-	format := fs.String("format", "mocha-json", "raw results format (mocha-json)")
+	format := fs.String("format", "", "raw results format (mocha-json, go-test-json); a known --suite supplies a default, otherwise mocha-json")
 	match := fs.String("match", "", "substring to match against each entry's ID or current failure message")
 	cause := fs.String("cause", "", "cause to assign to every matching entry")
 	note := fs.String("note", "", "optional note to assign alongside cause/flaky")
@@ -287,7 +301,10 @@ func runTag(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
-	applySuiteDefaults(*suite, baselinePath, resultsGlob)
+	applySuiteDefaults(*suite, baselinePath, resultsGlob, format)
+	if *format == "" {
+		*format = "mocha-json"
+	}
 	if *baselinePath == "" || *resultsGlob == "" || *match == "" || (*cause == "" && !*flaky) {
 		fmt.Fprintln(os.Stderr, "usage: baseline tag --suite <name> --match <substring> (--cause <name> | --flaky) [--baseline <path>] [--results <glob>] [--note <text>] [--force]")
 		return 2

--- a/cmd/baseline/main_test.go
+++ b/cmd/baseline/main_test.go
@@ -34,26 +34,34 @@ func writeMochaFixture(t *testing.T, dir, name, fullTitle, errMessage string) st
 }
 
 func TestApplySuiteDefaults(t *testing.T) {
-	baselinePath, resultsGlob := "", ""
-	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob)
-	if baselinePath != "testdata/oz_known_failures.json" || resultsGlob != "testdata/oz-hardhat-results/*.json" {
-		t.Fatalf("got baseline=%q results=%q", baselinePath, resultsGlob)
+	baselinePath, resultsGlob, format := "", "", ""
+	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob, &format)
+	if baselinePath != "testdata/oz_known_failures.json" || resultsGlob != "testdata/oz-hardhat-results/*.json" || format != "mocha-json" {
+		t.Fatalf("got baseline=%q results=%q format=%q", baselinePath, resultsGlob, format)
+	}
+}
+
+func TestApplySuiteDefaults_EthTests(t *testing.T) {
+	baselinePath, resultsGlob, format := "", "", ""
+	applySuiteDefaults("eth-tests", &baselinePath, &resultsGlob, &format)
+	if baselinePath != "testdata/eth_known_failures.json" || resultsGlob != "testdata/eth-tests-results/*.json" || format != "go-test-json" {
+		t.Fatalf("got baseline=%q results=%q format=%q", baselinePath, resultsGlob, format)
 	}
 }
 
 func TestApplySuiteDefaults_ExplicitValuesWin(t *testing.T) {
-	baselinePath, resultsGlob := "custom.json", "custom/*.json"
-	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob)
-	if baselinePath != "custom.json" || resultsGlob != "custom/*.json" {
-		t.Fatalf("explicit values should not be overridden, got baseline=%q results=%q", baselinePath, resultsGlob)
+	baselinePath, resultsGlob, format := "custom.json", "custom/*.json", "custom-format"
+	applySuiteDefaults("oz-hardhat", &baselinePath, &resultsGlob, &format)
+	if baselinePath != "custom.json" || resultsGlob != "custom/*.json" || format != "custom-format" {
+		t.Fatalf("explicit values should not be overridden, got baseline=%q results=%q format=%q", baselinePath, resultsGlob, format)
 	}
 }
 
 func TestApplySuiteDefaults_UnknownSuiteLeavesFlagsEmpty(t *testing.T) {
-	baselinePath, resultsGlob := "", ""
-	applySuiteDefaults("some-future-suite", &baselinePath, &resultsGlob)
-	if baselinePath != "" || resultsGlob != "" {
-		t.Fatalf("unrecognized suite should not set defaults, got baseline=%q results=%q", baselinePath, resultsGlob)
+	baselinePath, resultsGlob, format := "", "", ""
+	applySuiteDefaults("some-future-suite", &baselinePath, &resultsGlob, &format)
+	if baselinePath != "" || resultsGlob != "" || format != "" {
+		t.Fatalf("unrecognized suite should not set defaults, got baseline=%q results=%q format=%q", baselinePath, resultsGlob, format)
 	}
 }
 

--- a/cmd/baseline/testdata/gotest-allfail.json
+++ b/cmd/baseline/testdata/gotest-allfail.json
@@ -1,0 +1,10 @@
+{"Action":"run","Test":"TestFoo"}
+{"Action":"output","Test":"TestFoo","Output":"=== RUN   TestFoo\n"}
+{"Action":"output","Test":"TestFoo","Output":"    foo_test.go:10: boom A\n"}
+{"Action":"output","Test":"TestFoo","Output":"--- FAIL: TestFoo (0.00s)\n"}
+{"Action":"fail","Test":"TestFoo","Elapsed":0}
+{"Action":"run","Test":"TestBar"}
+{"Action":"output","Test":"TestBar","Output":"=== RUN   TestBar\n"}
+{"Action":"output","Test":"TestBar","Output":"    bar_test.go:20: boom B\n"}
+{"Action":"output","Test":"TestBar","Output":"--- FAIL: TestBar (0.00s)\n"}
+{"Action":"fail","Test":"TestBar","Elapsed":0}

--- a/cmd/baseline/testdata/gotest-allpass.json
+++ b/cmd/baseline/testdata/gotest-allpass.json
@@ -1,0 +1,8 @@
+{"Action":"run","Test":"TestFoo"}
+{"Action":"output","Test":"TestFoo","Output":"=== RUN   TestFoo\n"}
+{"Action":"output","Test":"TestFoo","Output":"--- PASS: TestFoo (0.00s)\n"}
+{"Action":"pass","Test":"TestFoo","Elapsed":0}
+{"Action":"run","Test":"TestBar"}
+{"Action":"output","Test":"TestBar","Output":"=== RUN   TestBar\n"}
+{"Action":"output","Test":"TestBar","Output":"--- PASS: TestBar (0.00s)\n"}
+{"Action":"pass","Test":"TestBar","Elapsed":0}

--- a/cmd/baseline/testdata/gotest-incomplete.json
+++ b/cmd/baseline/testdata/gotest-incomplete.json
@@ -1,0 +1,3 @@
+{"Action":"run","Test":"TestCrashes"}
+{"Action":"output","Test":"TestCrashes","Output":"=== RUN   TestCrashes\n"}
+{"Action":"output","Test":"TestCrashes","Output":"panic: runtime error: index out of range\n"}

--- a/cmd/baseline/testdata/gotest-mixed.json
+++ b/cmd/baseline/testdata/gotest-mixed.json
@@ -1,0 +1,13 @@
+{"Action":"run","Test":"TestA"}
+{"Action":"output","Test":"TestA","Output":"=== RUN   TestA\n"}
+{"Action":"output","Test":"TestA","Output":"--- PASS: TestA (0.00s)\n"}
+{"Action":"pass","Test":"TestA","Elapsed":0}
+{"Action":"run","Test":"TestB"}
+{"Action":"output","Test":"TestB","Output":"=== RUN   TestB\n"}
+{"Action":"output","Test":"TestB","Output":"    b_test.go:5: boom B\n"}
+{"Action":"output","Test":"TestB","Output":"--- FAIL: TestB (0.00s)\n"}
+{"Action":"fail","Test":"TestB","Elapsed":0}
+{"Action":"run","Test":"TestC"}
+{"Action":"output","Test":"TestC","Output":"=== RUN   TestC\n"}
+{"Action":"output","Test":"TestC","Output":"--- SKIP: TestC (0.00s)\n"}
+{"Action":"skip","Test":"TestC","Elapsed":0}

--- a/cmd/baseline/testdata/gotest-nested.json
+++ b/cmd/baseline/testdata/gotest-nested.json
@@ -1,0 +1,13 @@
+{"Action":"run","Test":"TestParent"}
+{"Action":"output","Test":"TestParent","Output":"=== RUN   TestParent\n"}
+{"Action":"run","Test":"TestParent/child_pass"}
+{"Action":"output","Test":"TestParent/child_pass","Output":"=== RUN   TestParent/child_pass\n"}
+{"Action":"output","Test":"TestParent/child_pass","Output":"--- PASS: TestParent/child_pass (0.00s)\n"}
+{"Action":"pass","Test":"TestParent/child_pass","Elapsed":0}
+{"Action":"run","Test":"TestParent/child_fail"}
+{"Action":"output","Test":"TestParent/child_fail","Output":"=== RUN   TestParent/child_fail\n"}
+{"Action":"output","Test":"TestParent/child_fail","Output":"    nested_test.go:42: root mismatch\n"}
+{"Action":"output","Test":"TestParent/child_fail","Output":"--- FAIL: TestParent/child_fail (0.00s)\n"}
+{"Action":"fail","Test":"TestParent/child_fail","Elapsed":0}
+{"Action":"output","Test":"TestParent","Output":"--- FAIL: TestParent (0.00s)\n"}
+{"Action":"fail","Test":"TestParent","Elapsed":0}

--- a/cmd/baseline/testdata/gotest-real-capture.json
+++ b/cmd/baseline/testdata/gotest-real-capture.json
@@ -1,0 +1,38 @@
+{"Time":"2026-07-23T15:10:02.656774+02:00","Action":"start","Package":"sample"}
+{"Time":"2026-07-23T15:10:03.389823+02:00","Action":"run","Package":"sample","Test":"TestParent"}
+{"Time":"2026-07-23T15:10:03.389899+02:00","Action":"output","Package":"sample","Test":"TestParent","Output":"=== RUN   TestParent\n"}
+{"Time":"2026-07-23T15:10:03.389925+02:00","Action":"run","Package":"sample","Test":"TestParent/child_pass"}
+{"Time":"2026-07-23T15:10:03.389931+02:00","Action":"output","Package":"sample","Test":"TestParent/child_pass","Output":"=== RUN   TestParent/child_pass\n"}
+{"Time":"2026-07-23T15:10:03.389942+02:00","Action":"output","Package":"sample","Test":"TestParent/child_pass","Output":"=== PAUSE TestParent/child_pass\n"}
+{"Time":"2026-07-23T15:10:03.389947+02:00","Action":"pause","Package":"sample","Test":"TestParent/child_pass"}
+{"Time":"2026-07-23T15:10:03.389951+02:00","Action":"run","Package":"sample","Test":"TestParent/child_fail"}
+{"Time":"2026-07-23T15:10:03.389955+02:00","Action":"output","Package":"sample","Test":"TestParent/child_fail","Output":"=== RUN   TestParent/child_fail\n"}
+{"Time":"2026-07-23T15:10:03.38996+02:00","Action":"output","Package":"sample","Test":"TestParent/child_fail","Output":"=== PAUSE TestParent/child_fail\n"}
+{"Time":"2026-07-23T15:10:03.389967+02:00","Action":"pause","Package":"sample","Test":"TestParent/child_fail"}
+{"Time":"2026-07-23T15:10:03.389978+02:00","Action":"cont","Package":"sample","Test":"TestParent/child_pass"}
+{"Time":"2026-07-23T15:10:03.389988+02:00","Action":"output","Package":"sample","Test":"TestParent/child_pass","Output":"=== CONT  TestParent/child_pass\n"}
+{"Time":"2026-07-23T15:10:03.39+02:00","Action":"output","Package":"sample","Test":"TestParent/child_pass","Output":"--- PASS: TestParent/child_pass (0.00s)\n"}
+{"Time":"2026-07-23T15:10:03.390022+02:00","Action":"pass","Package":"sample","Test":"TestParent/child_pass","Elapsed":0}
+{"Time":"2026-07-23T15:10:03.390034+02:00","Action":"cont","Package":"sample","Test":"TestParent/child_fail"}
+{"Time":"2026-07-23T15:10:03.390043+02:00","Action":"output","Package":"sample","Test":"TestParent/child_fail","Output":"=== CONT  TestParent/child_fail\n"}
+{"Time":"2026-07-23T15:10:03.390053+02:00","Action":"output","Package":"sample","Test":"TestParent/child_fail","Output":"    sample_test.go:11: root mismatch: got 0xabc want 0xdef\n"}
+{"Time":"2026-07-23T15:10:03.390077+02:00","Action":"output","Package":"sample","Test":"TestParent/child_fail","Output":"--- FAIL: TestParent/child_fail (0.00s)\n"}
+{"Time":"2026-07-23T15:10:03.390096+02:00","Action":"fail","Package":"sample","Test":"TestParent/child_fail","Elapsed":0}
+{"Time":"2026-07-23T15:10:03.390106+02:00","Action":"output","Package":"sample","Test":"TestParent","Output":"--- FAIL: TestParent (0.00s)\n"}
+{"Time":"2026-07-23T15:10:03.390116+02:00","Action":"fail","Package":"sample","Test":"TestParent","Elapsed":0}
+{"Time":"2026-07-23T15:10:03.390126+02:00","Action":"run","Package":"sample","Test":"TestSkipped"}
+{"Time":"2026-07-23T15:10:03.390136+02:00","Action":"output","Package":"sample","Test":"TestSkipped","Output":"=== RUN   TestSkipped\n"}
+{"Time":"2026-07-23T15:10:03.390146+02:00","Action":"output","Package":"sample","Test":"TestSkipped","Output":"    sample_test.go:16: not applicable\n"}
+{"Time":"2026-07-23T15:10:03.390156+02:00","Action":"output","Package":"sample","Test":"TestSkipped","Output":"--- SKIP: TestSkipped (0.00s)\n"}
+{"Time":"2026-07-23T15:10:03.390174+02:00","Action":"skip","Package":"sample","Test":"TestSkipped","Elapsed":0}
+{"Time":"2026-07-23T15:10:03.390184+02:00","Action":"run","Package":"sample","Test":"TestCrashy"}
+{"Time":"2026-07-23T15:10:03.390193+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"=== RUN   TestCrashy\n"}
+{"Time":"2026-07-23T15:10:03.390204+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"--- FAIL: TestCrashy (0.00s)\n"}
+{"Time":"2026-07-23T15:10:03.392463+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"panic: boom [recovered, repanicked]\n"}
+{"Time":"2026-07-23T15:10:03.392485+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"\n"}
+{"Time":"2026-07-23T15:10:03.392544+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"goroutine 10 [running]:\n"}
+{"Time":"2026-07-23T15:10:03.392568+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"sample.TestCrashy(...)\n"}
+{"Time":"2026-07-23T15:10:03.39263+02:00","Action":"output","Package":"sample","Test":"TestCrashy","Output":"\t/repo/sample_test.go:20 +0x2c\n"}
+{"Time":"2026-07-23T15:10:03.39372+02:00","Action":"fail","Package":"sample","Test":"TestCrashy","Elapsed":0}
+{"Time":"2026-07-23T15:10:03.393751+02:00","Action":"output","Package":"sample","Output":"FAIL\tsample\t0.736s\n"}
+{"Time":"2026-07-23T15:10:03.393768+02:00","Action":"fail","Package":"sample","Elapsed":0.737}

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -293,7 +293,7 @@ type blockingEndorser struct {
 	release <-chan struct{}
 }
 
-func (b *blockingEndorser) Execute(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction) (*peer.ProposalResponse, error) {
+func (b *blockingEndorser) Execute(ctx context.Context, inv endorsement.Invocation, ethTx *types.Transaction, _ time.Time) (*peer.ProposalResponse, error) {
 	select {
 	case <-b.release:
 		return b.execResp, b.execErr

--- a/scripts/fetch_execution_specs_tests.sh
+++ b/scripts/fetch_execution_specs_tests.sh
@@ -18,6 +18,10 @@ SHA256="3586193db06d4d5745d5e90b3c3008c2255a4e19ccd8f11a3ce887aec8c0b17c"
 DEST_DIR="${PROJECT_ROOT}/testdata/execution-specs-tests"
 TARBALL="${DEST_DIR}/fixtures.tar.gz"
 FIXTURES_DIR="${DEST_DIR}/fixtures"
+# Records which tarball's checksum the current FIXTURES_DIR was extracted
+# from, so a re-run can skip the (slow, ~400 MB) extraction step the same way
+# the download step is already skipped once the tarball is present and verified.
+EXTRACTED_STAMP="${DEST_DIR}/.fixtures-extracted.sha256"
 
 # sha256 helper: sha256sum on Linux/CI, shasum on macOS.
 sha256_of() {
@@ -60,8 +64,16 @@ else
   fi
 fi
 
-echo "==> Extracting into ${DEST_DIR}/ ..."
-rm -rf "${FIXTURES_DIR}"
-tar -xzf "${TARBALL}" -C "${DEST_DIR}"
+# Same idiom as the download above: matching stamp -> idempotent skip;
+# missing/stale stamp (version bump, interrupted prior extraction, etc.) ->
+# re-extract and rewrite it.
+if [ -f "${EXTRACTED_STAMP}" ] && [ "$(cat "${EXTRACTED_STAMP}")" = "${SHA256}" ]; then
+  echo "==> fixtures already extracted; skipping"
+else
+  echo "==> Extracting into ${DEST_DIR}/ ..."
+  rm -rf "${FIXTURES_DIR}"
+  tar -xzf "${TARBALL}" -C "${DEST_DIR}"
+  echo "${SHA256}" > "${EXTRACTED_STAMP}"
+fi
 
 echo "==> Done. Fixtures at: ${FIXTURES_DIR}"

--- a/scripts/run_eth_tests.sh
+++ b/scripts/run_eth_tests.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RESULTS_DIR="${PROJECT_ROOT}/testdata/eth-tests-results"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+main() {
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}Ethereum Conformance Tests${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    cd "${PROJECT_ROOT}"
+
+    if [ ! -d "testdata/execution-specs-tests/fixtures" ]; then
+        echo -e "${RED}Error: execution-specs fixtures not found${NC}"
+        echo "Run: make fetch-execution-specs-tests"
+        exit 1
+    fi
+
+    mkdir -p "${RESULTS_DIR}"
+
+    echo -e "${YELLOW}Running TestEthereumTests...${NC}"
+    # -json implies -v; each line is a self-contained event, so unlike the
+    # Hardhat suite (many independent file loads, split per-directory so one
+    # crash doesn't zero out the rest) this is one test binary and one
+    # invocation is enough — a mid-run crash still leaves everything up to
+    # that point parseable by cmd/baseline.
+    if go test -test.fullpath=true -timeout 2000s -run ^TestEthereumTests$ -json \
+        github.com/hyperledger/fabric-x-evm/integration > "${RESULTS_DIR}/eth-tests.json"; then
+        echo -e "${GREEN}TestEthereumTests: all passed${NC}"
+    else
+        echo -e "${YELLOW}TestEthereumTests: has failures (expected — see ${RESULTS_DIR}/eth-tests.json)${NC}"
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Running TestTransactionTests...${NC}"
+    # Separate invocation/file, same reasoning as above — the eth-tests suite's
+    # results glob (testdata/eth-tests-results/*.json) picks both up as one suite.
+    if go test -test.fullpath=true -timeout 2000s -run ^TestTransactionTests$ -json \
+        github.com/hyperledger/fabric-x-evm/integration > "${RESULTS_DIR}/transaction-tests.json"; then
+        echo -e "${GREEN}TestTransactionTests: all passed${NC}"
+    else
+        echo -e "${YELLOW}TestTransactionTests: has failures (expected — see ${RESULTS_DIR}/transaction-tests.json)${NC}"
+    fi
+
+    echo ""
+    echo -e "${GREEN}Results written to ${RESULTS_DIR}/${NC}"
+    echo ""
+
+    # Report only — this script's own exit status stays tied to whether the
+    # suite ran at all, not the baseline diff. Regressions failing the build
+    # is what a CI gate is for; a local, exploratory run shouldn't error out
+    # just because a known failure is still known to fail. Same idiom as
+    # run_hardhat_test.sh's --full.
+    go run ./cmd/baseline check --suite eth-tests || true
+}
+
+main

--- a/testdata/eth_known_failures.json
+++ b/testdata/eth_known_failures.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "TestEthereumTests/collision_with_create2_revert_in_initcode.json#01/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Osaka-state_test]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/collision_with_create2_revert_in_initcode.json#03/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Prague-state_test]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/collision_with_create2_revert_in_initcode.json/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Cancun-state_test]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#01/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Osaka-state_test-empty-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#01/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Osaka-state_test-initcode-with-deploy]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#01/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Osaka-state_test-sstore-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#03/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Prague-state_test-empty-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#03/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Prague-state_test-initcode-with-deploy]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json#03/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Prague-state_test-sstore-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Cancun-state_test-empty-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Cancun-state_test-initcode-with-deploy]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/create2_collision_storage.json/tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Cancun-state_test-sstore-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Cancun-state_test-opcode_CREATE-non-empty-balance-correct-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Cancun-state_test-opcode_CREATE2-non-empty-balance-correct-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Osaka-state_test-opcode_CREATE-non-empty-balance-correct-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Osaka-state_test-opcode_CREATE2-non-empty-balance-correct-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Prague-state_test-opcode_CREATE-non-empty-balance-correct-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_opcode.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Prague-state_test-opcode_CREATE2-non-empty-balance-correct-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_0-state_test-non-empty-balance-correct-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_0-state_test-non-empty-balance-revert-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_1-state_test-non-empty-balance-correct-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_1-state_test-non-empty-balance-revert-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_2-state_test-non-empty-balance-correct-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#02/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Cancun-tx_type_2-state_test-non-empty-balance-revert-initcode]/Cancun/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_0-state_test-non-empty-balance-correct-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_0-state_test-non-empty-balance-revert-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_1-state_test-non-empty-balance-correct-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_1-state_test-non-empty-balance-revert-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_2-state_test-non-empty-balance-correct-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#08/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Osaka-tx_type_2-state_test-non-empty-balance-revert-initcode]/Osaka/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_0-state_test-non-empty-balance-correct-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_0-state_test-non-empty-balance-revert-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_1-state_test-non-empty-balance-correct-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_1-state_test-non-empty-balance-revert-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_2-state_test-non-empty-balance-correct-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  },
+  {
+    "id": "TestEthereumTests/init_collision_create_tx.json#10/tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_2-state_test-non-empty-balance-revert-initcode]/Prague/0",
+    "cause": "eip7610-create-collision",
+    "note": "CREATE/CREATE2 into an account that already has storage/code produces a wrong post-state root; known StateDB gap (cf. #193)"
+  }
+]

--- a/testdata/eth_tests.skip
+++ b/testdata/eth_tests.skip
@@ -1,23 +1,21 @@
-# execution-specs state_tests that are skipped in ALL modes, quarantined here so the
-# conformance suite stays green in CI.
+# execution-specs state_tests that are skipped in ALL modes.
 #
-# --- EIP-7610 create-collision divergence (Cancun+), inherited from go-ethereum:
-#     CREATE/CREATE2 onto an address that already holds storage should fail per EIP-7610,
-#     but go-ethereum v1.17.3 implements the check as a hardcoded 28-address mainnet
-#     allowlist (guard = nonce + code + that static set, never the storage root), not a
-#     general storage check. These fixtures use synthetic addresses that hold storage but
-#     are not in geth's list, so geth's guard — and therefore ours, since we run geth's EVM
-#     create path unchanged — does not treat them as collisions. Not a fabric-x-evm bug and
-#     unrelated to the GetStorageRoot stub; affects any geth-based client.
-../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/create2_collision_storage.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/initcollision/init_collision_create_opcode.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
+# Unlike the compat-only skip idiom elsewhere, every entry here is skip-listed
+# because it PANICS, not because it merely fails an assertion — a panic that
+# escapes a subtest's own goroutine crashes the whole go test process (see
+# testing.tRunner's recover-then-repanic), taking every other in-flight and
+# not-yet-run test down with it. That's categorically unsafe for
+# testdata/eth_known_failures.json to track (a baseline entry assumes the
+# suite can still report the rest of the run cleanly), so these stay
+# hard-excluded until the underlying bug is fixed. Plain assertion failures
+# (wrong post-state root, etc.) belong in the baseline instead, not here.
+#
+# --- nil-pointer panic in DualStateDB.Snapshot (go-ethereum StateDB.Snapshot
+#     on a nil object) for a CREATE tx from a non-existent sender. Confirmed via
+#     a real run: crashes the entire TestEthereumTests binary, losing ~30k
+#     other subtests' results as collateral damage (goroutine dump:
+#     endorser/execution/dual_statedb.go:373 -> executor.go:428 ->
+#     integration/ethereum_test.go:317).
+../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
+../testdata/execution-specs-tests/fixtures/state_tests/for_prague/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json


### PR DESCRIPTION
Adds a go test -json parser to cmd/baseline (ParseGoTestJSON) and wires up a new eth-tests-execution-specs suite, mirroring the existing OZ Hardhat mocha-json baseline: known failures tracked per-subtest in testdata/eth_known_failures.json instead of a whole-file skip list.

Trims testdata/execution_specs_tests.skip down to only the one file that panics (confirmed via a real run: an unrecovered panic crashes the whole go test process, unsafe for the per-subtest baseline model to represent) -- the other 9 known-bad files now run and their failures are tracked in the baseline instead.

Wires testdata/execution-specs-tests fixture caching, a real (non-suppressed) baseline-check gate, and per-PR execution into the execution-specs-tests CI job.