### PR TITLE
refactor: drop HandleTx, unify notification path onto existing Handle…

### DIFF
--- a/common/notification.go
+++ b/common/notification.go
@@ -7,10 +7,10 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -19,18 +19,6 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/notification"
 	"google.golang.org/protobuf/proto"
 )
-
-// TxNotification contains data about a committed Ethereum transaction, reconstructed
-// from a blocks.Transaction for use by components that need EVM-specific fields
-// (e.g. EthTxHash, EthTxBytes) beyond what blocks.Transaction provides.
-type TxNotification struct {
-	BlockNum   uint64
-	TxNum      uint64
-	FabricTxID string
-	Status     committerpb.Status
-	EthTxBytes []byte
-	EthTxHash  common.Hash
-}
 
 var notifLogger = flogging.MustGetLogger("evm.notification")
 
@@ -71,6 +59,11 @@ func (d *AllTxBatchDispatcher) HandleBatch(ctx context.Context, batch notificati
 		var input peer.ChaincodeInput
 		if err := proto.Unmarshal(event.Metadata[0], &input); err != nil || len(input.Args) < 2 {
 			notifLogger.Debugf("Skipping tx %s: cannot extract eth tx from metadata", event.TxID)
+			continue
+		}
+
+		if !bytes.Equal(input.Args[0], []byte{byte(ProposalTypeEVMTx)}) {
+			notifLogger.Debugf("Skipping tx %s: not an EVM transaction", event.TxID)
 			continue
 		}
 

--- a/common/notification.go
+++ b/common/notification.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -21,46 +20,39 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// TxNotification contains all data needed to process a transaction notification.
-// EthTxBytes and EthTxHash come from the cache; NsRWS and Events come from the AllTxStreamer event.
+// TxNotification contains data about a committed Ethereum transaction, reconstructed
+// from a blocks.Transaction for use by components that need EVM-specific fields
+// (e.g. EthTxHash, EthTxBytes) beyond what blocks.Transaction provides.
 type TxNotification struct {
-	// From notification service
 	BlockNum   uint64
 	TxNum      uint64
 	FabricTxID string
 	Status     committerpb.Status
-
-	// From cache
 	EthTxBytes []byte
-	EthTxHash  common.Hash // pre-computed; handlers that only need the hash skip UnmarshalBinary
-
-	// From AllTxStreamer (IncludeReadWriteSets must be true)
-	NsRWS  []blocks.NsReadWriteSet
-	Events []byte
+	EthTxHash  common.Hash
 }
 
 var notifLogger = flogging.MustGetLogger("evm.notification")
 
-// TxHandler defines the interface for handlers that process transaction notifications in batches.
-// Both gateway and endorser components implement this to receive committed-transaction
-// notifications over the AllTxStreamer path (an alternative to the block-synchronizer path).
+// TxHandler defines the interface for handlers that process committed blocks delivered
+// via the AllTxStreamer path (an alternative to the block-synchronizer path).
 type TxHandler interface {
-	HandleTx(ctx context.Context, notifs []TxNotification) error
+	Handle(ctx context.Context, b blocks.Block) error
 }
 
 // AllTxBatchDispatcher implements notification.AllTxHandler. It bridges AllTxStreamer
 // (which delivers every committed transaction) to the internal TxHandler chain.
 //
-// For each committed transaction event it:
-//  1. Extracts the Ethereum transaction bytes from the event metadata.
-//  2. Converts the event's Namespaces to NsRWS + Events.
-//  3. Builds a TxNotification and dispatches it to all registered TxHandlers.
+// For each committed block it:
+//  1. Filters out non-EVM transactions (those without Ethereum tx bytes in InputArgs).
+//  2. Assembles a blocks.Block from the remaining events.
+//  3. Dispatches the block to all registered TxHandlers.
 type AllTxBatchDispatcher struct {
 	handlers []TxHandler
 }
 
-// NewAllTxBatchDispatcher creates a dispatcher that extracts EthTxBytes from event metadata
-// and dispatches them as TxNotifications to the handler chain.
+// NewAllTxBatchDispatcher creates a dispatcher that filters EVM transactions from
+// AllTxStreamer events and dispatches them as a blocks.Block to the handler chain.
 func NewAllTxBatchDispatcher(handlers ...TxHandler) *AllTxBatchDispatcher {
 	return &AllTxBatchDispatcher{handlers: handlers}
 }
@@ -69,66 +61,50 @@ func NewAllTxBatchDispatcher(handlers ...TxHandler) *AllTxBatchDispatcher {
 func (d *AllTxBatchDispatcher) HandleBatch(ctx context.Context, batch notification.AllTxBatch) error {
 	notifLogger.Debugf("[BLOCK] block=%d total_events=%d", batch.BlockNumber, len(batch.Events))
 
-	notifs := make([]TxNotification, 0, len(batch.Events))
+	txs := make([]blocks.Transaction, 0, len(batch.Events))
 	for _, event := range batch.Events {
-		// Extract Ethereum transaction from metadata
-		ethTxBytes, err := extractEthTxFromMetadata(event.Metadata)
-		if err != nil {
-			notifLogger.Debugf("Skipping tx %s: %v", event.TxID, err)
+		if len(event.Metadata) == 0 {
+			notifLogger.Debugf("Skipping tx %s: no metadata", event.TxID)
 			continue
 		}
 
-		var ethTx types.Transaction
-		if err := ethTx.UnmarshalBinary(ethTxBytes); err != nil {
-			return fmt.Errorf("unmarshal eth tx for %s: %w", event.TxID, err)
+		var input peer.ChaincodeInput
+		if err := proto.Unmarshal(event.Metadata[0], &input); err != nil || len(input.Args) < 2 {
+			notifLogger.Debugf("Skipping tx %s: cannot extract eth tx from metadata", event.TxID)
+			continue
 		}
 
 		nsrws, events := namespacesToNsRWS(event.Namespaces)
 
-		notifs = append(notifs, TxNotification{
-			BlockNum:   event.BlockNum,
-			TxNum:      uint64(event.TxNum),
-			FabricTxID: event.TxID,
-			Status:     event.Status,
-			EthTxBytes: ethTxBytes,
-			EthTxHash:  ethTx.Hash(),
-			NsRWS:      nsrws,
-			Events:     events,
+		txs = append(txs, blocks.Transaction{
+			ID:        event.TxID,
+			Number:    int64(event.TxNum),
+			InputArgs: input.Args,
+			Valid:     event.Status == committerpb.Status_COMMITTED,
+			Status:    int(event.Status),
+			Events:    events,
+			NsRWS:     nsrws,
 		})
 	}
 
-	if len(notifs) == 0 {
+	if len(txs) == 0 {
 		return nil
 	}
 
-	notifLogger.Debugf("[NOTIFY] block=%d dispatching=%d/%d txs", batch.BlockNumber, len(notifs), len(batch.Events))
+	notifLogger.Debugf("[NOTIFY] block=%d dispatching=%d/%d txs", batch.BlockNumber, len(txs), len(batch.Events))
+
+	b := blocks.Block{
+		Number:       batch.BlockNumber,
+		Transactions: txs,
+	}
 
 	for _, h := range d.handlers {
-		if err := h.HandleTx(ctx, notifs); err != nil {
+		if err := h.Handle(ctx, b); err != nil {
 			panic(fmt.Errorf("handler failed: %w", err))
 		}
 	}
 
 	return nil
-}
-
-// extractEthTxFromMetadata extracts the Ethereum transaction bytes from the event metadata.
-// Metadata[0] contains the marshaled ChaincodeInput, which has Args[1] = eth tx bytes.
-func extractEthTxFromMetadata(metadata [][]byte) ([]byte, error) {
-	if len(metadata) == 0 {
-		return nil, fmt.Errorf("no metadata")
-	}
-
-	var input peer.ChaincodeInput
-	if err := proto.Unmarshal(metadata[0], &input); err != nil {
-		return nil, fmt.Errorf("unmarshal input: %w", err)
-	}
-
-	if len(input.Args) < 2 {
-		return nil, fmt.Errorf("insufficient args: %d", len(input.Args))
-	}
-
-	return input.Args[1], nil
 }
 
 // namespacesToNsRWS converts applicationpb.TxNamespace slices (as delivered by

--- a/common/notification.go
+++ b/common/notification.go
@@ -34,26 +34,26 @@ type TxNotification struct {
 
 var notifLogger = flogging.MustGetLogger("evm.notification")
 
-// TxHandler defines the interface for handlers that process committed blocks delivered
-// via the AllTxStreamer path (an alternative to the block-synchronizer path).
-type TxHandler interface {
+// BlockHandler defines the interface for handlers that
+// process committed blocks delivered via the AllTxStreamer path
+type BlockHandler interface {
 	Handle(ctx context.Context, b blocks.Block) error
 }
 
 // AllTxBatchDispatcher implements notification.AllTxHandler. It bridges AllTxStreamer
-// (which delivers every committed transaction) to the internal TxHandler chain.
+// (which delivers every committed transaction) to the internal BlockHandler chain.
 //
 // For each committed block it:
 //  1. Filters out non-EVM transactions (those without Ethereum tx bytes in InputArgs).
 //  2. Assembles a blocks.Block from the remaining events.
-//  3. Dispatches the block to all registered TxHandlers.
+//  3. Dispatches the block to all registered BlockHandler.
 type AllTxBatchDispatcher struct {
-	handlers []TxHandler
+	handlers []BlockHandler
 }
 
 // NewAllTxBatchDispatcher creates a dispatcher that filters EVM transactions from
 // AllTxStreamer events and dispatches them as a blocks.Block to the handler chain.
-func NewAllTxBatchDispatcher(handlers ...TxHandler) *AllTxBatchDispatcher {
+func NewAllTxBatchDispatcher(handlers ...BlockHandler) *AllTxBatchDispatcher {
 	return &AllTxBatchDispatcher{handlers: handlers}
 }
 

--- a/endorser/storage/kvs_parity_test.go
+++ b/endorser/storage/kvs_parity_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 )
 
@@ -483,11 +481,10 @@ func TestPebbleVersionSemanticsMatchVersionedDB(t *testing.T) {
 	})
 }
 
-// TestPebbleHandleTxMultiBlock exercises the HandleTx notification path with
-// writes spanning two blocks delivered out of block order, covering PebbleKVS's
-// group-by-block + ascending-commit logic (LightKVS instead collapses a batch
-// into one snapshot, so this is a PebbleKVS-specific contract).
-func TestPebbleHandleTxMultiBlock(t *testing.T) {
+// TestPebbleHandleMultiBlock exercises the Handle path with writes spanning two
+// consecutive blocks, verifying that the checkpoint advances to 2 and that
+// time-travel reads resolve to each block's respective write.
+func TestPebbleHandleMultiBlock(t *testing.T) {
 	ctx := context.Background()
 	kvs, err := NewPebbleKVS(t.TempDir(), 8)
 	if err != nil {
@@ -495,22 +492,13 @@ func TestPebbleHandleTxMultiBlock(t *testing.T) {
 	}
 	defer kvs.Close()
 
-	mkNotif := func(block, tx uint64, id, val string) common.TxNotification {
-		return common.TxNotification{
-			BlockNum: block, TxNum: tx, FabricTxID: id,
-			Status: committerpb.Status_COMMITTED,
-			NsRWS: []blocks.NsReadWriteSet{{Namespace: "ns1", RWS: blocks.ReadWriteSet{
-				Writes: []blocks.KVWrite{{Key: "k", Value: []byte(val)}},
-			}}},
-		}
+	if err := kvs.Handle(ctx, mkBlock(1, 0, "b1", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("block1")})); err != nil {
+		t.Fatalf("Handle block 1: %v", err)
 	}
-	// Deliver block 2 before block 1 to prove the store commits in ascending
-	// block order (the checkpoint must advance monotonically to 2).
-	if err := kvs.HandleTx(ctx, []common.TxNotification{
-		mkNotif(2, 0, "b2", "block2"),
-		mkNotif(1, 0, "b1", "block1"),
-	}); err != nil {
-		t.Fatalf("HandleTx: %v", err)
+	if err := kvs.Handle(ctx, mkBlock(2, 0, "b2", true, "ns1",
+		blocks.KVWrite{Key: "k", Value: []byte("block2")})); err != nil {
+		t.Fatalf("Handle block 2: %v", err)
 	}
 
 	if n, err := kvs.BlockNumber(ctx); err != nil || n != 2 {

--- a/endorser/storage/lightkvs.go
+++ b/endorser/storage/lightkvs.go
@@ -14,8 +14,6 @@ import (
 	"maps"
 	"sync/atomic"
 
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 )
@@ -362,7 +360,7 @@ func (kvs *LightKVS) Update(updates []KeyValueVersion) error {
 }
 
 // collectWrites is a private helper that extracts writes from namespace read-write sets
-// and appends them to the provided updates slice. This is the common logic used by both Handle and HandleTx.
+// and appends them to the provided updates slice.
 func collectWrites(updates *[]KeyValueVersion, nsrwsList []blocks.NsReadWriteSet, blockNum, txNum uint64, txID string, valid bool) {
 	if !valid {
 		// Skip invalid transactions
@@ -395,27 +393,6 @@ func (kvs *LightKVS) Handle(ctx context.Context, b blocks.Block) error {
 
 	for _, tx := range b.Transactions {
 		collectWrites(&allUpdates, tx.NsRWS, b.Number, uint64(tx.Number), tx.ID, tx.Valid)
-	}
-
-	// Apply all updates atomically in a single Update call
-	if len(allUpdates) > 0 {
-		return kvs.Update(allUpdates)
-	}
-
-	return nil
-}
-
-// HandleTx implements the core.TxHandler interface.
-// It processes a batch of transaction notifications by extracting writes and applying them.
-// This is called by the notification dispatcher when transactions are committed.
-func (kvs *LightKVS) HandleTx(ctx context.Context, notifs []common.TxNotification) error {
-	// Collect all writes from all notifications in the batch
-	var allUpdates []KeyValueVersion
-
-	for _, notif := range notifs {
-		// Status check: committerpb.Status_COMMITTED means success
-		valid := notif.Status == committerpb.Status_COMMITTED
-		collectWrites(&allUpdates, notif.NsRWS, notif.BlockNum, notif.TxNum, notif.FabricTxID, valid)
 	}
 
 	// Apply all updates atomically in a single Update call

--- a/endorser/storage/pebblekvs.go
+++ b/endorser/storage/pebblekvs.go
@@ -17,8 +17,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	gethpebble "github.com/ethereum/go-ethereum/ethdb/pebble"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 )
@@ -347,47 +345,6 @@ func (p *PebbleKVS) Handle(ctx context.Context, b blocks.Block) error {
 	return p.commitBlock(b.Number, updates)
 }
 
-// HandleTx implements the notification write path: it extracts writes from a
-// batch of committed transaction notifications and applies them. Notifications
-// may span multiple blocks, so writes are grouped by block and each block is
-// committed atomically.
-//
-// Each call must carry all of a block's notifications. AllTxBatchDispatcher
-// satisfies this — the SDK delivers one AllTxBatch per block and the dispatcher
-// forwards each batch as one call — and the replay guard in commitBlock depends
-// on it: a block arriving in two calls would have its second half skipped as
-// already applied rather than merged.
-func (p *PebbleKVS) HandleTx(ctx context.Context, notifs []common.TxNotification) error {
-	if len(notifs) == 0 {
-		return nil
-	}
-
-	// Group by block so each block commits as one atomic batch, then apply
-	// blocks in ascending order.
-	byBlock := make(map[uint64][]KeyValueVersion)
-	var order []uint64
-	for _, notif := range notifs {
-		valid := notif.Status == committerpb.Status_COMMITTED
-		before := len(byBlock[notif.BlockNum])
-		updates := byBlock[notif.BlockNum]
-		collectWrites(&updates, notif.NsRWS, notif.BlockNum, notif.TxNum, notif.FabricTxID, valid)
-		if before == 0 && len(updates) > 0 {
-			order = append(order, notif.BlockNum)
-		}
-		byBlock[notif.BlockNum] = updates
-	}
-
-	// Apply in ascending block order so the persisted checkpoint advances
-	// monotonically.
-	sortUint64(order)
-	for _, blockNum := range order {
-		if err := p.Update(byBlock[blockNum]); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // BlockNumber returns the last committed block number.
 func (p *PebbleKVS) BlockNumber(ctx context.Context) (uint64, error) {
 	return p.currentBlock.Load(), nil
@@ -582,14 +539,4 @@ func decodeRecord(raw []byte) (*blocks.WriteRecord, error) {
 		IsDelete: flags&flagIsDelete != 0,
 		TxID:     txID,
 	}, nil
-}
-
-// sortUint64 sorts a small slice of block numbers ascending (insertion sort;
-// notification batches span very few distinct blocks).
-func sortUint64(s []uint64) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j-1] > s[j]; j-- {
-			s[j-1], s[j] = s[j], s[j-1]
-		}
-	}
 }

--- a/endorser/storage/versioned_db_wrapper.go
+++ b/endorser/storage/versioned_db_wrapper.go
@@ -9,8 +9,6 @@ package storage
 import (
 	"context"
 
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	"github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/hyperledger/fabric-x-sdk/state"
@@ -85,45 +83,6 @@ func (w *VersionedDBWrapper) Get(namespace, key string, lastBlock uint64) (*bloc
 // Handle implements blocks.BlockHandler by delegating to the underlying VersionedDB.
 func (w *VersionedDBWrapper) Handle(ctx context.Context, b blocks.Block) error {
 	return w.db.Handle(ctx, b)
-}
-
-// HandleTx implements the common.TxHandler interface.
-// It creates a synthetic block with the transactions and delegates to the underlying VersionedDB.
-func (w *VersionedDBWrapper) HandleTx(ctx context.Context, notifs []common.TxNotification) error {
-	if len(notifs) == 0 {
-		return nil
-	}
-
-	// Group notifications by block number
-	blockMap := make(map[uint64][]common.TxNotification)
-	for _, notif := range notifs {
-		blockMap[notif.BlockNum] = append(blockMap[notif.BlockNum], notif)
-	}
-
-	// Process each block
-	for blockNum, blockNotifs := range blockMap {
-		// Create a synthetic block with transactions from this block
-		txs := make([]blocks.Transaction, 0, len(blockNotifs))
-		for _, notif := range blockNotifs {
-			txs = append(txs, blocks.Transaction{
-				Number: int64(notif.TxNum),
-				ID:     notif.FabricTxID,
-				Valid:  notif.Status == committerpb.Status_COMMITTED, // Status = COMMITTED = valid
-				NsRWS:  notif.NsRWS,
-			})
-		}
-
-		syntheticBlock := blocks.Block{
-			Number:       blockNum,
-			Transactions: txs,
-		}
-
-		if err := w.db.Handle(ctx, syntheticBlock); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // BlockNumber returns the last processed block number.

--- a/gateway/core/txqueue.go
+++ b/gateway/core/txqueue.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	cmn "github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
@@ -145,23 +143,6 @@ func (q *TxQueue) Handle(ctx context.Context, block *domain.Block) error {
 			q.invalid++
 		}
 		q.Complete(txHash)
-	}
-
-	return nil
-}
-
-// HandleTx implements the TxHandler interface for processing transaction notifications.
-// It extracts ethereum transaction hashes from the notifications and marks them as complete.
-func (q *TxQueue) HandleTx(ctx context.Context, notifs []cmn.TxNotification) error {
-	for _, notif := range notifs {
-		q.mu.Lock()
-		q.total++
-		if notif.Status != committerpb.Status_COMMITTED {
-			q.invalid++
-		}
-		q.mu.Unlock()
-
-		q.Complete(notif.EthTxHash)
 	}
 
 	return nil

--- a/gateway/core/txqueue_v2.go
+++ b/gateway/core/txqueue_v2.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
-	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	cmn "github.com/hyperledger/fabric-x-evm/common"
 	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 )
 
@@ -412,49 +410,6 @@ func (q *TxQueueV2) Handle(ctx context.Context, block *domain.Block) error {
 
 		totalPromoted += q.completeUnlocked(txHash)
 	}
-
-	// Signal workers based on how many transactions were promoted
-	if totalPromoted == 1 {
-		// Only one transaction promoted - wake up one worker
-		q.cond.Signal()
-	} else if totalPromoted > 1 {
-		// Multiple transactions promoted - wake up all workers
-		q.cond.Broadcast()
-	}
-
-	return nil
-}
-
-// Stats returns statistics about processed transactions.
-// Returns (total transactions processed, invalid transactions).
-// HandleTx processes transaction notifications and marks transactions as complete.
-// This method implements the TxHandler interface for use with the notification system.
-func (q *TxQueueV2) HandleTx(ctx context.Context, notifs []cmn.TxNotification) error {
-	// Pre-extract transaction hashes and statuses outside the lock
-	numNotifs := len(notifs)
-	txHashes := make([]common.Hash, numNotifs)
-	statuses := make([]committerpb.Status, numNotifs)
-	for i, notif := range notifs {
-		txHashes[i] = notif.EthTxHash
-		statuses[i] = notif.Status
-	}
-
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	totalPromoted := 0
-
-	// Mark all transactions in the batch as complete
-	for i := 0; i < numNotifs; i++ {
-		q.total++
-		if statuses[i] != committerpb.Status_COMMITTED {
-			q.invalid++
-		}
-		totalPromoted += q.completeUnlocked(txHashes[i])
-	}
-
-	loggerV2.Debugf("[QUEUE] HandleTx: notifs=%d promoted=%d ready=%d waiting=%d pending=%d",
-		numNotifs, totalPromoted, q.readyList.Len(), q.waitingList.Len(), len(q.pendingMap))
 
 	// Signal workers based on how many transactions were promoted
 	if totalPromoted == 1 {

--- a/integration/perf/replay_json_dataset_test.go
+++ b/integration/perf/replay_json_dataset_test.go
@@ -33,6 +33,7 @@ import (
 	gwcore "github.com/hyperledger/fabric-x-evm/gateway/core"
 	gwtestimpl "github.com/hyperledger/fabric-x-evm/gateway/testimpl"
 	"github.com/hyperledger/fabric-x-evm/integration"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/grpclog"
 )
@@ -71,15 +72,34 @@ func (t *TxCompletionTracker) Stop() {
 	t.stopped = true
 }
 
-// HandleTx implements common.TxHandler. It receives notifications about completed transactions
-// and forwards them to the completion channel.
-func (t *TxCompletionTracker) HandleTx(ctx context.Context, notifs []fxcommon.TxNotification) error {
+// Handle implements common.TxHandler. It receives committed transactions and forwards
+// them to the completion channel, reconstructing the Ethereum tx hash from InputArgs.
+func (t *TxCompletionTracker) Handle(ctx context.Context, b blocks.Block) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.stopped {
 		return nil
 	}
-	for _, notif := range notifs {
+	for _, tx := range b.Transactions {
+		var ethTx types.Transaction
+		if len(tx.InputArgs) < 2 {
+			continue
+		}
+		if err := ethTx.UnmarshalBinary(tx.InputArgs[1]); err != nil {
+			continue
+		}
+		status := committerpb.Status_COMMITTED
+		if !tx.Valid {
+			status = committerpb.Status_ABORTED_MVCC_CONFLICT
+		}
+		notif := fxcommon.TxNotification{
+			BlockNum:   b.Number,
+			TxNum:      uint64(tx.Number),
+			FabricTxID: tx.ID,
+			Status:     status,
+			EthTxBytes: tx.InputArgs[1],
+			EthTxHash:  ethTx.Hash(),
+		}
 		select {
 		case t.completionCh <- notif:
 		default:

--- a/integration/perf/replay_json_dataset_test.go
+++ b/integration/perf/replay_json_dataset_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	fxcommon "github.com/hyperledger/fabric-x-evm/common"
 	econf "github.com/hyperledger/fabric-x-evm/endorser/config"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	"github.com/hyperledger/fabric-x-evm/endorser/testimpl"
@@ -49,16 +48,23 @@ var submitters = flag.Int("submitters", 4, "number of goroutines submitting tran
 var orderers = flag.Int("orderers", 8, "number of goroutines submitting transactions to the orderer (BatchSubmitter workers)")
 var outstanding = flag.Int("outstanding", 1000, "maximum number of outstanding transactions")
 
+// txCompletion carries the fields needed by the refill loop after a transaction commits.
+type txCompletion struct {
+	EthTxHash common.Hash
+	Valid     bool
+	Status    committerpb.Status
+}
+
 // TxCompletionTracker forwards all transaction completion notifications to a single channel.
-// It implements common.TxHandler to receive notifications from the notification system.
+// It implements common.BlockHandler to receive notifications from the notification system.
 type TxCompletionTracker struct {
 	mu           sync.Mutex
-	completionCh chan fxcommon.TxNotification
+	completionCh chan txCompletion
 	stopped      bool
 }
 
 // NewTxCompletionTracker creates a new tracker with a completion channel.
-func NewTxCompletionTracker(completionCh chan fxcommon.TxNotification) *TxCompletionTracker {
+func NewTxCompletionTracker(completionCh chan txCompletion) *TxCompletionTracker {
 	return &TxCompletionTracker{
 		completionCh: completionCh,
 	}
@@ -72,7 +78,7 @@ func (t *TxCompletionTracker) Stop() {
 	t.stopped = true
 }
 
-// Handle implements common.TxHandler. It receives committed transactions and forwards
+// Handle implements common.BlockHandler. It receives committed transactions and forwards
 // them to the completion channel, reconstructing the Ethereum tx hash from InputArgs.
 func (t *TxCompletionTracker) Handle(ctx context.Context, b blocks.Block) error {
 	t.mu.Lock()
@@ -88,17 +94,10 @@ func (t *TxCompletionTracker) Handle(ctx context.Context, b blocks.Block) error 
 		if err := ethTx.UnmarshalBinary(tx.InputArgs[1]); err != nil {
 			continue
 		}
-		status := committerpb.Status_COMMITTED
-		if !tx.Valid {
-			status = committerpb.Status_ABORTED_MVCC_CONFLICT
-		}
-		notif := fxcommon.TxNotification{
-			BlockNum:   b.Number,
-			TxNum:      uint64(tx.Number),
-			FabricTxID: tx.ID,
-			Status:     status,
-			EthTxBytes: tx.InputArgs[1],
-			EthTxHash:  ethTx.Hash(),
+		notif := txCompletion{
+			EthTxHash: ethTx.Hash(),
+			Valid:     tx.Valid,
+			Status:    committerpb.Status(tx.Status),
 		}
 		select {
 		case t.completionCh <- notif:
@@ -254,7 +253,7 @@ func runReplayTest(t *testing.T, processingWorkerCount int, submittingWorkerCoun
 	factory := balancePrimingEndorserFactory(balancePriming)
 
 	// Create completion channel for transaction notifications
-	completionCh := make(chan fxcommon.TxNotification, numOutstandingTx*2)
+	completionCh := make(chan txCompletion, numOutstandingTx*2)
 
 	// Create completion tracker for async transaction monitoring
 	tracker := NewTxCompletionTracker(completionCh)
@@ -575,7 +574,7 @@ func runReplayTest(t *testing.T, processingWorkerCount int, submittingWorkerCoun
 			}
 
 			// Update success/fail counts
-			if notif.Status == committerpb.Status_COMMITTED {
+			if notif.Valid {
 				atomic.AddInt64(&successCount, 1)
 				if metrics != nil {
 					metrics.RecordTransactionCommitted()

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -333,14 +333,14 @@ func (sp *StatePrimer) commitAndWait(end sdk.Endorsement, tx *types.Transaction,
 		}
 	}
 
-	// Only create the in-proc RPC client when we wait; the no-wait path leaked it.
+	// TODO: the ethclient created here leaks when wait=false; fix by closing it on the no-wait path too.
+	ec, err := NewNativeEthClient(sp.gw)
+	if err != nil {
+		return err
+	}
+
 	if wait {
-		ec, err := NewNativeEthClient(sp.gw)
-		if err != nil {
-			return err
-		}
-		defer ec.Close()
-		return waitForCommit(context.Background(), ec, tx)
+		waitForCommit(context.Background(), ec, tx)
 	}
 
 	return nil

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -333,13 +333,18 @@ func (sp *StatePrimer) commitAndWait(end sdk.Endorsement, tx *types.Transaction,
 		}
 	}
 
-	// TODO: the ethclient created here leaks when wait=false; fix by closing it on the no-wait path too.
-	ec, err := NewNativeEthClient(sp.gw)
-	if err != nil {
-		return err
-	}
-
+	// Only create the in-proc RPC client when we wait; the no-wait path leaked it.
 	if wait {
+		ec, err := NewNativeEthClient(sp.gw)
+		if err != nil {
+			return err
+		}
+		defer ec.Close()
+		// we ignore the return value of `waitForCommit` for now because
+		// the synchronisation-on-startup architecture might leave the wait
+		// for commit loop unworkable. As soon as
+		// https://github.com/hyperledger/fabric-x-evm/issues/221
+		// is complete we will add the return again
 		waitForCommit(context.Background(), ec, tx)
 	}
 

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -240,7 +240,7 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 			for _, db := range dbs {
 				txHandlers = append(txHandlers, db.(common.TxHandler))
 			}
-			txHandlers = append(txHandlers, gw.TxQueue.(common.TxHandler))
+			txHandlers = append(txHandlers, gw)
 			if extraHandler != nil {
 				txHandlers = append(txHandlers, extraHandler)
 			}

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -128,7 +128,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 
 // buildTestHarnessWithExtraHandler is like buildTestHarness but accepts an optional extra TxHandler
 // that will be inserted into the notification handler chain right before the cleanup handler.
-func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, useNotifications bool, extraHandler common.TxHandler) (*TestHarness, *network.Synchronizer, error) {
+func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, useNotifications bool, extraHandler common.BlockHandler) (*TestHarness, *network.Synchronizer, error) {
 	dbs := make([]storage.KVS, len(endorsers))
 	builders := make([]endorsement.Builder, len(endorsers))
 	ends := make([]eapi.Service, len(endorsers))
@@ -236,9 +236,9 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 			logger.Infof("Synchronizer stopped cleanly")
 
 			// Set up AllTxStreamer notification system
-			txHandlers := make([]common.TxHandler, 0, len(dbs)+2)
+			txHandlers := make([]common.BlockHandler, 0, len(dbs)+2)
 			for _, db := range dbs {
-				txHandlers = append(txHandlers, db.(common.TxHandler))
+				txHandlers = append(txHandlers, db.(common.BlockHandler))
 			}
 			txHandlers = append(txHandlers, gw)
 			if extraHandler != nil {
@@ -487,7 +487,7 @@ func newFileConfigHarness(t *testing.T, logger sdk.Logger, evmConfig execution.E
 // transaction completion tracking instead of block-based synchronization.
 // Uses MemoryStore and NotificationDispatcher for better performance in replay scenarios.
 // If extraHandler is non-nil, it will be inserted into the handler chain right before the cleanup handler.
-func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evmConfig execution.EVMConfig, primeDbPath string, configOverrides map[string]any, factory EndorserFactory, txQueue core.TxQueueInterface, extraHandler common.TxHandler, confFile string) (*TestHarness, error) {
+func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evmConfig execution.EVMConfig, primeDbPath string, configOverrides map[string]any, factory EndorserFactory, txQueue core.TxQueueInterface, extraHandler common.BlockHandler, confFile string) (*TestHarness, error) {
 	if primeDbPath != "" && !filepath.IsAbs(primeDbPath) {
 		if abs, err := filepath.Abs(primeDbPath); err == nil {
 			primeDbPath = abs

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -880,45 +880,22 @@
     "id": "Address functionCall with valid contract receiver reverts when the called function runs out of gas"
   },
   {
-    "id": "Address functionCallWithValue with non-zero value calls the requested function with existing value",
-    "cause": "insufficient-funds"
+    "id": "Arrays \"before each\" hook for \"sort reversed array\""
   },
   {
-    "id": "Address functionCallWithValue with non-zero value calls the requested function with transaction funds",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Address functionCallWithValue with non-zero value reverts when calling non-payable functions",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Address sendValue when sender contract has funds \"before each\" hook for \"sends 0 wei\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Arrays \"before each\" hook for \"slice from start to end\""
+    "id": "Arrays address sort [skip-on-coverage] address[] of length 384 \"after each\" hook for \"sort array for identical elements\""
   },
   {
     "id": "BeaconProxy bad beacon is not accepted non-compliant beacon"
   },
   {
-    "id": "BeaconProxy initialization payable initialization",
-    "cause": "insufficient-funds"
+    "id": "BlockHeader current block"
   },
   {
-    "id": "BeaconProxy initialization reverting initialization due to value",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
+    "id": "BlockHeader reads all fields from pre-parsed list"
   },
   {
     "id": "Clones with immutable args: 0x clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -926,19 +903,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -946,19 +911,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x11223344 clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -966,19 +919,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x11223344 clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -986,19 +927,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -1006,31 +935,11 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones without immutable args clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args cloneDeterministic initialization with parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones without immutable args cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args cloneDeterministic initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Create2 deploy deploys a contract with funds deposited in the factory",
     "cause": "insufficient-funds"
   },
   {
@@ -1044,30 +953,6 @@
   {
     "id": "CrosschainBridgeERC721 \"before each\" hook for \"token getters\"",
     "cause": "hardhat_setBalance"
-  },
-  {
-    "id": "ECDSA parse signature 65 and 64 bytes signatures",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns a different address",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature for arbitrary length message",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "EIP712 with long name and version digest",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "EIP712 with short name and version digest",
-    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "ERC1155 like an ERC1155 ERC165 when the interfaceId is not supported uses less than 30k",
@@ -1106,40 +991,22 @@
     "cause": "gas-stub"
   },
   {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones deterministic deployment (create2) initialization with parameters non payable when sending some balance reverts"
   },
   {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones deterministic deployment (create2) initialization without parameters non payable when sending some balance reverts"
   },
   {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones deterministic deployment (create2) without initialization when sending some balance reverts"
   },
   {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones non-deterministic deployment (create) initialization with parameters non payable when sending some balance reverts"
   },
   {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones non-deterministic deployment (create) initialization without parameters non payable when sending some balance reverts"
   },
   {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true without initialization when sending some balance reverts",
-    "cause": "insufficient-funds"
+    "id": "ERC1967Clones non-deterministic deployment (create) without initialization when sending some balance reverts"
   },
   {
     "id": "ERC1967Utils ADMIN_SLOT \"before each\" hook: set admin for \"returns current admin and matches admin slot value\"",
@@ -1166,20 +1033,59 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "ERC20Permit permit accepts owner signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Permit permit rejects expired permit",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Permit permit rejects other signature",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization cancels the next nonce after consuming the previous one"
   },
   {
-    "id": "ERC20Permit permit rejects reused signature",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization prevents usage of canceled authorization in transferWithAuthorization"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization shares the keyed counter between transfer and receive"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization with bytes signature prevents usage of canceled authorization by an ERC1271 wallet"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization accepts holder signature when called by recipient"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects out-of-order nonces sharing the same key"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects reused signature"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature accepts ERC1271 wallet signature when called by recipient"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature accepts holder signature when called by recipient"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization accepts holder signature"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects out-of-order nonces sharing the same key"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects reused signature"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature accepts ERC1271 wallet signature"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature accepts holder signature"
+  },
+  {
+    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization works with different keys in parallel"
+  },
+  {
+    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects expired authorization"
+  },
+  {
+    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects expired authorization"
   },
   {
     "id": "ERC20Votes vote with blockNumber Compound test suite getPastVotes generally returns the voting balance at the appropriate checkpoint",
@@ -1267,19 +1173,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1301,19 +1195,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with blockNumber set delegation with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1391,19 +1273,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1420,19 +1290,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with timestamp set delegation with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1452,40 +1310,55 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature but mismatched value",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for expired deadline",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for non-current nonce",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas"
   },
   {
-    "id": "ERC2771Forwarder execute with valid requests emits an event and consumes nonce for a successful request",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas forced by the relayer",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "ERC2771Forwarder execute with valid requests reverts with an unsuccessful request",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address \"after each\" hook for \"ignores a request with a valid signature for expired deadline\""
   },
   {
-    "id": "ERC2771Forwarder executeBatch \"before each\" hook for \"sanity\"",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address ignores a request with a valid signature for expired deadline"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is the zero address reverts with at least one valid signature for expired deadline"
   },
   {
     "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for expired deadline",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for non-current nonce",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC3009 using blockNumber clock authorizationState returns true after the nonce is consumed"
   },
   {
-    "id": "ERC2771Forwarder verify with valid signature returns true without altering the nonce",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC3009 using blockNumber clock receiveWithAuthorization accepts holder signature when called by recipient"
+  },
+  {
+    "id": "ERC3009 using blockNumber clock receiveWithAuthorization rejects reused nonce with ERC3009UsedAuthorization"
+  },
+  {
+    "id": "ERC3009 using blockNumber clock transferWithAuthorization accepts random nonces in any order"
+  },
+  {
+    "id": "ERC3009 using blockNumber clock transferWithAuthorization emits AuthorizationUsed and Transfer with the expected balance changes"
+  },
+  {
+    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects reused nonce with ERC3009UsedAuthorization"
+  },
+  {
+    "id": "ERC3009 using blockNumber clock transferWithAuthorization supports validBefore that points to an value beyond the type(uint48).max"
+  },
+  {
+    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects at the validBefore boundary (current == validBefore)"
+  },
+  {
+    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects expired authorization"
   },
   {
     "id": "ERC6372Utils blockNumber clock mode from uint48",
@@ -1592,19 +1465,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1628,44 +1489,469 @@
     "cause": "gas-stub"
   },
   {
-    "id": "ERC7786Recipient receive multiple similar messages",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC-6372 behavior in blockNumber mode should have a correct clock value"
   },
   {
-    "id": "ERC7786Recipient receives gateway relayed messages",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is not supported uses less than 30k"
   },
   {
-    "id": "Governor using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is supported uses less than 30k gas"
   },
   {
-    "id": "Governor using $ERC20VotesLegacyMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after deadline"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after execution"
   },
   {
-    "id": "GovernorCountingFractional using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after proposal"
   },
   {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after vote"
   },
   {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after deadline"
   },
   {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after execution"
   },
   {
-    "id": "GovernorCrosschain \"before each\" hook for \"execute with executor\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20Votes cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20Votes deployment check"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes send ethers"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Executed"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20Votes vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20Votes vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC-6372 behavior in blockNumber mode should have a correct clock value"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is not supported uses less than 30k"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is supported uses less than 30k gas"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after proposal"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock deployment check"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock send ethers"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC-6372 behavior in timestamp mode should have a correct clock value"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is not supported uses less than 30k"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is supported uses less than 30k gas"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock send ethers"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight fractional then nominal"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if no weight remaining"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #1"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #2"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params spend more than available"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if vote type is invalid"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight twice"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight fractional then nominal"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if no weight remaining"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #1"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #2"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params spend more than available"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if vote type is invalid"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight twice"
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock cast override vote \"before each\" hook for \"override after delegate vote\""
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock cast override vote \"before each\" hook for \"override after delegate vote\""
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCrosschain execute with executor"
+  },
+  {
+    "id": "GovernorCrosschain reconfigure executor"
   },
   {
     "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\"",
@@ -1676,16 +1962,43 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorNoncesKeyed \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed on vote by signature \"before each\" hook for \"if signature does not match signer\""
   },
   {
-    "id": "GovernorPreventLateQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with a valid EIP-1271 signature"
   },
   {
-    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature with reason"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature with reason"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes Delay is extended to prevent last minute take-over"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes nominal workflow unaffected"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes onlyGovernance updates can setLateQuorumVoteExtension through governance"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock Delay is extended to prevent last minute take-over"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock nominal workflow unaffected"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock onlyGovernance updates can setLateQuorumVoteExtension through governance"
   },
   {
     "id": "GovernorProposalGuardian using $ERC20Votes \"before each\" hook for \"deployment check\"",
@@ -1696,12 +2009,10 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20Votes \"before each\" hook for \"sequential proposal ids\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSequentialProposalId using $ERC20Votes nominal workflow"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock \"before each\" hook for \"sequential proposal ids\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock nominal workflow"
   },
   {
     "id": "GovernorStorage using $ERC20Votes \"before each\" hook for \"queue and execute by id\"",
@@ -1714,12 +2025,28 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal is queued if super quorum is reached and eta is set"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is not reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is reached but vote fails"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal succeeds early when super quorum is reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal is queued if super quorum is reached and eta is set"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is not reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is reached but vote fails"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal succeeds early when super quorum is reached"
   },
   {
     "id": "GovernorTimelockAccess using $ERC20Votes \"before each\" hook for \"accepts ether transfers\"",
@@ -1742,44 +2069,175 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes \"before each\" hook for \"doesn't accept ether transfers\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel after queue prevents executing"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock \"before each\" hook for \"doesn't accept ether transfers\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel before queue prevents scheduling"
   },
   {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel on timelock is reflected on governor"
   },
   {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes clear queue of pending governor calls"
   },
   {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes nominal"
   },
   {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay can be executed through governance"
   },
   {
-    "id": "GovernorWithParams using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay is payable and can transfer eth to EOA"
   },
   {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay protected against other proposers"
   },
   {
-    "id": "LowLevelCall call with 64 bytes return in the scratch space calls the requested function with value and returns true",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance updateTimelock can be executed through governance to"
   },
   {
-    "id": "LowLevelCall call without any return calls the requested function with value and returns true",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes post deployment check"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed by another proposer"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if not queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if too early"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on queue if already queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel after queue prevents executing"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel before queue prevents scheduling"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel on timelock is reflected on governor"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock clear queue of pending governor calls"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock nominal"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay can be executed through governance"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay is payable and can transfer eth to EOA"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay protected against other proposers"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance updateTimelock can be executed through governance to"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed by another proposer"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if not queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if too early"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on queue if already queued"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes deployment check"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates can updateQuorumNumerator through governance"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates cannot updateQuorumNumerator over the maximum"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum not reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock deployment check"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates can updateQuorumNumerator through governance"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates cannot updateQuorumNumerator over the maximum"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum not reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes deployment check"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes proposal remains active until super quorum is reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes super quorum updates can update super quorum through governance"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock deployment check"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock proposal remains active until super quorum is reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock super quorum updates can update super quorum through governance"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes Voting with params is properly supported"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes nominal is unaffected"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if signature does not match signer"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if vote nonce is incorrect"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EIP-1271 signature signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EOA signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock Voting with params is properly supported"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if signature does not match signer"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if vote nonce is incorrect"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EIP-1271 signature signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EOA signatures"
   },
   {
     "id": "MerkleTree push pushing to a full tree reverts"
@@ -2845,11 +3303,58 @@
     "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
-    "id": "RelayedCall default (zero) salt direct call to the relayer"
+    "id": "RateLimiter RefillingBucket with some capacity consume consume one key does not affect another key"
   },
   {
-    "id": "RelayedCall default (zero) salt relayed call target success (with value)",
-    "cause": "insufficient-funds"
+    "id": "RateLimiter RefillingBucket with some capacity consume consume(0) is a no-op that returns true"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity fully refills after a window has elapsed"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity multiple consumes in the same block accumulate"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity refills linearly over time"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume one key does not affect another key"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume(0) is a no-op that returns true"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity updateSettings side effect on usage"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity updateSettings with window=0 collapses refill to a single second"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity used does not go below zero"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity used saturates to zero after a long idle"
+  },
+  {
+    "id": "RateLimiter RefillingBucket with some capacity using sync to mitigate updateSettings side effect"
+  },
+  {
+    "id": "RateLimiter SlidingWindow with some capacity consume after a full-window idle truncates cumulative history"
+  },
+  {
+    "id": "RateLimiter SlidingWindow with some capacity multiple consumes in the same block overwrite the checkpoint in place"
+  },
+  {
+    "id": "RateLimiter SlidingWindow with some capacity only consumptions outside the window drop out"
+  },
+  {
+    "id": "RateLimiter SlidingWindow with some capacity past consumptions drop out after the window elapses"
+  },
+  {
+    "id": "RateLimiter SlidingWindow with some capacity updateSettings with window=0 collapses window to a single second"
+  },
+  {
+    "id": "RelayedCall default (zero) salt direct call to the relayer"
   },
   {
     "id": "RelayedCall default (zero) salt relayer input format",
@@ -2861,10 +3366,6 @@
   {
     "id": "RelayedCall random salt input format",
     "cause": "hardhat_setBalance"
-  },
-  {
-    "id": "RelayedCall random salt relayed call target success (with value)",
-    "cause": "insufficient-funds"
   },
   {
     "id": "SafeERC20 with ERC1363 that returns no boolean values reverts on approveAndCallRelaxed"
@@ -2880,14 +3381,6 @@
   },
   {
     "id": "SafeERC20 with address that has no contract code reverts on increaseAllowance"
-  },
-  {
-    "id": "SignatureChecker (ERC1271) \"before all\" hook: deploying in \"SignatureChecker (ERC1271)\"",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "SimulateCall \"before each\" hook for \"automatic simulator deployment\"",
-    "cause": "insufficient-funds"
   },
   {
     "id": "Time Delay get & getFull",
@@ -3008,12 +3501,28 @@
     "id": "TrieProof verify verify transaction and receipt inclusion in block"
   },
   {
-    "id": "VestingWallet \"before each\" hook for \"rejects zero address for beneficiary\"",
-    "cause": "insufficient-funds"
+    "id": "VestingWallet vesting schedule ERC20 vesting check vesting schedule"
   },
   {
-    "id": "VestingWalletCliff \"before each\" hook for \"rejects a larger cliff than vesting duration\"",
-    "cause": "insufficient-funds"
+    "id": "VestingWallet vesting schedule ERC20 vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWallet vesting schedule Eth vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWallet vesting schedule Eth vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule ERC20 vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule ERC20 vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule Eth vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule Eth vesting execute vesting schedule"
   },
   {
     "id": "Votes vote with blockNumber ERC-6372 behavior in blockNumber mode should have a correct clock value",
@@ -3044,19 +3553,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3092,19 +3589,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3172,19 +3657,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3220,19 +3693,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -880,23 +880,45 @@
     "id": "Address functionCall with valid contract receiver reverts when the called function runs out of gas"
   },
   {
-    "id": "Arrays \"before each\" hook for \"sort reversed array\""
+    "id": "Address functionCallWithValue with non-zero value calls the requested function with existing value",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Arrays address sort [skip-on-coverage] address[] of length 384 \"after each\" hook for \"sort array for identical elements\""
+    "id": "Address functionCallWithValue with non-zero value calls the requested function with transaction funds",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Address functionCallWithValue with non-zero value reverts when calling non-payable functions",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Address sendValue when sender contract has funds \"before each\" hook for \"sends 0 wei\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Arrays \"before each\" hook for \"slice from start to end\""
   },
   {
     "id": "BeaconProxy bad beacon is not accepted non-compliant beacon"
   },
   {
-    "id": "BlockHeader current block"
+    "id": "BeaconProxy initialization payable initialization",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "BlockHeader reads all fields from pre-parsed list",
-    "cause": "execution reverted"
+    "id": "BeaconProxy initialization reverting initialization due to value",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x clone construct with value factory has enough balance",
+    "cause": "insufficient-funds"
   },
   {
     "id": "Clones with immutable args: 0x clone initialization with parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -904,7 +926,19 @@
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones with immutable args: 0x clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x cloneDeterministic construct with value factory has enough balance",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -912,7 +946,19 @@
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones with immutable args: 0x cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x11223344 clone construct with value factory has enough balance",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones with immutable args: 0x11223344 clone initialization with parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x11223344 clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -920,7 +966,19 @@
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones with immutable args: 0x11223344 clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x11223344 cloneDeterministic construct with value factory has enough balance",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -928,7 +986,19 @@
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones without immutable args clone construct with value factory has enough balance",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones without immutable args clone initialization with parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones without immutable args clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -936,11 +1006,31 @@
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones without immutable args clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones without immutable args cloneDeterministic construct with value factory has enough balance",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones without immutable args cloneDeterministic initialization with parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
+    "id": "Clones without immutable args cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
     "id": "Clones without immutable args cloneDeterministic initialization without parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Clones without immutable args cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "Create2 deploy deploys a contract with funds deposited in the factory",
     "cause": "insufficient-funds"
   },
   {
@@ -954,6 +1044,30 @@
   {
     "id": "CrosschainBridgeERC721 \"before each\" hook for \"token getters\"",
     "cause": "hardhat_setBalance"
+  },
+  {
+    "id": "ECDSA parse signature 65 and 64 bytes signatures",
+    "cause": "personal_sign"
+  },
+  {
+    "id": "ECDSA recover with valid signature using <signer>.sign returns a different address",
+    "cause": "personal_sign"
+  },
+  {
+    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature",
+    "cause": "personal_sign"
+  },
+  {
+    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature for arbitrary length message",
+    "cause": "personal_sign"
+  },
+  {
+    "id": "EIP712 with long name and version digest",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "EIP712 with short name and version digest",
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "ERC1155 like an ERC1155 ERC165 when the interfaceId is not supported uses less than 30k",
@@ -992,27 +1106,39 @@
     "cause": "gas-stub"
   },
   {
-    "id": "ERC1967Clones deterministic deployment (create2) initialization with parameters non payable when sending some balance reverts",
+    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones deterministic deployment (create2) initialization without parameters non payable when sending some balance reverts",
+    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones deterministic deployment (create2) without initialization when sending some balance reverts",
+    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones non-deterministic deployment (create) initialization with parameters non payable when sending some balance reverts",
+    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones non-deterministic deployment (create) initialization without parameters non payable when sending some balance reverts",
+    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones non-deterministic deployment (create) without initialization when sending some balance reverts",
+    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters non payable when sending some balance reverts",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC1967Proxy (unsafe) allowUninitialized is true without initialization when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
@@ -1040,75 +1166,19 @@
     "cause": "hardhat_setBalance"
   },
   {
+    "id": "ERC20Permit permit accepts owner signature",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC20Permit permit rejects expired permit",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization cancels the next nonce after consuming the previous one",
+    "id": "ERC20Permit permit rejects other signature",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization prevents usage of canceled authorization in transferWithAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization shares the keyed counter between transfer and receive",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization with bytes signature prevents usage of canceled authorization by an ERC1271 wallet",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects out-of-order nonces sharing the same key",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects reused signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature accepts ERC1271 wallet signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization accepts holder signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects out-of-order nonces sharing the same key",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects reused signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature accepts ERC1271 wallet signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature accepts holder signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization works with different keys in parallel",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects expired authorization",
+    "id": "ERC20Permit permit rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1197,7 +1267,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1219,7 +1301,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC20Votes vote with blockNumber set delegation with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1297,7 +1391,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1314,7 +1420,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC20Votes vote with timestamp set delegation with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC20Votes vote with timestamp set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1334,64 +1452,39 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature but mismatched value",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for expired deadline",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas"
+    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for non-current nonce",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas forced by the relayer",
-    "cause": "insufficient-funds"
+    "id": "ERC2771Forwarder execute with valid requests emits an event and consumes nonce for a successful request",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address \"after each\" hook for \"ignores a request with a valid signature for expired deadline\""
+    "id": "ERC2771Forwarder execute with valid requests reverts with an unsuccessful request",
+    "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address ignores a request with a valid signature for expired deadline"
-  },
-  {
-    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is the zero address reverts with at least one valid signature for expired deadline",
-    "cause": "insufficient-funds"
+    "id": "ERC2771Forwarder executeBatch \"before each\" hook for \"sanity\"",
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for expired deadline",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using blockNumber clock authorizationState returns true after the nonce is consumed",
+    "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for non-current nonce",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using blockNumber clock receiveWithAuthorization accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock receiveWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization accepts random nonces in any order",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization emits AuthorizationUsed and Transfer with the expected balance changes",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization supports validBefore that points to an value beyond the type(uint48).max",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects at the validBefore boundary (current == validBefore)",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects expired authorization",
+    "id": "ERC2771Forwarder verify with valid signature returns true without altering the nonce",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1499,7 +1592,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1523,466 +1628,44 @@
     "cause": "gas-stub"
   },
   {
-    "id": "Governor using $ERC20Votes ERC-6372 behavior in blockNumber mode should have a correct clock value"
+    "id": "ERC7786Recipient receive multiple similar messages",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is not supported uses less than 30k"
+    "id": "ERC7786Recipient receives gateway relayed messages",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is supported uses less than 30k gas"
+    "id": "Governor using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel internal after deadline"
+    "id": "Governor using $ERC20VotesLegacyMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel internal after execution"
+    "id": "Governor using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel internal after proposal"
+    "id": "GovernorCountingFractional using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel internal after vote"
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel public after deadline"
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel public after execution"
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "Governor using $ERC20Votes cancel public after vote"
-  },
-  {
-    "id": "Governor using $ERC20Votes cancel public after vote started"
-  },
-  {
-    "id": "Governor using $ERC20Votes deployment check"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20Votes nominal workflow"
-  },
-  {
-    "id": "Governor using $ERC20Votes onlyGovernance updates can setProposalThreshold to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingDelay through governance"
-  },
-  {
-    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingPeriod through governance"
-  },
-  {
-    "id": "Governor using $ERC20Votes onlyGovernance updates cannot setVotingPeriod to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20Votes send ethers"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if proposal was already executed"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if quorum is not reached"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if receiver revert with reason"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if receiver revert without reason"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if score not reached"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on execute if voting is not over"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on propose if proposer has below threshold votes"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on queue always"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on vote if support value is invalid"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on vote if vote was already casted"
-  },
-  {
-    "id": "Governor using $ERC20Votes should revert on vote if voting is over"
-  },
-  {
-    "id": "Governor using $ERC20Votes state Defeated"
-  },
-  {
-    "id": "Governor using $ERC20Votes state Executed"
-  },
-  {
-    "id": "Governor using $ERC20Votes state Pending & Active"
-  },
-  {
-    "id": "Governor using $ERC20Votes state Succeeded"
-  },
-  {
-    "id": "Governor using $ERC20Votes vote with signature votes with a valid EIP-1271 signature"
-  },
-  {
-    "id": "Governor using $ERC20Votes vote with signature votes with an EOA signature on two proposals"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock ERC-6372 behavior in blockNumber mode should have a correct clock value"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is not supported uses less than 30k"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is supported uses less than 30k gas"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel internal after deadline"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel internal after execution"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel internal after proposal"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel internal after vote"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel public after deadline"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel public after execution"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote started"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock deployment check"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock nominal workflow"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setProposalThreshold to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingDelay through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingPeriod through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock send ethers"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if proposal was already executed"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if quorum is not reached"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert with reason"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert without reason"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if score not reached"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if voting is not over"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on propose if proposer has below threshold votes"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on queue always"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if support value is invalid"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if vote was already casted"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if voting is over"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock state Defeated"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock state Executed"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock state Pending & Active"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock state Succeeded"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with a valid EIP-1271 signature"
-  },
-  {
-    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with an EOA signature on two proposals"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock ERC-6372 behavior in timestamp mode should have a correct clock value"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is not supported uses less than 30k"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is supported uses less than 30k gas"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel internal after deadline"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel internal after execution"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel internal after vote"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel public after deadline"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel public after execution"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote started"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix proposer can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix someone else can propose"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock nominal workflow"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setProposalThreshold to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingDelay through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingPeriod through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock send ethers"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if proposal was already executed"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if quorum is not reached"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert with reason"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert without reason"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if score not reached"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if voting is not over"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on propose if proposer has below threshold votes"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on queue always"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if vote was already casted"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if voting is over"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock state Defeated"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock state Executed"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock state Pending & Active"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock state Succeeded"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with a valid EIP-1271 signature"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with an EOA signature on two proposals"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes nominal is unaffected"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight fractional then nominal"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if no weight remaining"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #1"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #2"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params spend more than available"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if vote type is invalid"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight twice"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock nominal is unaffected"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight fractional then nominal"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if no weight remaining"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #1"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #2"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params spend more than available"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if vote type is invalid"
-  },
-  {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight twice"
-  },
-  {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock cast override vote \"before each\" hook for \"override after delegate vote\""
-  },
-  {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock nominal is unaffected"
-  },
-  {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock cast override vote \"before each\" hook for \"override after delegate vote\""
-  },
-  {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock nominal is unaffected"
-  },
-  {
-    "id": "GovernorCrosschain execute with executor"
-  },
-  {
-    "id": "GovernorCrosschain reconfigure executor"
+    "id": "GovernorCrosschain \"before each\" hook for \"execute with executor\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\"",
@@ -1993,43 +1676,16 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorNoncesKeyed on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "GovernorNoncesKeyed \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with a valid EIP-1271 signature"
+    "id": "GovernorPreventLateQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature"
-  },
-  {
-    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature with reason"
-  },
-  {
-    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with a valid EIP-1271 signature"
-  },
-  {
-    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature"
-  },
-  {
-    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature with reason"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20Votes Delay is extended to prevent last minute take-over"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20Votes nominal workflow unaffected"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20Votes onlyGovernance updates can setLateQuorumVoteExtension through governance"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock Delay is extended to prevent last minute take-over"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock nominal workflow unaffected"
-  },
-  {
-    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock onlyGovernance updates can setLateQuorumVoteExtension through governance"
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "GovernorProposalGuardian using $ERC20Votes \"before each\" hook for \"deployment check\"",
@@ -2040,10 +1696,12 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20Votes nominal workflow"
+    "id": "GovernorSequentialProposalId using $ERC20Votes \"before each\" hook for \"sequential proposal ids\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock nominal workflow"
+    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock \"before each\" hook for \"sequential proposal ids\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "GovernorStorage using $ERC20Votes \"before each\" hook for \"queue and execute by id\"",
@@ -2056,28 +1714,12 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20Votes proposal is queued if super quorum is reached and eta is set"
+    "id": "GovernorSuperQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is not reached"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is reached but vote fails"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20Votes proposal succeeds early when super quorum is reached"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal is queued if super quorum is reached and eta is set"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is not reached"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is reached but vote fails"
-  },
-  {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal succeeds early when super quorum is reached"
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "GovernorTimelockAccess using $ERC20Votes \"before each\" hook for \"accepts ether transfers\"",
@@ -2100,175 +1742,44 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel after queue prevents executing"
+    "id": "GovernorTimelockControl using $ERC20Votes \"before each\" hook for \"doesn't accept ether transfers\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel before queue prevents scheduling"
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock \"before each\" hook for \"doesn't accept ether transfers\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel on timelock is reflected on governor"
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes clear queue of pending governor calls"
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes nominal"
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay can be executed through governance"
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay is payable and can transfer eth to EOA"
+    "id": "GovernorWithParams using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay protected against other proposers"
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance updateTimelock can be executed through governance to"
+    "id": "LowLevelCall call with 64 bytes return in the scratch space calls the requested function with value and returns true",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes post deployment check"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed by another proposer"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if not queued"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if too early"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20Votes should revert on queue if already queued"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel after queue prevents executing"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel before queue prevents scheduling"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel on timelock is reflected on governor"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock clear queue of pending governor calls"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock nominal"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay can be executed through governance"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay is payable and can transfer eth to EOA"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay protected against other proposers"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance updateTimelock can be executed through governance to"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed by another proposer"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if not queued"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if too early"
-  },
-  {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on queue if already queued"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes deployment check"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates can updateQuorumNumerator through governance"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates cannot updateQuorumNumerator over the maximum"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum not reached"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum reached"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock deployment check"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates can updateQuorumNumerator through governance"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates cannot updateQuorumNumerator over the maximum"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum not reached"
-  },
-  {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum reached"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes deployment check"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes proposal remains active until super quorum is reached"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes super quorum updates can update super quorum through governance"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock deployment check"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock proposal remains active until super quorum is reached"
-  },
-  {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock super quorum updates can update super quorum through governance"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes Voting with params is properly supported"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes nominal is unaffected"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if signature does not match signer"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if vote nonce is incorrect"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EIP-1271 signature signatures"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EOA signatures"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock Voting with params is properly supported"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock nominal is unaffected"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if signature does not match signer"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if vote nonce is incorrect"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EIP-1271 signature signatures"
-  },
-  {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EOA signatures"
+    "id": "LowLevelCall call without any return calls the requested function with value and returns true",
+    "cause": "insufficient-funds"
   },
   {
     "id": "MerkleTree push pushing to a full tree reverts"
@@ -2276,1118 +1787,1069 @@
   {
     "id": "Packing extract / replace extract bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes1 + bytes1 => bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes10 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes12 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes2 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes22 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes6 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes10 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes12 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes16 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes20 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes4 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes8 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes12 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes16 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes4 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes6 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes8 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes10 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes2 => bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes20 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes22 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes4 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes6 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes8 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes12 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes2 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes4 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes8 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes10 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes2 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes6 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes24 + bytes4 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes24 + bytes8 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes28 + bytes4 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes12 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes16 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes2 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes20 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes24 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes28 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes4 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes6 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes8 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes10 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes16 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes2 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes22 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes4 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes6 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes12 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes16 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes2 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes20 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes24 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes4 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes8 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity consume consume one key does not affect another key"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity consume consume(0) is a no-op that returns true"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity fully refills after a window has elapsed"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity multiple consumes in the same block accumulate",
-    "cause": "nonce too low"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity refills linearly over time"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume one key does not affect another key"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity tryConsume tryConsume(0) is a no-op that returns true"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity updateSettings side effect on usage"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity updateSettings with window=0 collapses refill to a single second"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity used does not go below zero"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity used saturates to zero after a long idle"
-  },
-  {
-    "id": "RateLimiter RefillingBucket with some capacity using sync to mitigate updateSettings side effect"
-  },
-  {
-    "id": "RateLimiter SlidingWindow with some capacity consume after a full-window idle truncates cumulative history"
-  },
-  {
-    "id": "RateLimiter SlidingWindow with some capacity multiple consumes in the same block overwrite the checkpoint in place",
-    "cause": "execution reverted"
-  },
-  {
-    "id": "RateLimiter SlidingWindow with some capacity only consumptions outside the window drop out"
-  },
-  {
-    "id": "RateLimiter SlidingWindow with some capacity past consumptions drop out after the window elapses"
-  },
-  {
-    "id": "RateLimiter SlidingWindow with some capacity updateSettings with window=0 collapses window to a single second"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
   },
   {
     "id": "RelayedCall default (zero) salt direct call to the relayer"
+  },
+  {
+    "id": "RelayedCall default (zero) salt relayed call target success (with value)",
+    "cause": "insufficient-funds"
   },
   {
     "id": "RelayedCall default (zero) salt relayer input format",
@@ -3399,6 +2861,10 @@
   {
     "id": "RelayedCall random salt input format",
     "cause": "hardhat_setBalance"
+  },
+  {
+    "id": "RelayedCall random salt relayed call target success (with value)",
+    "cause": "insufficient-funds"
   },
   {
     "id": "SafeERC20 with ERC1363 that returns no boolean values reverts on approveAndCallRelaxed"
@@ -3414,6 +2880,14 @@
   },
   {
     "id": "SafeERC20 with address that has no contract code reverts on increaseAllowance"
+  },
+  {
+    "id": "SignatureChecker (ERC1271) \"before all\" hook: deploying in \"SignatureChecker (ERC1271)\"",
+    "cause": "personal_sign"
+  },
+  {
+    "id": "SimulateCall \"before each\" hook for \"automatic simulator deployment\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "Time Delay get & getFull",
@@ -3534,28 +3008,12 @@
     "id": "TrieProof verify verify transaction and receipt inclusion in block"
   },
   {
-    "id": "VestingWallet vesting schedule ERC20 vesting check vesting schedule"
+    "id": "VestingWallet \"before each\" hook for \"rejects zero address for beneficiary\"",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "VestingWallet vesting schedule ERC20 vesting execute vesting schedule"
-  },
-  {
-    "id": "VestingWallet vesting schedule Eth vesting check vesting schedule"
-  },
-  {
-    "id": "VestingWallet vesting schedule Eth vesting execute vesting schedule"
-  },
-  {
-    "id": "VestingWalletCliff vesting schedule ERC20 vesting check vesting schedule"
-  },
-  {
-    "id": "VestingWalletCliff vesting schedule ERC20 vesting execute vesting schedule"
-  },
-  {
-    "id": "VestingWalletCliff vesting schedule Eth vesting check vesting schedule"
-  },
-  {
-    "id": "VestingWalletCliff vesting schedule Eth vesting execute vesting schedule"
+    "id": "VestingWalletCliff \"before each\" hook for \"rejects a larger cliff than vesting duration\"",
+    "cause": "insufficient-funds"
   },
   {
     "id": "Votes vote with blockNumber ERC-6372 behavior in blockNumber mode should have a correct clock value",
@@ -3586,7 +3044,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3622,7 +3092,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3690,7 +3172,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3726,7 +3220,19 @@
     "cause": "eth_signTypedData_v4"
   },
   {
+    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
     "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {


### PR DESCRIPTION
… interface

The HandleTx method introduced a second block-handling interface alongside the existing Handle. This change removes it: AllTxBatchDispatcher now assembles a blocks.Block from the streamer events and calls the standard Handle, so LightKVS, VersionedDBWrapper, TxQueue, and TxQueueV2 lose their HandleTx implementations and the TxNotification.NsRWS/Events fields that only served them.