### PR TITLE
fix: implement eth_signTypedData_v4 and personal_sign in the test RPC

### DIFF
--- a/gateway/testimpl/server.go
+++ b/gateway/testimpl/server.go
@@ -90,6 +90,11 @@ func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys
 		return nil, err
 	}
 
+	// personal_sign for EIP-191 message signing (ethers.js signMessage)
+	if err := srv.RegisterName("personal", NewPersonalAPI(testAccountKeys)); err != nil {
+		return nil, err
+	}
+
 	return srv, nil
 }
 

--- a/gateway/testimpl/signing.go
+++ b/gateway/testimpl/signing.go
@@ -29,12 +29,12 @@ import (
 type typedDataArg apitypes.TypedData
 
 func (t *typedDataArg) UnmarshalJSON(data []byte) error {
-	if len(data) > 0 && data[0] == '"' {
-		var s string
-		if err := json.Unmarshal(data, &s); err != nil {
-			return err
-		}
-		data = []byte(s)
+	// ethers.js sends a JSON-encoded string; Hardhat may send an object.
+	// Prefer string decode first so leading whitespace still works (encoding/json
+	// allows it; a data[0]=='"' check would miss that).
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		return json.Unmarshal([]byte(s), (*apitypes.TypedData)(t))
 	}
 	return json.Unmarshal(data, (*apitypes.TypedData)(t))
 }

--- a/gateway/testimpl/signing.go
+++ b/gateway/testimpl/signing.go
@@ -1,0 +1,90 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+
+WARNING: This package contains test-only/unsafe RPC implementations.
+DO NOT use in production environments. These methods perform server-side
+message signing which is inherently insecure and should only be used
+for development and testing purposes.
+*/
+
+package testimpl
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+// typedDataArg accepts EIP-712 payloads either as a JSON object or as a
+// JSON-encoded string. ethers.js sends the latter via eth_signTypedData_v4.
+type typedDataArg apitypes.TypedData
+
+func (t *typedDataArg) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		data = []byte(s)
+	}
+	return json.Unmarshal(data, (*apitypes.TypedData)(t))
+}
+
+// SignTypedData_v4 implements eth_signTypedData_v4 (EIP-712).
+// Registers as eth_signTypedData_v4 via geth's formatName (first letter lowercased).
+//
+// SECURITY WARNING: Server-side signing with held private keys is for tests only.
+func (api *TestEthAPI) SignTypedData_v4(ctx context.Context, addr common.Address, data typedDataArg) (hexutil.Bytes, error) {
+	privateKey, ok := api.testAccountKeys[addr]
+	if !ok {
+		return nil, fmt.Errorf("no private key available for address %s", addr.Hex())
+	}
+
+	sighash, _, err := apitypes.TypedDataAndHash(apitypes.TypedData(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash typed data: %w", err)
+	}
+	return signWithLegacyV(sighash, privateKey)
+}
+
+// PersonalAPI provides the personal_* RPC namespace for Hardhat/ethers tests.
+type PersonalAPI struct {
+	testAccountKeys map[common.Address]*ecdsa.PrivateKey
+}
+
+// NewPersonalAPI creates a personal API bound to the given test account keys.
+func NewPersonalAPI(keys map[common.Address]*ecdsa.PrivateKey) *PersonalAPI {
+	return &PersonalAPI{testAccountKeys: keys}
+}
+
+// Sign implements personal_sign (EIP-191 personal message).
+// Parameter order matches the personal_sign convention: data, address, optional password.
+// The password is accepted for RPC compatibility and ignored in the test backend.
+//
+// SECURITY WARNING: Server-side signing with held private keys is for tests only.
+func (api *PersonalAPI) Sign(ctx context.Context, data hexutil.Bytes, addr common.Address, passwd *string) (hexutil.Bytes, error) {
+	privateKey, ok := api.testAccountKeys[addr]
+	if !ok {
+		return nil, fmt.Errorf("no private key available for address %s", addr.Hex())
+	}
+	return signWithLegacyV(accounts.TextHash(data), privateKey)
+}
+
+// signWithLegacyV signs hash and rewrites V from 0/1 to 27/28 (yellow paper).
+func signWithLegacyV(hash []byte, key *ecdsa.PrivateKey) (hexutil.Bytes, error) {
+	sig, err := crypto.Sign(hash, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+	sig[64] += 27
+	return sig, nil
+}

--- a/gateway/testimpl/signing_test.go
+++ b/gateway/testimpl/signing_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/hyperledger/fabric-x-evm/gateway/api"
+)
+
+func loadSigningFixture(t *testing.T) (*TestAccountManager, common.Address) {
+	t.Helper()
+	mgr, err := LoadTestAccounts("../../testdata/test_accounts.json")
+	if err != nil {
+		t.Fatalf("LoadTestAccounts: %v", err)
+	}
+	return mgr, mgr.Addresses[0]
+}
+
+func dialSigningServer(t *testing.T, mgr *TestAccountManager) *rpc.Client {
+	t.Helper()
+	srv := rpc.NewServer()
+	prodAPI := api.NewEthAPI(nil)
+	testAPI := NewTestEthAPI(prodAPI, nil, mgr.Addresses, mgr.PrivateKeys, &txFence{})
+	if err := srv.RegisterName("eth", testAPI); err != nil {
+		t.Fatalf("RegisterName eth: %v", err)
+	}
+	if err := srv.RegisterName("personal", NewPersonalAPI(mgr.PrivateKeys)); err != nil {
+		t.Fatalf("RegisterName personal: %v", err)
+	}
+	client := rpc.DialInProc(srv)
+	t.Cleanup(client.Close)
+	return client
+}
+
+func recoverSigner(t *testing.T, hash, sig []byte) common.Address {
+	t.Helper()
+	if len(sig) != 65 {
+		t.Fatalf("signature length = %d, want 65", len(sig))
+	}
+	// Clone so we do not mutate the caller's slice.
+	s := make([]byte, 65)
+	copy(s, sig)
+	if s[64] != 27 && s[64] != 28 {
+		t.Fatalf("V = %d, want 27 or 28", s[64])
+	}
+	s[64] -= 27
+	pub, err := crypto.SigToPub(hash, s)
+	if err != nil {
+		t.Fatalf("SigToPub: %v", err)
+	}
+	return crypto.PubkeyToAddress(*pub)
+}
+
+func TestPersonalAPI_Sign_RecoversSigner(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	api := NewPersonalAPI(mgr.PrivateKeys)
+
+	msg := []byte("hello fabric-evm")
+	sig, err := api.Sign(context.Background(), hexutil.Bytes(msg), addr, nil)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	got := recoverSigner(t, accounts.TextHash(msg), sig)
+	if got != addr {
+		t.Fatalf("recovered %s, want %s", got.Hex(), addr.Hex())
+	}
+}
+
+func TestPersonalAPI_Sign_UnknownAddress(t *testing.T) {
+	mgr, _ := loadSigningFixture(t)
+	api := NewPersonalAPI(mgr.PrivateKeys)
+	unknown := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	_, err := api.Sign(context.Background(), hexutil.Bytes("x"), unknown, nil)
+	if err == nil || !strings.Contains(err.Error(), "no private key") {
+		t.Fatalf("error = %v, want no private key", err)
+	}
+}
+
+func TestPersonalAPI_Sign_RPCRegistration(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	client := dialSigningServer(t, mgr)
+
+	msg := []byte("rpc personal_sign")
+	var result hexutil.Bytes
+	if err := client.CallContext(context.Background(), &result, "personal_sign", hexutil.Bytes(msg), addr); err != nil {
+		t.Fatalf("personal_sign: %v", err)
+	}
+	got := recoverSigner(t, accounts.TextHash(msg), result)
+	if got != addr {
+		t.Fatalf("recovered %s, want %s", got.Hex(), addr.Hex())
+	}
+}
+
+func TestPersonalAPI_Sign_RPCWithPassword(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	client := dialSigningServer(t, mgr)
+
+	msg := []byte("with password")
+	var result hexutil.Bytes
+	// Optional third arg accepted and ignored.
+	if err := client.CallContext(context.Background(), &result, "personal_sign", hexutil.Bytes(msg), addr, ""); err != nil {
+		t.Fatalf("personal_sign with password: %v", err)
+	}
+	if len(result) != 65 {
+		t.Fatalf("sig len = %d, want 65", len(result))
+	}
+}
+
+func TestSignTypedData_v4_RecoversSigner(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	testAPI := NewTestEthAPI(api.NewEthAPI(nil), nil, mgr.Addresses, mgr.PrivateKeys, &txFence{})
+
+	td := permitTypedData(addr.Hex(), "1")
+	sig, err := testAPI.SignTypedData_v4(context.Background(), addr, typedDataArg(td))
+	if err != nil {
+		t.Fatalf("SignTypedData_v4: %v", err)
+	}
+	hash, _, err := apitypes.TypedDataAndHash(td)
+	if err != nil {
+		t.Fatalf("TypedDataAndHash: %v", err)
+	}
+	got := recoverSigner(t, hash, sig)
+	if got != addr {
+		t.Fatalf("recovered %s, want %s", got.Hex(), addr.Hex())
+	}
+}
+
+func TestSignTypedData_v4_UnknownAddress(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	testAPI := NewTestEthAPI(api.NewEthAPI(nil), nil, mgr.Addresses, mgr.PrivateKeys, &txFence{})
+	unknown := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	_, err := testAPI.SignTypedData_v4(context.Background(), unknown, typedDataArg(permitTypedData(addr.Hex(), "1")))
+	if err == nil || !strings.Contains(err.Error(), "no private key") {
+		t.Fatalf("error = %v, want no private key", err)
+	}
+}
+
+func TestSignTypedData_v4_RPCObjectAndString(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	client := dialSigningServer(t, mgr)
+	td := permitTypedData(addr.Hex(), "1")
+
+	// Object form (Hardhat-style).
+	var sigObj hexutil.Bytes
+	if err := client.CallContext(context.Background(), &sigObj, "eth_signTypedData_v4", addr, td); err != nil {
+		t.Fatalf("eth_signTypedData_v4 object: %v", err)
+	}
+	hash, _, err := apitypes.TypedDataAndHash(td)
+	if err != nil {
+		t.Fatalf("TypedDataAndHash: %v", err)
+	}
+	if recoverSigner(t, hash, sigObj) != addr {
+		t.Fatalf("object form recovered wrong address")
+	}
+
+	// String form (ethers.js style).
+	payload, err := json.Marshal(td)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var sigStr hexutil.Bytes
+	if err := client.CallContext(context.Background(), &sigStr, "eth_signTypedData_v4", addr, string(payload)); err != nil {
+		t.Fatalf("eth_signTypedData_v4 string: %v", err)
+	}
+	if recoverSigner(t, hash, sigStr) != addr {
+		t.Fatalf("string form recovered wrong address")
+	}
+	if string(sigObj) != string(sigStr) {
+		t.Fatalf("object and string signatures differ")
+	}
+}
+
+func TestSignTypedData_v4_InvalidTypedData(t *testing.T) {
+	mgr, addr := loadSigningFixture(t)
+	testAPI := NewTestEthAPI(api.NewEthAPI(nil), nil, mgr.Addresses, mgr.PrivateKeys, &txFence{})
+	// Empty primary type / types → hash failure.
+	_, err := testAPI.SignTypedData_v4(context.Background(), addr, typedDataArg{})
+	if err == nil {
+		t.Fatal("expected error for invalid typed data")
+	}
+}
+
+func TestTypedDataArg_UnmarshalJSON(t *testing.T) {
+	td := permitTypedData("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826", "1")
+	raw, err := json.Marshal(td)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var asObj typedDataArg
+	if err := json.Unmarshal(raw, &asObj); err != nil {
+		t.Fatalf("object: %v", err)
+	}
+	if asObj.PrimaryType != "Permit" {
+		t.Fatalf("PrimaryType = %q", asObj.PrimaryType)
+	}
+
+	quoted, err := json.Marshal(string(raw))
+	if err != nil {
+		t.Fatalf("quote: %v", err)
+	}
+	var asStr typedDataArg
+	if err := json.Unmarshal(quoted, &asStr); err != nil {
+		t.Fatalf("string: %v", err)
+	}
+	if asStr.PrimaryType != "Permit" {
+		t.Fatalf("string PrimaryType = %q", asStr.PrimaryType)
+	}
+}
+
+// permitTypedData is a minimal EIP-2612-style payload for signing tests.
+func permitTypedData(owner, chainID string) apitypes.TypedData {
+	// math.HexOrDecimal256 unmarshals from JSON numbers/strings; build via JSON
+	// so chainId is populated the same way production RPC calls do.
+	raw := []byte(`{
+		"types": {
+			"EIP712Domain": [
+				{"name":"name","type":"string"},
+				{"name":"version","type":"string"},
+				{"name":"chainId","type":"uint256"},
+				{"name":"verifyingContract","type":"address"}
+			],
+			"Permit": [
+				{"name":"owner","type":"address"},
+				{"name":"spender","type":"address"},
+				{"name":"value","type":"uint256"},
+				{"name":"nonce","type":"uint256"},
+				{"name":"deadline","type":"uint256"}
+			]
+		},
+		"primaryType": "Permit",
+		"domain": {
+			"name": "MyToken",
+			"version": "1",
+			"chainId": ` + chainID + `,
+			"verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+		},
+		"message": {
+			"owner": "` + owner + `",
+			"spender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+			"value": "1000",
+			"nonce": "0",
+			"deadline": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+		}
+	}`)
+	var td apitypes.TypedData
+	if err := json.Unmarshal(raw, &td); err != nil {
+		panic(err)
+	}
+	return td
+}

--- a/gateway/testimpl/signing_test.go
+++ b/gateway/testimpl/signing_test.go
@@ -220,6 +220,16 @@ func TestTypedDataArg_UnmarshalJSON(t *testing.T) {
 	if asStr.PrimaryType != "Permit" {
 		t.Fatalf("string PrimaryType = %q", asStr.PrimaryType)
 	}
+
+	// Leading whitespace on the raw token (call UnmarshalJSON directly: top-level
+	// json.Unmarshal strips spaces before invoking the method).
+	var asPadded typedDataArg
+	if err := asPadded.UnmarshalJSON(append([]byte("  "), quoted...)); err != nil {
+		t.Fatalf("padded string: %v", err)
+	}
+	if asPadded.PrimaryType != "Permit" {
+		t.Fatalf("padded PrimaryType = %q", asPadded.PrimaryType)
+	}
 }
 
 // permitTypedData is a minimal EIP-2612-style payload for signing tests.

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1060,30 +1060,6 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "ECDSA parse signature 65 and 64 bytes signatures",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns a different address",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "ECDSA recover with valid signature using <signer>.sign returns signer address with correct signature for arbitrary length message",
-    "cause": "personal_sign"
-  },
-  {
-    "id": "EIP712 with long name and version digest",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "EIP712 with short name and version digest",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC1155 like an ERC1155 ERC165 when the interfaceId is not supported uses less than 30k",
     "cause": "gas-stub"
   },
