### PR TITLE
fix: pre-fund known Hardhat test accounts on testnode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,8 @@ jobs:
   oz-hardhat-compat:
     name: OZ Hardhat Compatibility
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Full suite needs headroom once more tests get past early failures.
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/endorser/config/config.go
+++ b/endorser/config/config.go
@@ -27,7 +27,7 @@ type Endorser struct {
 type DB struct {
 	Database    string `mapstructure:"database" yaml:"database"`
 	ConnString  string `mapstructure:"connection-string" yaml:"connection-string"`
-	HistorySize int    `mapstructure:"history_size" yaml:"history_size"` // number of historical snapshots to keep (default: 2, use 128 for test RPC)
+	HistorySize int    `mapstructure:"history_size" yaml:"history_size"` // number of historical snapshots to keep (default: 2; test RPC uses a large value)
 }
 
 // Validate checks that required fields are set and values are within acceptable ranges.

--- a/endorser/storage/revertible_lightkvs.go
+++ b/endorser/storage/revertible_lightkvs.go
@@ -49,56 +49,57 @@ func NewRevertibleLightKVS(lightKVS *LightKVS) *RevertibleLightKVS {
 // NewSnapshot starts a new read transaction and returns a Reader for the specified block number.
 // The Reader will see a consistent snapshot of the store at the requested block number.
 // If blockNumber is 0, it returns the current snapshot (latest state).
-// Otherwise, if the requested snapshot is in the past, the preserved snapshot is selected
-// by hop distance from the current block number.
+//
+// Historical lookups search history by block number (exact match, else the latest
+// preserved snapshot at or before the request). Hop-by-distance is wrong when
+// empty blocks leave no Update entry: Fabric block numbers then skip, and a
+// distance-based index misses snapshots that are still in the ring.
 // Readers must call Close() when done to allow garbage collection of old snapshots.
 func (kvs *RevertibleLightKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
 	current := kvs.Current.Load()
 	count := int(kvs.NextIndex.Load())
-	availableBlocks := make([]uint64, 0, count+1)
-	for i := 0; i < count; i++ {
-		snapshot := kvs.History[i].Load()
-		if snapshot != nil {
-			availableBlocks = append(availableBlocks, snapshot.BlockNumber)
-		}
-	}
-	availableBlocks = append(availableBlocks, current.BlockNumber)
-
-	revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() called: requested=%d current=%d historyCount=%d available=%v",
-		blockNumber, current.BlockNumber, count, availableBlocks)
 
 	if blockNumber == 0 || blockNumber >= current.BlockNumber {
-		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning current snapshot: requested=%d returned=%d available=%v",
-			blockNumber, current.BlockNumber, availableBlocks)
+		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning current snapshot: requested=%d returned=%d historyCount=%d",
+			blockNumber, current.BlockNumber, count)
 		return &Reader{
 			Snapshot: current,
 			Kvs:      kvs.LightKVS,
 		}, nil
 	}
 
-	distance := current.BlockNumber - blockNumber
-	if distance > uint64(count) {
-		err := fmt.Errorf("snapshot not found for block number %d", blockNumber)
-		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning error: requested=%d current=%d distance=%d historyCount=%d available=%v err=%v",
-			blockNumber, current.BlockNumber, distance, count, availableBlocks, err)
-		return nil, err
+	// Exact match on a preserved snapshot, else the nearest older one (state is
+	// unchanged across empty blocks that never called Update).
+	var best *Snapshot
+	for i := 0; i < count; i++ {
+		snap := kvs.History[i].Load()
+		if snap == nil {
+			continue
+		}
+		if snap.BlockNumber == blockNumber {
+			revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() exact history hit: requested=%d", blockNumber)
+			return &Reader{
+				Snapshot: snap,
+				Kvs:      kvs.LightKVS,
+			}, nil
+		}
+		if snap.BlockNumber < blockNumber && (best == nil || snap.BlockNumber > best.BlockNumber) {
+			best = snap
+		}
+	}
+	if best != nil {
+		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() nearest history hit: requested=%d returned=%d",
+			blockNumber, best.BlockNumber)
+		return &Reader{
+			Snapshot: best,
+			Kvs:      kvs.LightKVS,
+		}, nil
 	}
 
-	targetIndex := count - int(distance)
-	snapshot := kvs.History[targetIndex].Load()
-	if snapshot == nil {
-		err := fmt.Errorf("snapshot not found for block number %d", blockNumber)
-		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning error: requested=%d current=%d distance=%d targetIndex=%d historyCount=%d available=%v err=%v",
-			blockNumber, current.BlockNumber, distance, targetIndex, count, availableBlocks, err)
-		return nil, err
-	}
-
-	revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning historical snapshot: requested=%d returned=%d distance=%d targetIndex=%d historyCount=%d available=%v",
-		blockNumber, snapshot.BlockNumber, distance, targetIndex, count, availableBlocks)
-	return &Reader{
-		Snapshot: snapshot,
-		Kvs:      kvs.LightKVS,
-	}, nil
+	err := fmt.Errorf("snapshot not found for block number %d", blockNumber)
+	revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning error: requested=%d current=%d historyCount=%d err=%v",
+		blockNumber, current.BlockNumber, count, err)
+	return nil, err
 }
 
 // Update atomically applies a batch of updates to the store.

--- a/endorser/storage/revertible_lightkvs_test.go
+++ b/endorser/storage/revertible_lightkvs_test.go
@@ -201,6 +201,41 @@ func TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks(t *testing.T) {
 	if rec1 == nil || string(rec1.Value) != "v1" {
 		t.Fatalf("expected key1=v1 at block 1, got %+v", rec1)
 	}
+
+	// At or past current returns latest (v5).
+	rLatest, err := kvs.NewSnapshot(5)
+	if err != nil {
+		t.Fatalf("NewSnapshot(5): %v", err)
+	}
+	defer rLatest.Close()
+	recLatest, err := rLatest.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get latest: %v", err)
+	}
+	if recLatest == nil || string(recLatest.Value) != "v5" {
+		t.Fatalf("expected key1=v5 at block 5, got %+v", recLatest)
+	}
+}
+
+// TestRevertibleLightKVS_NewSnapshot_NotFound covers the error path when no
+// preserved snapshot is at or before the requested block (e.g. history slots
+// cleared while current has already advanced).
+func TestRevertibleLightKVS_NewSnapshot_NotFound(t *testing.T) {
+	kvs := NewRevertibleLightKVS(NewLightKVS(4))
+
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:key1", Value: []byte("v10"), BlockNum: 10, TxNum: 0, TxID: "tx10"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Drop the only history entry (pre-update empty snapshot) so nothing
+	// older than current remains.
+	kvs.History[0].Store(nil)
+
+	if _, err := kvs.NewSnapshot(3); err == nil {
+		t.Fatal("expected error when no history exists at or before block 3")
+	}
 }
 
 // TestRevertibleLightKVS_HistoryExhaustedPanics documents the deliberate trade-off:

--- a/endorser/storage/revertible_lightkvs_test.go
+++ b/endorser/storage/revertible_lightkvs_test.go
@@ -155,6 +155,54 @@ func TestRevertibleLightKVS_RevertThenContinue(t *testing.T) {
 	}
 }
 
+// TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks ensures historical reads
+// find state when Fabric block numbers advance without an Update for empty blocks
+// (hop-by-distance lookup used to miss those snapshots).
+func TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks(t *testing.T) {
+	kvs := NewRevertibleLightKVS(NewLightKVS(8))
+
+	// Blocks 1 and 5 wrote; 2–4 were empty (no Update).
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:key1", Value: []byte("v1"), BlockNum: 1, TxNum: 0, TxID: "tx1"},
+	}); err != nil {
+		t.Fatalf("Update block 1: %v", err)
+	}
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:key1", Value: []byte("v5"), BlockNum: 5, TxNum: 0, TxID: "tx5"},
+	}); err != nil {
+		t.Fatalf("Update block 5: %v", err)
+	}
+
+	// Read as-of block 3: no entry for 3, but state is still v1 from block 1.
+	reader, err := kvs.NewSnapshot(3)
+	if err != nil {
+		t.Fatalf("NewSnapshot(3): %v", err)
+	}
+	defer reader.Close()
+
+	rec, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" {
+		t.Fatalf("expected key1=v1 at block 3, got %+v", rec)
+	}
+
+	// Exact match at block 1 still works.
+	r1, err := kvs.NewSnapshot(1)
+	if err != nil {
+		t.Fatalf("NewSnapshot(1): %v", err)
+	}
+	defer r1.Close()
+	rec1, err := r1.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get at 1: %v", err)
+	}
+	if rec1 == nil || string(rec1.Value) != "v1" {
+		t.Fatalf("expected key1=v1 at block 1, got %+v", rec1)
+	}
+}
+
 // TestRevertibleLightKVS_HistoryExhaustedPanics documents the deliberate trade-off:
 // unlike plain LightKVS (which wraps forever), a revert-capable instance panics once
 // its bounded history window fills up, since a wrapping ring buffer can't guarantee

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -200,7 +200,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 		}
 
 		// Pre-fund known Hardhat test EOAs so value transfers pass the balance
-		// check (issue #254). Test-RPC / testnode only — production stays at zero.
+		// check (issue #254). Test RPC / testnode only. Production accounts stay at zero.
 		if err := testimpl.FundTestAccounts(ctx, lightKVS, cfg.Network.Namespace, testAccountMgr.Addresses, testimpl.DefaultTestAccountBalance); err != nil {
 			return nil, fmt.Errorf("failed to fund test accounts: %w", err)
 		}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -96,8 +96,10 @@ func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableT
 	endorserSyncs := make([]*network.Synchronizer, 0, len(cfg.Endorsers))
 	var firstKVS estorage.KVS // Keep first endorser's KVS for test server
 	for i, ecfg := range cfg.Endorsers {
+		// Test RPC needs a large sequential history window (see testnode); production
+		// only needs a couple of snapshots for the synchronizer.
 		if enableTestRPC {
-			ecfg.Database.HistorySize = 128
+			ecfg.Database.HistorySize = 16384
 		} else if ecfg.Database.HistorySize == 0 {
 			ecfg.Database.HistorySize = 2
 		}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -197,6 +197,13 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 			return nil, fmt.Errorf("failed to load test accounts: %w", err)
 		}
 
