### PR TITLE
fix: register evm_setAutomine stub in the test RPC

### DIFF
--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -223,6 +223,13 @@ func (api *EvmAPI) Mine(ctx context.Context) (string, error) {
 	return "0x0", nil
 }
 
+// SetAutomine accepts evm_setAutomine for RPC compatibility with Hardhat tests.
+// It does not change mining mode: block production is driven by Fabric consensus.
+func (api *EvmAPI) SetAutomine(ctx context.Context, enabled bool) error {
+	hardhatLogger.Debugf("EvmAPI.SetAutomine() called enabled=%v (stub; no state change)", enabled)
+	return nil
+}
+
 // IncreaseTime increases the timestamp of the next block (evm_increaseTime).
 // This is a stub that returns the time increase amount.
 func (api *EvmAPI) IncreaseTime(ctx context.Context, seconds hexutil.Uint64) (hexutil.Uint64, error) {

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -8,6 +8,7 @@ package testimpl
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -23,6 +24,17 @@ func dialHardhat(t *testing.T) *rpc.Client {
 	srv := rpc.NewServer()
 	if err := srv.RegisterName("hardhat", NewHardhatAPI()); err != nil {
 		t.Fatalf("RegisterName hardhat: %v", err)
+	}
+	client := rpc.DialInProc(srv)
+	t.Cleanup(client.Close)
+	return client
+}
+
+func dialEvm(t *testing.T) *rpc.Client {
+	t.Helper()
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("evm", NewEvmAPI(&mockRevertibleKVS{}, &mockRevertibleStore{}, &txFence{})); err != nil {
+		t.Fatalf("RegisterName evm: %v", err)
 	}
 	client := rpc.DialInProc(srv)
 	t.Cleanup(client.Close)
@@ -57,6 +69,29 @@ func TestHardhatAPI_Mine_RPCRegistration(t *testing.T) {
 				t.Fatalf("result = %#v, want nil", result)
 			}
 		})
+	}
+}
+
+func TestEvmAPI_SetAutomine_RPCRegistration(t *testing.T) {
+	client := dialEvm(t)
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%v", enabled), func(t *testing.T) {
+			var result any
+			if err := client.CallContext(context.Background(), &result, "evm_setAutomine", enabled); err != nil {
+				t.Fatalf("evm_setAutomine: %v", err)
+			}
+			if result != nil {
+				t.Fatalf("result = %#v, want nil", result)
+			}
+		})
+	}
+}
+
+func TestEvmAPI_SetAutomine_MissingArg(t *testing.T) {
+	client := dialEvm(t)
+	var result any
+	if err := client.CallContext(context.Background(), &result, "evm_setAutomine"); err == nil {
+		t.Fatal("expected error for missing argument")
 	}
 }
 

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1526,7 +1526,7 @@
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite numCheckpoints does not add more than one checkpoint in a block",
-    "cause": "evm_setAutomine"
+    "cause": "transaction already pending"
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite numCheckpoints returns the number of checkpoints for a delegate",
@@ -1660,7 +1660,7 @@
   },
   {
     "id": "ERC20Votes vote with timestamp Compound test suite numCheckpoints does not add more than one checkpoint in a block",
-    "cause": "evm_setAutomine"
+    "cause": "transaction already pending"
   },
   {
     "id": "ERC20Votes vote with timestamp Compound test suite numCheckpoints returns the number of checkpoints for a delegate",
@@ -3329,7 +3329,7 @@
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity multiple consumes in the same block accumulate",
-    "cause": "evm_setAutomine"
+    "cause": "nonce too low"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity refills linearly over time"
@@ -3353,15 +3353,14 @@
     "id": "RateLimiter RefillingBucket with some capacity used saturates to zero after a long idle"
   },
   {
-    "id": "RateLimiter RefillingBucket with some capacity using sync to mitigate updateSettings side effect",
-    "cause": "evm_setAutomine"
+    "id": "RateLimiter RefillingBucket with some capacity using sync to mitigate updateSettings side effect"
   },
   {
     "id": "RateLimiter SlidingWindow with some capacity consume after a full-window idle truncates cumulative history"
   },
   {
     "id": "RateLimiter SlidingWindow with some capacity multiple consumes in the same block overwrite the checkpoint in place",
-    "cause": "evm_setAutomine"
+    "cause": "execution reverted"
   },
   {
     "id": "RateLimiter SlidingWindow with some capacity only consumptions outside the window drop out"
@@ -3533,8 +3532,7 @@
     "cause": "eth_getProof"
   },
   {
-    "id": "TrieProof verify verify transaction and receipt inclusion in block",
-    "cause": "evm_setAutomine"
+    "id": "TrieProof verify verify transaction and receipt inclusion in block"
   },
   {
     "id": "VestingWallet \"before each\" hook for \"rejects zero address for beneficiary\"",


### PR DESCRIPTION
Closes #253
Part of #248

Same kind of gap as the hardhat_mine and hardhat_impersonateAccount stubs: the OpenZeppelin suite calls evm_setAutomine, and our test RPC did not register it, so those paths failed with method not found.

This adds SetAutomine on EvmAPI as a no-op. It accepts the bool, returns success, and does not change how blocks are produced. Fabric still owns block timing through the orderer, same reason evm_mine is already a stub. The issue notes only a handful of tests hit this, so a real automine implementation is not worth the complexity right now.

## Code

gateway/testimpl/hardhat_helpers.go adds EvmAPI.SetAutomine. The evm namespace is already registered in the test server, so no server.go change was needed.

gateway/testimpl/hardhat_helpers_test.go covers the in process RPC path for true and false, plus a missing argument case. Shared dialEvm / dialHardhat helpers keep the setup tidy next to the existing Hardhat tests.

## Baseline

Full compatible set run (scripts/run_hardhat_test.sh --full), then reconciled testdata/oz_known_failures.json:

* all 6 prior failures tagged evm_setAutomine no longer fail for method not found
* those same 6 still fail later (pending txs, nonce, reverts, or assertion noise), which is expected when automine is only a stub
* zero remaining evm_setAutomine cause tags

cmd/baseline check against that run is clean (no regressions, no stale entries).

## Verification

* go test ./gateway/testimpl/
* go test ./... -short
* go vet / staticcheck on the touched package
* CI style Hardhat path: ERC20.test.js (126 passing)
* full OZ suite + baseline check

Happy to tweak cause tags if anything looks off. Thanks!