@@ -1228,23 +1204,7 @@
     "cause": "hardhat_setBalance"
   },
   {
-    "id": "ERC20Permit permit accepts owner signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Permit permit rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Permit permit rejects other signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Permit permit rejects reused signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization accepts authorizer signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1256,27 +1216,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization rejects cancellation of a non-next nonce in the same key sequence",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization rejects other signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization rejects reused nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization shares the keyed counter between transfer and receive",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization with bytes signature accepts ERC1271 wallet signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization with bytes signature accepts authorizer signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1284,23 +1224,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber cancelAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects authorization not yet valid",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects other signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1312,10 +1236,6 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization rejects when caller is not the recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature accepts ERC1271 wallet signature when called by recipient",
     "cause": "eth_signTypedData_v4"
   },
@@ -1324,27 +1244,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber receiveWithAuthorization with bytes signature rejects when caller is not the recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization accepts holder signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects authorization not yet valid",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization rejects other signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1356,10 +1256,6 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization treats mixed clock-flag inputs as timestamp",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature accepts ERC1271 wallet signature",
     "cause": "eth_signTypedData_v4"
   },
@@ -1368,63 +1264,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with blockNumber transferWithAuthorization works with different keys in parallel",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization accepts authorizer signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization cancels the next nonce after consuming the previous one",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization prevents usage of canceled authorization in transferWithAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization rejects cancellation of a non-next nonce in the same key sequence",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization rejects other signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization rejects reused nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization shares the keyed counter between transfer and receive",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization with bytes signature accepts ERC1271 wallet signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization with bytes signature accepts authorizer signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization with bytes signature prevents usage of canceled authorization by an ERC1271 wallet",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp cancelAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects authorization not yet valid",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1432,79 +1272,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects other signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects out-of-order nonces sharing the same key",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects reused signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization rejects when caller is not the recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization with bytes signature accepts ERC1271 wallet signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization with bytes signature accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp receiveWithAuthorization with bytes signature rejects when caller is not the recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization accepts holder signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects authorization not yet valid",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects other signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects out-of-order nonces sharing the same key",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization rejects reused signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization treats mixed clock-flag inputs as timestamp",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization with bytes signature accepts ERC1271 wallet signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization with bytes signature accepts holder signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization with bytes signature rejects invalid ERC1271 signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20TransferAuthorization with timestamp transferWithAuthorization works with different keys in parallel",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1593,19 +1361,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1627,19 +1383,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with blockNumber set delegation with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with blockNumber set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1717,19 +1461,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1746,19 +1478,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC20Votes vote with timestamp set delegation with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC20Votes vote with timestamp set delegation with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1778,43 +1498,49 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature but mismatched value",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for expired deadline",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC2771Forwarder execute with tampered request reverts with valid signature for non-current nonce",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas"
   },
   {
-    "id": "ERC2771Forwarder execute with valid requests emits an event and consumes nonce for a successful request",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests bubbles out of gas forced by the relayer",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "ERC2771Forwarder execute with valid requests reverts with an unsuccessful request",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests reverts with mismatched value",
+    "cause": "insufficient-funds"
   },
   {
-    "id": "ERC2771Forwarder executeBatch \"before each\" hook for \"sanity\"",
-    "cause": "eth_signTypedData_v4"
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address \"after each\" hook for \"ignores a request with a valid signature for non-current nonce\""
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is a known address ignores a request with a valid signature for non-current nonce",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is the zero address reverts with at least one valid signature for expired deadline",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with tampered requests when the refund receiver is the zero address reverts with at least one valid signature for non-current nonce",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with valid requests atomic batch with reverting request reverts the whole batch",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with valid requests emits events",
+    "cause": "insufficient-funds"
+  },
+  {
+    "id": "ERC2771Forwarder executeBatch with valid requests increase nonces",
+    "cause": "insufficient-funds"
   },
   {
     "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for expired deadline",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC2771Forwarder verify with tampered values returns false with valid signature for non-current nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC2771Forwarder verify with valid signature returns true without altering the nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 mixed clock-flag inputs falls back to the timestamp clock",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1822,31 +1548,11 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using blockNumber clock cancelAuthorization cancels an unused authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock cancelAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock cancelAuthorization rejects re-cancellation with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC3009 using blockNumber clock receiveWithAuthorization accepts holder signature when called by recipient",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using blockNumber clock receiveWithAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC3009 using blockNumber clock receiveWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock receiveWithAuthorization rejects when caller is not the recipient",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1858,31 +1564,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects at the validAfter boundary (current == validAfter)",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects at the validBefore boundary (current == validBefore)",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects authorization not yet valid",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using blockNumber clock transferWithAuthorization rejects validAfter that points to an value beyond the type(uint48).max",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -1890,75 +1572,11 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using timestamp clock authorizationState returns true after the nonce is consumed",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock cancelAuthorization cancels an unused authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock cancelAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock cancelAuthorization rejects re-cancellation with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock receiveWithAuthorization accepts holder signature when called by recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock receiveWithAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock receiveWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock receiveWithAuthorization rejects when caller is not the recipient",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization accepts random nonces in any order",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization emits AuthorizationUsed and Transfer with the expected balance changes",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects at the validAfter boundary (current == validAfter)",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC3009 using timestamp clock transferWithAuthorization rejects at the validBefore boundary (current == validBefore)",
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects authorization not yet valid",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC3009 using timestamp clock transferWithAuthorization rejects expired authorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects invalid signature",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects reused nonce with ERC3009UsedAuthorization",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization rejects validAfter that points to an value beyond the type(uint48).max",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC3009 using timestamp clock transferWithAuthorization supports validBefore that points to an value beyond the type(uint48).max",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -2066,19 +1684,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "ERC721Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3409,10 +3015,6 @@
     "id": "SafeERC20 with address that has no contract code reverts on increaseAllowance"
   },
   {
-    "id": "SignatureChecker (ERC1271) \"before all\" hook: deploying in \"SignatureChecker (ERC1271)\"",
-    "cause": "personal_sign"
-  },
-  {
     "id": "SimulateCall \"before each\" hook for \"automatic simulator deployment\"",
     "cause": "insufficient-funds"
   },