+		// Pre-fund known Hardhat test EOAs so value transfers pass the balance
+		// check (issue #254). Test-RPC / testnode only — production stays at zero.
+		if err := testimpl.FundTestAccounts(lightKVS, cfg.Network.Namespace, testAccountMgr.Addresses, testimpl.DefaultTestAccountBalance); err != nil {
+			return nil, fmt.Errorf("failed to fund test accounts: %w", err)
+		}
+		appLogger.Infof("Funded %d test accounts with %s wei each", len(testAccountMgr.Addresses), testimpl.DefaultTestAccountBalance.String())
+
 		revertibleKVS, ok := lightKVS.(estorage.Revertible)
 		if !ok {
 			return nil, fmt.Errorf("test RPC enabled but lightKVS is not Revertible")

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -201,7 +201,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 
 		// Pre-fund known Hardhat test EOAs so value transfers pass the balance
 		// check (issue #254). Test-RPC / testnode only — production stays at zero.
-		if err := testimpl.FundTestAccounts(lightKVS, cfg.Network.Namespace, testAccountMgr.Addresses, testimpl.DefaultTestAccountBalance); err != nil {
+		if err := testimpl.FundTestAccounts(ctx, lightKVS, cfg.Network.Namespace, testAccountMgr.Addresses, testimpl.DefaultTestAccountBalance); err != nil {
 			return nil, fmt.Errorf("failed to fund test accounts: %w", err)
 		}
 		appLogger.Infof("Funded %d test accounts with %s wei each", len(testAccountMgr.Addresses), testimpl.DefaultTestAccountBalance.String())

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -67,8 +67,10 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 		ChainConfig: common.BuildChainConfig(tcfg.ChainID),
 	}
 
-	// HistorySize=128 gives evm_snapshot/evm_revert enough history to rewind through.
-	endorserDB := econfig.DB{Database: "memory", HistorySize: 128}
+	// Large sequential history for the full OZ Hardhat suite: RevertibleLightKVS
+	// does not wrap, and loadFixture stretches can commit far more than 128 blocks
+	// between reverts. Undersizing panics or drops historical reads mid-suite.
+	endorserDB := econfig.DB{Database: "memory", HistorySize: 16384}
 	endorser, endorserKVS, _, err := eapp.NewEndorserCore(endorserDB, testNodeChannel, testNodeNamespace, protocol, signer, evmConfig, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endorser: %w", err)

--- a/gateway/app/testnode_fund_test.go
+++ b/gateway/app/testnode_fund_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-evm/gateway/testimpl"
+)
+
+// TestNewTestNode_PrefundsHardhatAccounts verifies issue #254: known Hardhat
+// EOAs receive the default genesis balance on testnode startup so value
+// transfers are not rejected with insufficient funds.
+func TestNewTestNode_PrefundsHardhatAccounts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	application, err := NewTestNode(ctx, TestNodeConfig{
+		Listen:  "127.0.0.1:0",
+		ChainID: 31337,
+	})
+	if err != nil {
+		t.Fatalf("NewTestNode: %v", err)
+	}
+
+	mgr, err := testimpl.DefaultTestAccounts()
+	if err != nil {
+		t.Fatalf("DefaultTestAccounts: %v", err)
+	}
+
+	gw := application.Gateway()
+	for _, addr := range mgr.Addresses {
+		bal, err := gw.BalanceAt(ctx, addr, nil)
+		if err != nil {
+			t.Fatalf("BalanceAt(%s): %v", addr.Hex(), err)
+		}
+		if bal.Cmp(testimpl.DefaultTestAccountBalance) != 0 {
+			t.Errorf("balance of %s = %s, want %s", addr.Hex(), bal, testimpl.DefaultTestAccountBalance)
+		}
+	}
+}

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -111,15 +111,16 @@ func (cfg Config) Validate() error {
 		for i := range cfg.Endorsers {
 			errs = append(errs, cfg.Endorsers[i].Validate())
 
-      // Checked here rather than in Endorser.Validate because the backend and
-		  // the protocol it has to agree with live at different config levels.
-		  // Skipped when the protocol itself is already invalid, so one bad
-		  // protocol value is not also reported once per endorser.
-		  if protocolErr == nil {
-			  if err := endorser.ValidateDatabaseProtocol(cfg.Endorsers[i].Database.Database, cfg.Network.Protocol); err != nil {
-				  errs = append(errs, fmt.Errorf("endorsers[%d]: %w", i, err))
-		    }
-      }
+			// Checked here rather than in Endorser.Validate because the backend and
+			// the protocol it has to agree with live at different config levels.
+			// Skipped when the protocol itself is already invalid, so one bad
+			// protocol value is not also reported once per endorser.
+			if protocolErr == nil {
+				if err := endorser.ValidateDatabaseProtocol(cfg.Endorsers[i].Database.Database, cfg.Network.Protocol); err != nil {
+					errs = append(errs, fmt.Errorf("endorsers[%d]: %w", i, err))
+				}
+			}
+		}
 	} else {
 		for i, e := range cfg.Gateway.Endorsers {
 			if err := e.Validate(); err != nil {

--- a/gateway/testimpl/fund_accounts.go
+++ b/gateway/testimpl/fund_accounts.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+
+WARNING: This package contains test-only/unsafe RPC implementations.
+DO NOT use in production environments.
+*/
+
+package testimpl
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
+)
+
+// DefaultTestAccountBalance is Hardhat Network's default genesis balance per
+// account: 10_000 ETH. Matches @nomicfoundation/hardhat-network-helpers and
+// testdata/openzeppelin-contracts/test/helpers/account.js.
+var DefaultTestAccountBalance = new(big.Int).Mul(big.NewInt(10_000), big.NewInt(params.Ether))
+
+// FundTestAccounts seeds native ETH balances for the given addresses into the
+// endorser KVS. Intended for test-RPC / testnode startup only: production
+// accounts correctly start at zero.
+//
+// Writes land in the current snapshot in place (no history advance), so the
+// funded balances look like genesis state and survive later Handle/Update
+// clones as well as reverts that restore pre-funding block numbers.
+//
+// kvs must be *estorage.LightKVS or *estorage.RevertibleLightKVS (memory DB).
+func FundTestAccounts(kvs estorage.KVS, namespace string, addresses []common.Address, balance *big.Int) error {
+	if balance == nil || balance.Sign() <= 0 {
+		return nil
+	}
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	snap, err := currentSnapshot(kvs)
+	if err != nil {
+		return err
+	}
+
+	balBytes := balance.Bytes()
+	for _, addr := range addresses {
+		// Key layout matches LightKVS.Reader.Get / collectWrites:
+		// fullKey = namespace + ":" + accKey(addr, "bal")
+		// accKey  = "acc:" + addr.Hex() + ":bal"
+		key := namespace + ":acc:" + addr.Hex() + ":bal"
+		// Copy bytes so callers can reuse the balance buffer later.
+		val := append([]byte(nil), balBytes...)
+		snap.Data[key] = &estorage.ValueVersion{
+			Value:    val,
+			BlockNum: snap.BlockNumber,
+			TxNum:    0,
+			Version:  0,
+			TxID:     "test-account-funding",
+		}
+	}
+	return nil
+}
+
+func currentSnapshot(kvs estorage.KVS) (*estorage.Snapshot, error) {
+	switch k := kvs.(type) {
+	case *estorage.RevertibleLightKVS:
+		if k.LightKVS == nil {
+			return nil, fmt.Errorf("fund test accounts: RevertibleLightKVS has nil LightKVS")
+		}
+		snap := k.Current.Load()
+		if snap == nil {
+			return nil, fmt.Errorf("fund test accounts: KVS has no current snapshot")
+		}
+		return snap, nil
+	case *estorage.LightKVS:
+		snap := k.Current.Load()
+		if snap == nil {
+			return nil, fmt.Errorf("fund test accounts: KVS has no current snapshot")
+		}
+		return snap, nil
+	default:
+		return nil, fmt.Errorf("fund test accounts: KVS type %T does not support in-place funding (need memory LightKVS)", kvs)
+	}
+}

--- a/gateway/testimpl/fund_accounts.go
+++ b/gateway/testimpl/fund_accounts.go
@@ -10,12 +10,17 @@ DO NOT use in production environments.
 package testimpl
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
 )
 
 // DefaultTestAccountBalance is Hardhat Network's default genesis balance per
@@ -27,12 +32,13 @@ var DefaultTestAccountBalance = new(big.Int).Mul(big.NewInt(10_000), big.NewInt(
 // endorser KVS. Intended for test-RPC / testnode startup only: production
 // accounts correctly start at zero.
 //
-// Writes land in the current snapshot in place (no history advance), so the
-// funded balances look like genesis state and survive later Handle/Update
-// clones as well as reverts that restore pre-funding block numbers.
-//
-// kvs must be *estorage.LightKVS or *estorage.RevertibleLightKVS (memory DB).
+// Balances are applied through the normal StateDB write path and committed with
+// KVS.Handle on a synthetic block, so versions and keys match real commits and
+// any KVS backend that implements Handle works (not only LightKVS in place).
 func FundTestAccounts(kvs estorage.KVS, namespace string, addresses []common.Address, balance *big.Int) error {
+	if kvs == nil {
+		return fmt.Errorf("fund test accounts: nil KVS")
+	}
 	if balance == nil || balance.Sign() <= 0 {
 		return nil
 	}
@@ -40,48 +46,56 @@ func FundTestAccounts(kvs estorage.KVS, namespace string, addresses []common.Add
 		return nil
 	}
 
-	snap, err := currentSnapshot(kvs)
+	ctx := context.Background()
+
+	// Latest snapshot (block 0 means latest on current KVS APIs).
+	reader, err := kvs.NewSnapshot(0)
 	if err != nil {
-		return err
+		return fmt.Errorf("fund test accounts: snapshot: %w", err)
+	}
+	defer reader.Close()
+
+	stateDB, err := execution.NewStateDB(ctx, reader, namespace, 0, true)
+	if err != nil {
+		return fmt.Errorf("fund test accounts: statedb: %w", err)
 	}
 
-	balBytes := balance.Bytes()
+	amount := uint256.MustFromBig(balance)
 	for _, addr := range addresses {
-		// Key layout matches LightKVS.Reader.Get / collectWrites:
-		// fullKey = namespace + ":" + accKey(addr, "bal")
-		// accKey  = "acc:" + addr.Hex() + ":bal"
-		key := namespace + ":acc:" + addr.Hex() + ":bal"
-		// Copy bytes so callers can reuse the balance buffer later.
-		val := append([]byte(nil), balBytes...)
-		snap.Data[key] = &estorage.ValueVersion{
-			Value:    val,
-			BlockNum: snap.BlockNumber,
-			TxNum:    0,
-			Version:  0,
-			TxID:     "test-account-funding",
-		}
+		stateDB.CreateAccount(addr)
+		stateDB.AddBalance(addr, amount, tracing.BalanceChangeUnspecified)
+	}
+
+	rws := stateDB.Result()
+	if len(rws.Writes) == 0 {
+		return fmt.Errorf("fund test accounts: statedb produced no writes")
+	}
+
+	blockNum, err := kvs.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("fund test accounts: block number: %w", err)
+	}
+
+	// Synthetic block through the same Handle path real commits use, so Update
+	// assigns versions and any BlockHandler-backed KVS accepts the writes.
+	block := blocks.Block{
+		Number: blockNum,
+		Transactions: []blocks.Transaction{
+			{
+				ID:     "test-account-funding",
+				Number: 0,
+				Valid:  true,
+				NsRWS: []blocks.NsReadWriteSet{
+					{
+						Namespace: namespace,
+						RWS:       rws,
+					},
+				},
+			},
+		},
+	}
+	if err := kvs.Handle(ctx, block); err != nil {
+		return fmt.Errorf("fund test accounts: handle: %w", err)
 	}
 	return nil
-}
-
-func currentSnapshot(kvs estorage.KVS) (*estorage.Snapshot, error) {
-	switch k := kvs.(type) {
-	case *estorage.RevertibleLightKVS:
-		if k.LightKVS == nil {
-			return nil, fmt.Errorf("fund test accounts: RevertibleLightKVS has nil LightKVS")
-		}
-		snap := k.Current.Load()
-		if snap == nil {
-			return nil, fmt.Errorf("fund test accounts: KVS has no current snapshot")
-		}
-		return snap, nil
-	case *estorage.LightKVS:
-		snap := k.Current.Load()
-		if snap == nil {
-			return nil, fmt.Errorf("fund test accounts: KVS has no current snapshot")
-		}
-		return snap, nil
-	default:
-		return nil, fmt.Errorf("fund test accounts: KVS type %T does not support in-place funding (need memory LightKVS)", kvs)
-	}
 }

--- a/gateway/testimpl/fund_accounts.go
+++ b/gateway/testimpl/fund_accounts.go
@@ -35,7 +35,7 @@ var DefaultTestAccountBalance = new(big.Int).Mul(big.NewInt(10_000), big.NewInt(
 // Balances are applied through the normal StateDB write path and committed with
 // KVS.Handle on a synthetic block, so versions and keys match real commits and
 // any KVS backend that implements Handle works (not only LightKVS in place).
-func FundTestAccounts(kvs estorage.KVS, namespace string, addresses []common.Address, balance *big.Int) error {
+func FundTestAccounts(ctx context.Context, kvs estorage.KVS, namespace string, addresses []common.Address, balance *big.Int) error {
 	if kvs == nil {
 		return fmt.Errorf("fund test accounts: nil KVS")
 	}
@@ -45,8 +45,6 @@ func FundTestAccounts(kvs estorage.KVS, namespace string, addresses []common.Add
 	if len(addresses) == 0 {
 		return nil
 	}
-
-	ctx := context.Background()
 
 	// Latest snapshot (block 0 means latest on current KVS APIs).
 	reader, err := kvs.NewSnapshot(0)

--- a/gateway/testimpl/fund_accounts_test.go
+++ b/gateway/testimpl/fund_accounts_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
+	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
+)
+
+const testNS = "basic"
+
+func TestDefaultTestAccountBalance_IsHardhatDefault(t *testing.T) {
+	want := new(big.Int).Mul(big.NewInt(10_000), big.NewInt(params.Ether))
+	if DefaultTestAccountBalance.Cmp(want) != 0 {
+		t.Fatalf("DefaultTestAccountBalance = %s, want %s", DefaultTestAccountBalance, want)
+	}
+}
+
+func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
+	kvs := estorage.NewRevertibleLightKVS(estorage.NewLightKVS(8))
+	addrs := []common.Address{
+		common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+		common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+	}
+	balance := new(big.Int).Mul(big.NewInt(10_000), big.NewInt(params.Ether))
+
+	if err := FundTestAccounts(kvs, testNS, addrs, balance); err != nil {
+		t.Fatalf("FundTestAccounts: %v", err)
+	}
+
+	// History must not advance — funding is genesis-like, not a new block.
+	if n := kvs.NextIndex.Load(); n != 0 {
+		t.Fatalf("NextIndex = %d after fund, want 0 (no history advance)", n)
+	}
+
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	defer reader.Close()
+
+	stateDB, err := execution.NewStateDB(context.Background(), reader, testNS, 0, true)
+	if err != nil {
+		t.Fatalf("NewStateDB: %v", err)
+	}
+
+	for _, addr := range addrs {
+		got := stateDB.GetBalance(addr).ToBig()
+		if got.Cmp(balance) != 0 {
+			t.Errorf("balance of %s = %s, want %s", addr.Hex(), got, balance)
+		}
+		if !stateDB.Exist(addr) {
+			t.Errorf("account %s should Exist after funding", addr.Hex())
+		}
+	}
+
+	// Unfunded address stays at zero.
+	other := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	if got := stateDB.GetBalance(other).ToBig(); got.Sign() != 0 {
+		t.Errorf("unfunded account balance = %s, want 0", got)
+	}
+}
+
+func TestFundTestAccounts_DefaultAccounts(t *testing.T) {
+	kvs := estorage.NewLightKVS(4)
+	mgr, err := DefaultTestAccounts()
+	if err != nil {
+		t.Fatalf("DefaultTestAccounts: %v", err)
+	}
+	if len(mgr.Addresses) == 0 {
+		t.Fatal("expected Hardhat test accounts, got none")
+	}
+
+	if err := FundTestAccounts(kvs, testNS, mgr.Addresses, DefaultTestAccountBalance); err != nil {
+		t.Fatalf("FundTestAccounts: %v", err)
+	}
+
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	defer reader.Close()
+
+	// Spot-check via KVS Get (namespace-qualified key path used by StateDB).
+	for _, addr := range mgr.Addresses {
+		rec, err := reader.Get(testNS, "acc:"+addr.Hex()+":bal")
+		if err != nil {
+			t.Fatalf("Get bal for %s: %v", addr.Hex(), err)
+		}
+		if rec == nil || len(rec.Value) == 0 {
+			t.Fatalf("missing balance for %s", addr.Hex())
+		}
+		got := new(big.Int).SetBytes(rec.Value)
+		if got.Cmp(DefaultTestAccountBalance) != 0 {
+			t.Errorf("%s balance = %s, want %s", addr.Hex(), got, DefaultTestAccountBalance)
+		}
+	}
+}
+
+func TestFundTestAccounts_NoopOnZeroOrEmpty(t *testing.T) {
+	kvs := estorage.NewLightKVS(2)
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+
+	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, big.NewInt(0)); err != nil {
+		t.Fatalf("zero balance: %v", err)
+	}
+	if err := FundTestAccounts(kvs, testNS, nil, DefaultTestAccountBalance); err != nil {
+		t.Fatalf("empty addrs: %v", err)
+	}
+	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, nil); err != nil {
+		t.Fatalf("nil balance: %v", err)
+	}
+
+	snap := kvs.Current.Load()
+	if len(snap.Data) != 0 {
+		t.Fatalf("expected no keys written, got %d", len(snap.Data))
+	}
+}
+
+func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
+	kvs := estorage.NewLightKVS(4)
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, DefaultTestAccountBalance); err != nil {
+		t.Fatalf("FundTestAccounts: %v", err)
+	}
+
+	// Simulate a later block write (unrelated key) — funded balance must clone through.
+	if err := kvs.Update([]estorage.KeyValueVersion{{
+		Key:      testNS + ":str:" + addr.Hex() + ":0x00",
+		Value:    []byte{1},
+		BlockNum: 1,
+		TxNum:    0,
+		TxID:     "tx-1",
+	}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	defer reader.Close()
+
+	rec, err := reader.Get(testNS, "acc:"+addr.Hex()+":bal")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("balance key missing after Update clone")
+	}
+	got := new(big.Int).SetBytes(rec.Value)
+	if got.Cmp(DefaultTestAccountBalance) != 0 {
+		t.Fatalf("balance after Update = %s, want %s", got, DefaultTestAccountBalance)
+	}
+}
+
+func TestFundTestAccounts_UnsupportedKVS(t *testing.T) {
+	// VersionedDBWrapper is not supported for in-place funding.
+	err := FundTestAccounts(nil, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
+	if err == nil {
+		t.Fatal("expected error for nil/unsupported KVS")
+	}
+}

--- a/gateway/testimpl/fund_accounts_test.go
+++ b/gateway/testimpl/fund_accounts_test.go
@@ -171,3 +171,38 @@ func TestFundTestAccounts_UnsupportedKVS(t *testing.T) {
 		t.Fatal("expected error for nil/unsupported KVS")
 	}
 }
+
+func TestFundTestAccounts_NilEmbeddedLightKVS(t *testing.T) {
+	kvs := &estorage.RevertibleLightKVS{} // LightKVS unset
+	err := FundTestAccounts(kvs, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
+	if err == nil {
+		t.Fatal("expected error for nil embedded LightKVS")
+	}
+}
+
+func TestFundTestAccounts_NilCurrentSnapshot(t *testing.T) {
+	base := estorage.NewLightKVS(2)
+	base.Current.Store(nil)
+	err := FundTestAccounts(base, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
+	if err == nil {
+		t.Fatal("expected error when current snapshot is nil")
+	}
+
+	rev := estorage.NewRevertibleLightKVS(estorage.NewLightKVS(2))
+	rev.Current.Store(nil)
+	err = FundTestAccounts(rev, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
+	if err == nil {
+		t.Fatal("expected error when revertible current snapshot is nil")
+	}
+}
+
+func TestFundTestAccounts_NegativeBalanceIsNoop(t *testing.T) {
+	kvs := estorage.NewLightKVS(2)
+	err := FundTestAccounts(kvs, testNS, []common.Address{{1}}, big.NewInt(-1))
+	if err != nil {
+		t.Fatalf("negative balance: %v", err)
+	}
+	if len(kvs.Current.Load().Data) != 0 {
+		t.Fatal("expected no keys for negative balance")
+	}
+}

--- a/gateway/testimpl/fund_accounts_test.go
+++ b/gateway/testimpl/fund_accounts_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package testimpl
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -19,13 +18,6 @@ import (
 
 const testNS = "basic"
 
-func TestDefaultTestAccountBalance_IsHardhatDefault(t *testing.T) {
-	want := new(big.Int).Mul(big.NewInt(10_000), big.NewInt(params.Ether))
-	if DefaultTestAccountBalance.Cmp(want) != 0 {
-		t.Fatalf("DefaultTestAccountBalance = %s, want %s", DefaultTestAccountBalance, want)
-	}
-}
-
 func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
 	kvs := estorage.NewRevertibleLightKVS(estorage.NewLightKVS(8))
 	addrs := []common.Address{
@@ -34,7 +26,7 @@ func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
 	}
 	balance := new(big.Int).Mul(big.NewInt(10_000), big.NewInt(params.Ether))
 
-	if err := FundTestAccounts(kvs, testNS, addrs, balance); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, addrs, balance); err != nil {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
@@ -44,7 +36,7 @@ func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
 	}
 	defer reader.Close()
 
-	stateDB, err := execution.NewStateDB(context.Background(), reader, testNS, 0, true)
+	stateDB, err := execution.NewStateDB(t.Context(), reader, testNS, 0, true)
 	if err != nil {
 		t.Fatalf("NewStateDB: %v", err)
 	}
@@ -76,7 +68,7 @@ func TestFundTestAccounts_DefaultAccounts(t *testing.T) {
 		t.Fatal("expected Hardhat test accounts, got none")
 	}
 
-	if err := FundTestAccounts(kvs, testNS, mgr.Addresses, DefaultTestAccountBalance); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, mgr.Addresses, DefaultTestAccountBalance); err != nil {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
@@ -99,10 +91,6 @@ func TestFundTestAccounts_DefaultAccounts(t *testing.T) {
 		if got.Cmp(DefaultTestAccountBalance) != 0 {
 			t.Errorf("%s balance = %s, want %s", addr.Hex(), got, DefaultTestAccountBalance)
 		}
-		// Handle path must assign a real version (not a hardcoded 0 forever).
-		if rec.Version != 0 {
-			// First write is version 0; fine. Just ensure field is populated.
-		}
 		if rec.TxID != "test-account-funding" {
 			t.Errorf("%s TxID = %q, want test-account-funding", addr.Hex(), rec.TxID)
 		}
@@ -113,13 +101,13 @@ func TestFundTestAccounts_NoopOnZeroOrEmpty(t *testing.T) {
 	kvs := estorage.NewLightKVS(2)
 	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 
-	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, big.NewInt(0)); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, big.NewInt(0)); err != nil {
 		t.Fatalf("zero balance: %v", err)
 	}
-	if err := FundTestAccounts(kvs, testNS, nil, DefaultTestAccountBalance); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, nil, DefaultTestAccountBalance); err != nil {
 		t.Fatalf("empty addrs: %v", err)
 	}
-	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, nil); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, nil); err != nil {
 		t.Fatalf("nil balance: %v", err)
 	}
 
@@ -132,7 +120,7 @@ func TestFundTestAccounts_NoopOnZeroOrEmpty(t *testing.T) {
 func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
 	kvs := estorage.NewLightKVS(4)
 	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, DefaultTestAccountBalance); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, DefaultTestAccountBalance); err != nil {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
@@ -167,7 +155,7 @@ func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
 }
 
 func TestFundTestAccounts_NilKVS(t *testing.T) {
-	err := FundTestAccounts(nil, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
+	err := FundTestAccounts(t.Context(), nil, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
 	if err == nil {
 		t.Fatal("expected error for nil KVS")
 	}
@@ -175,7 +163,7 @@ func TestFundTestAccounts_NilKVS(t *testing.T) {
 
 func TestFundTestAccounts_NegativeBalanceIsNoop(t *testing.T) {
 	kvs := estorage.NewLightKVS(2)
-	err := FundTestAccounts(kvs, testNS, []common.Address{{1}}, big.NewInt(-1))
+	err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{{1}}, big.NewInt(-1))
 	if err != nil {
 		t.Fatalf("negative balance: %v", err)
 	}
@@ -190,7 +178,7 @@ func TestFundTestAccounts_UsesHandleVersions(t *testing.T) {
 	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 	half := new(big.Int).Mul(big.NewInt(5_000), big.NewInt(params.Ether))
 
-	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, half); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, half); err != nil {
 		t.Fatalf("first fund: %v", err)
 	}
 	reader, err := kvs.NewSnapshot(0)
@@ -207,7 +195,7 @@ func TestFundTestAccounts_UsesHandleVersions(t *testing.T) {
 	}
 
 	// Second fund AddBalances again (creates a new write through Handle).
-	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, half); err != nil {
+	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, half); err != nil {
 		t.Fatalf("second fund: %v", err)
 	}
 	reader, err = kvs.NewSnapshot(0)

--- a/gateway/testimpl/fund_accounts_test.go
+++ b/gateway/testimpl/fund_accounts_test.go
@@ -38,11 +38,6 @@ func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
-	// History must not advance — funding is genesis-like, not a new block.
-	if n := kvs.NextIndex.Load(); n != 0 {
-		t.Fatalf("NextIndex = %d after fund, want 0 (no history advance)", n)
-	}
-
 	reader, err := kvs.NewSnapshot(0)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
@@ -104,6 +99,13 @@ func TestFundTestAccounts_DefaultAccounts(t *testing.T) {
 		if got.Cmp(DefaultTestAccountBalance) != 0 {
 			t.Errorf("%s balance = %s, want %s", addr.Hex(), got, DefaultTestAccountBalance)
 		}
+		// Handle path must assign a real version (not a hardcoded 0 forever).
+		if rec.Version != 0 {
+			// First write is version 0; fine. Just ensure field is populated.
+		}
+		if rec.TxID != "test-account-funding" {
+			t.Errorf("%s TxID = %q, want test-account-funding", addr.Hex(), rec.TxID)
+		}
 	}
 }
 
@@ -134,7 +136,7 @@ func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
-	// Simulate a later block write (unrelated key) — funded balance must clone through.
+	// Simulate a later block write (unrelated key); funded balance must clone through.
 	if err := kvs.Update([]estorage.KeyValueVersion{{
 		Key:      testNS + ":str:" + addr.Hex() + ":0x00",
 		Value:    []byte{1},
@@ -164,35 +166,10 @@ func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
 	}
 }
 
-func TestFundTestAccounts_UnsupportedKVS(t *testing.T) {
-	// VersionedDBWrapper is not supported for in-place funding.
+func TestFundTestAccounts_NilKVS(t *testing.T) {
 	err := FundTestAccounts(nil, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
 	if err == nil {
-		t.Fatal("expected error for nil/unsupported KVS")
-	}
-}
-
-func TestFundTestAccounts_NilEmbeddedLightKVS(t *testing.T) {
-	kvs := &estorage.RevertibleLightKVS{} // LightKVS unset
-	err := FundTestAccounts(kvs, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
-	if err == nil {
-		t.Fatal("expected error for nil embedded LightKVS")
-	}
-}
-
-func TestFundTestAccounts_NilCurrentSnapshot(t *testing.T) {
-	base := estorage.NewLightKVS(2)
-	base.Current.Store(nil)
-	err := FundTestAccounts(base, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
-	if err == nil {
-		t.Fatal("expected error when current snapshot is nil")
-	}
-
-	rev := estorage.NewRevertibleLightKVS(estorage.NewLightKVS(2))
-	rev.Current.Store(nil)
-	err = FundTestAccounts(rev, testNS, []common.Address{{1}}, DefaultTestAccountBalance)
-	if err == nil {
-		t.Fatal("expected error when revertible current snapshot is nil")
+		t.Fatal("expected error for nil KVS")
 	}
 }
 
@@ -204,5 +181,50 @@ func TestFundTestAccounts_NegativeBalanceIsNoop(t *testing.T) {
 	}
 	if len(kvs.Current.Load().Data) != 0 {
 		t.Fatal("expected no keys for negative balance")
+	}
+}
+
+func TestFundTestAccounts_UsesHandleVersions(t *testing.T) {
+	// Two funding rounds for the same account should bump the key version via Update.
+	kvs := estorage.NewLightKVS(4)
+	addr := common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+	half := new(big.Int).Mul(big.NewInt(5_000), big.NewInt(params.Ether))
+
+	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, half); err != nil {
+		t.Fatalf("first fund: %v", err)
+	}
+	reader, err := kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	rec1, err := reader.Get(testNS, "acc:"+addr.Hex()+":bal")
+	reader.Close()
+	if err != nil || rec1 == nil {
+		t.Fatalf("first bal: rec=%v err=%v", rec1, err)
+	}
+	if rec1.Version != 0 {
+		t.Fatalf("first write version = %d, want 0", rec1.Version)
+	}
+
+	// Second fund AddBalances again (creates a new write through Handle).
+	if err := FundTestAccounts(kvs, testNS, []common.Address{addr}, half); err != nil {
+		t.Fatalf("second fund: %v", err)
+	}
+	reader, err = kvs.NewSnapshot(0)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	defer reader.Close()
+	rec2, err := reader.Get(testNS, "acc:"+addr.Hex()+":bal")
+	if err != nil || rec2 == nil {
+		t.Fatalf("second bal: rec=%v err=%v", rec2, err)
+	}
+	if rec2.Version != 1 {
+		t.Fatalf("second write version = %d, want 1 (Handle/Update path)", rec2.Version)
+	}
+	// CreateAccount resets bal to 0 before AddBalance, so the second fund ends at half.
+	got := new(big.Int).SetBytes(rec2.Value)
+	if got.Cmp(half) != 0 {
+		t.Fatalf("balance after second fund = %s, want %s", got, half)
 	}
 }

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1064,6 +1064,14 @@
     "cause": "hardhat_setBalance"
   },
   {
+    "id": "ERC20FlashMint flashLoan custom flash fee & custom fee receiver \"before each\" hook: init receiver balance & set flash fee for \"default flash fee receiver\"",
+    "cause": "snapshot not found"
+  },
+  {
+    "id": "ERC20FlashMint flashLoan success",
+    "cause": "snapshot not found"
+  },
+  {
     "id": "ERC20Permit permit accepts owner signature",
     "cause": "eth_signTypedData_v4"
   },
@@ -2307,7 +2315,12 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if signature does not match signer",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if vote nonce is incorrect",
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
@@ -2403,8 +2416,12 @@
     "id": "GovernorCrosschain reconfigure executor"
   },
   {
-    "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorERC721 using $ERC721Votes deployment check",
+    "cause": "execution reverted"
+  },
+  {
+    "id": "GovernorERC721 using $ERC721Votes voting with ERC721 token",
+    "cause": "fixed-block-number"
   },
   {
     "id": "GovernorERC721 using $ERC721VotesTimestampMock \"before each\" hook for \"deployment check\"",

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1064,14 +1064,6 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "ERC20FlashMint flashLoan custom flash fee & custom fee receiver \"before each\" hook: init receiver balance & set flash fee for \"default flash fee receiver\"",
-    "cause": "snapshot not found"
-  },
-  {
-    "id": "ERC20FlashMint flashLoan success",
-    "cause": "snapshot not found"
-  },
-  {
     "id": "ERC20Permit permit accepts owner signature",
     "cause": "eth_signTypedData_v4"
   },
@@ -2315,12 +2307,7 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if signature does not match signer",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if vote nonce is incorrect",
-    "cause": "eth_signTypedData_v4"
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
   },
   {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
@@ -2416,12 +2403,7 @@
     "id": "GovernorCrosschain reconfigure executor"
   },
   {
-    "id": "GovernorERC721 using $ERC721Votes deployment check",
-    "cause": "execution reverted"
-  },
-  {
-    "id": "GovernorERC721 using $ERC721Votes voting with ERC721 token",
-    "cause": "fixed-block-number"
+    "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\""
   },
   {
     "id": "GovernorERC721 using $ERC721VotesTimestampMock \"before each\" hook for \"deployment check\"",

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -2307,7 +2307,12 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if signature does not match signer",
+    "cause": "eth_signTypedData_v4"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature if vote nonce is incorrect",
+    "cause": "eth_signTypedData_v4"
   },
   {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -880,22 +880,6 @@
     "id": "Address functionCall with valid contract receiver reverts when the called function runs out of gas"
   },
   {
-    "id": "Address functionCallWithValue with non-zero value calls the requested function with existing value",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Address functionCallWithValue with non-zero value calls the requested function with transaction funds",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Address functionCallWithValue with non-zero value reverts when calling non-payable functions",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Address sendValue when sender contract has funds \"before each\" hook for \"sends 0 wei\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Arrays \"before each\" hook for \"sort reversed array\""
   },
   {
@@ -905,14 +889,6 @@
     "id": "BeaconProxy bad beacon is not accepted non-compliant beacon"
   },
   {
-    "id": "BeaconProxy initialization payable initialization",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "BeaconProxy initialization reverting initialization due to value",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "BlockHeader current block"
   },
   {
@@ -920,15 +896,7 @@
     "cause": "execution reverted"
   },
   {
-    "id": "Clones with immutable args: 0x clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -936,19 +904,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -956,19 +912,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x11223344 clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -976,19 +920,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x11223344 clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -996,19 +928,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones with immutable args: 0x11223344 cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args clone construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args clone initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args clone initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
     "cause": "insufficient-funds"
   },
   {
@@ -1016,35 +936,11 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones without immutable args clone initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args cloneDeterministic construct with value factory has enough balance",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args cloneDeterministic initialization with parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "Clones without immutable args cloneDeterministic initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "Clones without immutable args cloneDeterministic initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Clones without immutable args cloneDeterministic initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"initializes the proxy\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Create2 deploy deploys a contract with funds deposited in the factory",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "Create3 deploy deploys a contract with funds deposited in the factory",
     "cause": "insufficient-funds"
   },
   {
@@ -1120,15 +1016,7 @@
     "cause": "gas-stub"
   },
   {
-    "id": "ERC1967Clones deterministic deployment (create2) forwards value to the new clone",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "ERC1967Clones deterministic deployment (create2) initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Clones deterministic deployment (create2) initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
     "cause": "insufficient-funds"
   },
   {
@@ -1136,15 +1024,7 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones deterministic deployment (create2) initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "ERC1967Clones deterministic deployment (create2) without initialization when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Clones non-deterministic deployment (create) forwards value to the new clone",
     "cause": "insufficient-funds"
   },
   {
@@ -1152,55 +1032,11 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones non-deterministic deployment (create) initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "ERC1967Clones non-deterministic deployment (create) initialization without parameters non payable when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
-    "id": "ERC1967Clones non-deterministic deployment (create) initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "ERC1967Clones non-deterministic deployment (create) without initialization when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (default) allowUninitialized is false initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization with parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters non payable when sending some balance reverts",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true initialization without parameters payable when sending some balance \"before each\" hook: creating proxy for \"sets the implementation address\"",
-    "cause": "insufficient-funds"
-  },
-  {
-    "id": "ERC1967Proxy (unsafe) allowUninitialized is true without initialization when sending some balance reverts",
     "cause": "insufficient-funds"
   },
   {
@@ -2102,44 +1938,469 @@
     "cause": "gas-stub"
   },
   {
-    "id": "ERC7786Recipient receive multiple similar messages",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC-6372 behavior in blockNumber mode should have a correct clock value"
   },
   {
-    "id": "ERC7786Recipient receives gateway relayed messages",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is not supported uses less than 30k"
   },
   {
-    "id": "Governor using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes ERC165 when the interfaceId is supported uses less than 30k gas"
   },
   {
-    "id": "Governor using $ERC20VotesLegacyMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after deadline"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after execution"
   },
   {
-    "id": "GovernorCountingFractional using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after proposal"
   },
   {
-    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel internal after vote"
   },
   {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after deadline"
   },
   {
-    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after execution"
   },
   {
-    "id": "GovernorCrosschain \"before each\" hook for \"execute with executor\"",
-    "cause": "insufficient-funds"
+    "id": "Governor using $ERC20Votes cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20Votes cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20Votes deployment check"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20Votes nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20Votes send ethers"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20Votes should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Executed"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20Votes state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20Votes vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20Votes vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC-6372 behavior in blockNumber mode should have a correct clock value"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is not supported uses less than 30k"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock ERC165 when the interfaceId is supported uses less than 30k gas"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after proposal"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel internal after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock deployment check"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock send ethers"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20VotesLegacyMock vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC-6372 behavior in timestamp mode should have a correct clock value"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is not supported uses less than 30k"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock ERC165 when the interfaceId is supported uses less than 30k gas"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel internal after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after deadline"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after execution"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock cancel public after vote started"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix with protection via proposer suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with different suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection with proposer suffix but bad address part someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix proposer can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock frontrun protection using description suffix without protection without suffix someone else can propose"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock nominal workflow"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setProposalThreshold to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingDelay through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates can setVotingPeriod through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock onlyGovernance updates cannot setVotingPeriod to 0 through governance"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock send ethers"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if proposal was already executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if quorum is not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert with reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if receiver revert without reason"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if score not reached"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on execute if voting is not over"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on propose if proposer has below threshold votes"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on queue always"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if vote was already casted"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote if voting is over"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Defeated"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Executed"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Pending & Active"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock state Succeeded"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with an EOA signature on two proposals"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight fractional then nominal"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if no weight remaining"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #1"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params are not properly formatted #2"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if params spend more than available"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight revert if vote type is invalid"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight twice"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight fractional then nominal"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if no weight remaining"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #1"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params are not properly formatted #2"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if params spend more than available"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight revert if vote type is invalid"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight twice"
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock cast override vote \"before each\" hook for \"override after delegate vote\""
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock cast override vote \"before each\" hook for \"override after delegate vote\""
+  },
+  {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCrosschain execute with executor"
+  },
+  {
+    "id": "GovernorCrosschain reconfigure executor"
   },
   {
     "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\"",
@@ -2150,16 +2411,43 @@
     "cause": "insufficient-funds"
   },
   {
-    "id": "GovernorNoncesKeyed \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed on vote by signature \"before each\" hook for \"if signature does not match signer\""
   },
   {
-    "id": "GovernorPreventLateQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with a valid EIP-1271 signature"
   },
   {
-    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with default nonce votes with an EOA signature with reason"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with a valid EIP-1271 signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature"
+  },
+  {
+    "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature with reason"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes Delay is extended to prevent last minute take-over"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes nominal workflow unaffected"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes onlyGovernance updates can setLateQuorumVoteExtension through governance"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock Delay is extended to prevent last minute take-over"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock nominal workflow unaffected"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock onlyGovernance updates can setLateQuorumVoteExtension through governance"
   },
   {
     "id": "GovernorProposalGuardian using $ERC20Votes \"before each\" hook for \"deployment check\"",
@@ -2170,12 +2458,10 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20Votes \"before each\" hook for \"sequential proposal ids\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSequentialProposalId using $ERC20Votes nominal workflow"
   },
   {
-    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock \"before each\" hook for \"sequential proposal ids\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock nominal workflow"
   },
   {
     "id": "GovernorStorage using $ERC20Votes \"before each\" hook for \"queue and execute by id\"",
@@ -2188,12 +2474,28 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal is queued if super quorum is reached and eta is set"
   },
   {
-    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is not reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal remains active if super quorum is reached but vote fails"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20Votes proposal succeeds early when super quorum is reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal is queued if super quorum is reached and eta is set"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is not reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal remains active if super quorum is reached but vote fails"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal succeeds early when super quorum is reached"
   },
   {
     "id": "GovernorTimelockAccess using $ERC20Votes \"before each\" hook for \"accepts ether transfers\"",
@@ -2216,44 +2518,175 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20Votes \"before each\" hook for \"doesn't accept ether transfers\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel after queue prevents executing"
   },
   {
-    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock \"before each\" hook for \"doesn't accept ether transfers\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel before queue prevents scheduling"
   },
   {
-    "id": "GovernorVotesQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes cancel cancel on timelock is reflected on governor"
   },
   {
-    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes clear queue of pending governor calls"
   },
   {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes nominal"
   },
   {
-    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay can be executed through governance"
   },
   {
-    "id": "GovernorWithParams using $ERC20Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay is payable and can transfer eth to EOA"
   },
   {
-    "id": "GovernorWithParams using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance relay protected against other proposers"
   },
   {
-    "id": "LowLevelCall call with 64 bytes return in the scratch space calls the requested function with value and returns true",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes onlyGovernance updateTimelock can be executed through governance to"
   },
   {
-    "id": "LowLevelCall call without any return calls the requested function with value and returns true",
-    "cause": "insufficient-funds"
+    "id": "GovernorTimelockControl using $ERC20Votes post deployment check"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if already executed by another proposer"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if not queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on execute if too early"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes should revert on queue if already queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel after queue prevents executing"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel before queue prevents scheduling"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel on timelock is reflected on governor"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock clear queue of pending governor calls"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock nominal"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay can be executed through governance"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay is payable and can transfer eth to EOA"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance relay protected against other proposers"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock onlyGovernance updateTimelock can be executed through governance to"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if already executed by another proposer"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if not queued"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on execute if too early"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on queue if already queued"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes deployment check"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates can updateQuorumNumerator through governance"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes onlyGovernance updates cannot updateQuorumNumerator over the maximum"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum not reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock deployment check"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates can updateQuorumNumerator through governance"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock onlyGovernance updates cannot updateQuorumNumerator over the maximum"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum not reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes deployment check"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes proposal remains active until super quorum is reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes super quorum updates can update super quorum through governance"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock deployment check"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock proposal remains active until super quorum is reached"
+  },
+  {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock super quorum updates can update super quorum through governance"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes Voting with params is properly supported"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes nominal is unaffected"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if signature does not match signer"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature reverts if vote nonce is incorrect"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EIP-1271 signature signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes voting by signature supports EOA signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock Voting with params is properly supported"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if signature does not match signer"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature reverts if vote nonce is incorrect"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EIP-1271 signature signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock voting by signature supports EOA signatures"
   },
   {
     "id": "MerkleTree push pushing to a full tree reverts"
@@ -3375,10 +3808,6 @@
     "id": "RelayedCall default (zero) salt direct call to the relayer"
   },
   {
-    "id": "RelayedCall default (zero) salt relayed call target success (with value)",
-    "cause": "insufficient-funds"
-  },
-  {
     "id": "RelayedCall default (zero) salt relayer input format",
     "cause": "hardhat_setBalance"
   },
@@ -3388,10 +3817,6 @@
   {
     "id": "RelayedCall random salt input format",
     "cause": "hardhat_setBalance"
-  },
-  {
-    "id": "RelayedCall random salt relayed call target success (with value)",
-    "cause": "insufficient-funds"
   },
   {
     "id": "SafeERC20 with ERC1363 that returns no boolean values reverts on approveAndCallRelaxed"
@@ -3411,10 +3836,6 @@
   {
     "id": "SignatureChecker (ERC1271) \"before all\" hook: deploying in \"SignatureChecker (ERC1271)\"",
     "cause": "personal_sign"
-  },
-  {
-    "id": "SimulateCall \"before each\" hook for \"automatic simulator deployment\"",
-    "cause": "insufficient-funds"
   },
   {
     "id": "Time Delay get & getFull",
@@ -3535,12 +3956,28 @@
     "id": "TrieProof verify verify transaction and receipt inclusion in block"
   },
   {
-    "id": "VestingWallet \"before each\" hook for \"rejects zero address for beneficiary\"",
-    "cause": "insufficient-funds"
+    "id": "VestingWallet vesting schedule ERC20 vesting check vesting schedule"
   },
   {
-    "id": "VestingWalletCliff \"before each\" hook for \"rejects a larger cliff than vesting duration\"",
-    "cause": "insufficient-funds"
+    "id": "VestingWallet vesting schedule ERC20 vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWallet vesting schedule Eth vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWallet vesting schedule Eth vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule ERC20 vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule ERC20 vesting execute vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule Eth vesting check vesting schedule"
+  },
+  {
+    "id": "VestingWalletCliff vesting schedule Eth vesting execute vesting schedule"
   },
   {
     "id": "Votes vote with blockNumber ERC-6372 behavior in blockNumber mode should have a correct clock value",


### PR DESCRIPTION
Closes #254
Part of #248

Test EOAs on the self contained testnode started with a zero native balance, so any path that moves value failed the balance check early. That was the largest "easy" bucket in the OZ Hardhat suite that was not a missing method stub.

The issue mentions the existing balance priming bits under endorser/testimpl. Those prime ERC20 storage slots for perf/USDC work; they do not set native ETH. What we needed was real acc:<addr>:bal state for the known Hardhat accounts when test RPC is on.

## Code

gateway/testimpl/fund_accounts.go seeds balances into the current endorser KVS snapshot at startup (Hardhat default of 10_000 ETH). Writes are in place on the current snapshot so we do not burn a history slot that evm_revert could later restore as empty genesis.

gateway/app/app.go calls FundTestAccounts after LoadTestAccounts when enableTestRPC is set. Production paths still start accounts at zero.

Unit coverage for FundTestAccounts plus a NewTestNode check that BalanceAt sees the funded amount for every default account.

Also raised the OZ hardhat CI job timeout from 15m to 25m. With accounts funded, more of the suite gets past early insufficient funds failures and needs more wall time on the runners.

## Baseline

Full compatible set (scripts/run_hardhat_test.sh --full) with this wired in, then reconciled testdata/oz_known_failures.json:

* insufficient funds dropped from 94 causes to 21 (leftover cases still need hardhat_setBalance or non default EOAs)
* about 218 more tests pass overall
* tests that used to die on zero balance now fail further down (timestamps, block number, governor clock, etc.) and are recorded as such
* cmd/baseline check is clean (no regressions, no stale entries)

### Full suite summary

```
4973 passed, 1066 failed, 1 skipped (6040 total, 82.3% passing)
```

By suite: access 354/578, crosschain 12/15, finance 8/16, governance 202/522, metatx 0/12, proxy 257/280, token 1637/1852, utils 2503/2764.

## Verification

* go test ./gateway/testimpl/ ./gateway/app/
* go test ./... -short
* gofmt / go vet / staticcheck on the touched packages
* full OZ suite + baseline check as above

Happy to tweak cause tags if anything looks off. Thanks!