### PR TITLE
test: fix nil eth StateDB panic for empty pre-state fixtures

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -234,8 +234,7 @@ cases. These divergences are deliberate consequences of the modern-only semantic
 regressions.
 
 These known-divergent cases are quarantined in `testdata/eth_tests.skip`: the EIP-7610
-create-collision fixtures above, and a `CREATE` transaction from a non-existent sender (currently a
-nil-pointer panic in `DualStateDB.Snapshot`). All other Osaka-forward state tests pass.
+create-collision fixtures above. All other Osaka-forward state tests pass.
 
 **Native ETH balances not funded**: balances are implemented but unused. Accounts have zero ETH 
 balance by default. Value transfers inside the EVM (`CALL` with value, `SELFDESTRUCT` beneficiary, 

--- a/integration/ethereum_test.go
+++ b/integration/ethereum_test.go
@@ -480,10 +480,10 @@ func newEthereumTestHarness(t *testing.T, evmConfig execution.EVMConfig, pre typ
 
 // primeGenesisAlloc primes the state from ethereum genesis format and sets up ethStateDB for wrappers
 func (eth *ethereumTestHarness) primeGenesisAlloc(ctx context.Context, pre types.GenesisAlloc, wait bool) error {
-	if len(pre) == 0 {
-		return nil
-	}
-
+	// Even with an empty pre-state we must build and set an eth StateDB: the
+	// pre-validation nonceReader and the post-execution root commit both read it,
+	// and a fixture with no pre-accounts (e.g. a CREATE from a non-existent sender)
+	// would otherwise leave it nil and panic in GetNonce.
 	primer, err := eth.NewStatePrimer()
 	if err != nil {
 		return err

--- a/testdata/eth_tests.skip
+++ b/testdata/eth_tests.skip
@@ -16,8 +16,3 @@
 ../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/initcollision/init_collision_create_tx.json
-#
-# --- nil-pointer panic in DualStateDB.Snapshot for a CREATE tx from a non-existent sender.
-../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json
-../testdata/execution-specs-tests/fixtures/state_tests/for_prague/ported_static/stTransactionTest/no_src_account_create1559/no_src_account_create1559.json


### PR DESCRIPTION
### Addressed issue

Closes #275 — nil-pointer panic on the `no_src_account_create1559` conformance
fixture (a CREATE from a sender with no pre-existing account).

### Summary

The panic was a **test-harness** bug, not a production `DualStateDB` issue as the
ticket initially suspected. `primeGenesisAlloc` (in `integration/ethereum_test.go`)
returned early when a fixture had no pre-state accounts — but building the
pre-state is also what creates and sets the eth StateDB the harness later reads.
Skipping it left that StateDB `nil`, so the pre-validation `nonceReader` panicked
in `GetNonce` for a sender that doesn't exist yet.

- Drop the `if len(pre) == 0 { return nil }` early-return so an empty pre-state
  still builds and sets an empty eth StateDB. The priming loop is a no-op for zero
  accounts; the rest of the flow is unchanged.
- With that in place the fixture passes (state-root check included), confirming the
  production path (`core.ValidateTx`, `DualStateDB`, execute/commit) already handled
  this case correctly — so no production code changes were needed.
- Remove the 3 `no_src_account_create1559` entries from `testdata/eth_tests.skip`
  and drop the corresponding note from `COMPATIBILITY.md`.

Test-harness/skip/docs only — no production/runtime code changes.

### Validation done

- The previously-panicking fixture now passes:
  `go test ./integration -run 'TestEthereumTests/no_src_account_create1559.json' -v` → PASS.
- `make checks` passes.
- Full `make eth-tests` is green (both suites, 0 failures) with the fixtures now
  un-skipped — nothing else regressed.
- Skip list drops from 15 → 12 entries (only the EIP-7610 group remains, tracked
  separately in #276).
  
### Screenshot
  
<img width="1458" height="579" alt="image" src="https://github.com/user-attachments/assets/c17f9721-0a9a-4d49-a387-6fe14438a7bc" />