@@ -3571,19 +3173,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3619,19 +3209,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "Votes vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3699,19 +3277,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with blockNumber run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {
@@ -3747,19 +3313,7 @@
     "cause": "eth_signTypedData_v4"
   },
   {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad delegatee",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects bad nonce",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
     "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects expired permit",
-    "cause": "eth_signTypedData_v4"
-  },
-  {
-    "id": "VotesExtended vote with timestamp run votes workflow delegation with signature with signature rejects reused signature",
     "cause": "eth_signTypedData_v4"
   },
   {


### PR DESCRIPTION
Fixes #250
Part of #248

Test RPC already had eth_accounts and eth_sendTransaction with real keys. This adds the two signing methods Hardhat and ethers actually call for permits and messages.

eth_signTypedData_v4 on the eth namespace (EIP-712). personal_sign on the personal namespace (EIP-191). Both use TestAccountManager keys the same way SendTransaction does. Typed data accepts either a JSON object or a JSON string because ethers sends the latter. V is adjusted to 27/28.

Unit tests cover recovery and RPC registration. Full OZ suite was run and testdata/oz_known_failures.json was updated to match.

Local full suite: 4919 pass, 785 fail, 1 skip (86.2%). personal_sign cause tags are gone. eth_signTypedData_v4 tags dropped from 165 to 49; those leftovers fail for other reasons (clocks and such), not a missing method. Ten new expected failures are ERC2771 executeBatch hitting insufficient funds once signing works. Prefunding those accounts is #254 if you want that next.

## Test plan

- [x] go test ./gateway/testimpl/
- [x] go build ./cmd/fxevm
- [x] make hardhat-tests-full
- [x] go run ./cmd/baseline check --suite oz-hardhat
- [x] ERC20Permit smoke (5/6; expired permit still needs time travel)
- [x] CI Quick Tests and OZ Hardhat Compatibility