### PR TITLE
gateway: enable the gRPC endorsement path via config 

### DIFF
--- a/endorser/client/dial.go
+++ b/endorser/client/dial.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Right Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package client
+
+import (
+	"fmt"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"google.golang.org/grpc"
+
+	"github.com/hyperledger/fabric-x-evm/common"
+)
+
+// Dial opens a gRPC connection to cfg's endpoint using cfg's TLS settings and
+// returns a Client backed by it. The caller owns the returned Client and must close it.
+func Dial(cfg common.ClientConfig) (*Client, error) {
+	tlsCreds, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode:        cfg.TLS.Mode,
+		CertPath:    cfg.TLS.CertPath,
+		KeyPath:     cfg.TLS.KeyPath,
+		CACertPaths: cfg.TLS.CACertPaths,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load TLS credentials: %w", err)
+	}
+	creds, err := connection.NewClientGRPCTransportCredentials(tlsCreds)
+	if err != nil {
+		return nil, fmt.Errorf("build transport credentials: %w", err)
+	}
+	conn, err := grpc.NewClient(cfg.Endpoint.Address(), grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", cfg.Endpoint.Address(), err)
+	}
+	return New(conn), nil
+}

--- a/endorser/client/dial_test.go
+++ b/endorser/client/dial_test.go
@@ -7,11 +7,24 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 package client
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-evm/common"
 )
+
+// writeGarbage writes non-PEM content to a temp file and returns its path -
+// the file exists and reads fine, but isn't valid certificate data.
+func writeGarbage(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	if err := os.WriteFile(path, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
 
 func TestDial_NoTLS_Succeeds(t *testing.T) {
 	cfg := common.ClientConfig{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 0}}
@@ -43,5 +56,29 @@ func TestDial_MissingCertFile_ReturnsLoadError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "load TLS credentials") {
 		t.Errorf("error = %q, want it to mention loading TLS credentials", err.Error())
+	}
+}
+
+// The cert files exist and are readable (so NewClientTLSCredentials succeeds),
+// but their content isn't valid certificate data, so building the transport
+// credentials from the loaded bytes fails.
+func TestDial_InvalidCertContent_ReturnsBuildError(t *testing.T) {
+	garbage := writeGarbage(t)
+	cfg := common.ClientConfig{
+		Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 0},
+		TLS: common.TLSConfig{
+			Mode:        "mtls",
+			CertPath:    garbage,
+			KeyPath:     garbage,
+			CACertPaths: []string{garbage},
+		},
+	}
+
+	_, err := Dial(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid certificate content")
+	}
+	if !strings.Contains(err.Error(), "build transport credentials") {
+		t.Errorf("error = %q, want it to mention building transport credentials", err.Error())
 	}
 }

--- a/endorser/client/dial_test.go
+++ b/endorser/client/dial_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-evm/common"
+)
+
+func TestDial_NoTLS_Succeeds(t *testing.T) {
+	cfg := common.ClientConfig{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 0}}
+
+	c, err := Dial(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if c == nil {
+		t.Fatal("Client = nil, want non-nil")
+	}
+}
+
+func TestDial_MissingCertFile_ReturnsLoadError(t *testing.T) {
+	cfg := common.ClientConfig{
+		Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 0},
+		TLS: common.TLSConfig{
+			Mode:        "mtls",
+			CertPath:    "/no/such/cert.pem",
+			KeyPath:     "/no/such/key.pem",
+			CACertPaths: []string{"/no/such/ca.pem"},
+		},
+	}
+
+	_, err := Dial(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing cert files")
+	}
+	if !strings.Contains(err.Error(), "load TLS credentials") {
+		t.Errorf("error = %q, want it to mention loading TLS credentials", err.Error())
+	}
+}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -134,7 +134,7 @@ func newSplitApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, lo
 		cl, err := eclient.Dial(ecfg)
 		if err != nil {
 			closeAll()
-			return nil, fmt.Errorf("dial endorsers %d: %w", i, err)
+			return nil, fmt.Errorf("dial endorser %d: %w", i, err)
 		}
 		conns = append(conns, cl)
 	}

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -24,6 +24,7 @@ import (
 
 	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
 	eapp "github.com/hyperledger/fabric-x-evm/endorser/app"
+	eclient "github.com/hyperledger/fabric-x-evm/endorser/client"
 	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/config"
@@ -38,6 +39,7 @@ var appLogger = flogging.MustGetLogger("gateway.app")
 type App struct {
 	cfg           config.Config
 	endorserSyncs []*network.Synchronizer
+	endorserConns []*eclient.Client // set only in split deployment; closed on Shutdown
 	gwSync        *network.Synchronizer
 	gateway       *core.Gateway
 	chain         *core.Chain
@@ -82,18 +84,23 @@ func NewTestNodeWithConfig(ctx context.Context, cfg config.Config, testAccountsP
 func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableTestRPC bool, testAccountsPath string) (*App, error) {
 	logger := sdk.NewStdLogger("gateway")
 
+	if len(cfg.Gateway.Endorsers) > 0 {
+		if enableTestRPC {
+			return nil, fmt.Errorf("test RPC is not supported with split deployment (gateway.endorsers configured)")
+		}
+		return newSplitApp(ctx, cfg, gwSigner, logger, enableTestRPC, testAccountsPath)
+	}
+
 	// Create endorsers and their synchronizers.
 	endorsers := make([]eapi.Service, 0, len(cfg.Endorsers))
 	endorserSyncs := make([]*network.Synchronizer, 0, len(cfg.Endorsers))
 	var firstKVS estorage.KVS // Keep first endorser's KVS for test server
 	for i, ecfg := range cfg.Endorsers {
-		// Set history size: always 128 for test RPC (snapshot/revert), else default to 2 if not set
 		if enableTestRPC {
 			ecfg.Database.HistorySize = 128
 		} else if ecfg.Database.HistorySize == 0 {
 			ecfg.Database.HistorySize = 2
 		}
-		// load the identity to connect to the peer for synchronizing, and for signing the endorsement.
 		eSigner, err := identity.SignerFromMSP(ecfg.Identity.MSPDir, ecfg.Identity.MspID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create signer: %w", err)
@@ -111,6 +118,39 @@ func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableT
 	}
 
 	return buildApp(ctx, cfg, gwSigner, logger, endorsers, endorserSyncs, firstKVS, enableTestRPC, testAccountsPath)
+}
+
+// newSplitApp builds the gateway in split-deployment mode: every endorsers is
+// dialed over gRPC (co-located ones on localhost, remote ones on their configured address)
+// instead of built in-process
+func newSplitApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, enableTestRPC bool, testAccountsPath string) (*App, error) {
+	conns := make([]*eclient.Client, 0, len(cfg.Gateway.Endorsers))
+	closeAll := func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}
+	for i, ecfg := range cfg.Gateway.Endorsers {
+		cl, err := eclient.Dial(ecfg)
+		if err != nil {
+			closeAll()
+			return nil, fmt.Errorf("dial endorsers %d: %w", i, err)
+		}
+		conns = append(conns, cl)
+	}
+
+	endorsers := make([]eapi.Service, len(conns))
+	for i, c := range conns {
+		endorsers[i] = c
+	}
+
+	app, err := buildApp(ctx, cfg, gwSigner, logger, endorsers, nil, nil, enableTestRPC, testAccountsPath)
+	if err != nil {
+		closeAll()
+		return nil, err
+	}
+	app.endorserConns = conns
+	return app, nil
 }
 
 // buildApp wires up the gateway from pre-built endorsers.
@@ -259,6 +299,13 @@ func (a *App) Shutdown() error {
 		appLogger.Warnf("chain close error: %v", err)
 	} else {
 		appLogger.Debug("chain closed")
+	}
+
+	// Close dialed endorser connections (split deployment only)
+	for _, c := range a.endorserConns {
+		if err := c.Close(); err != nil {
+			appLogger.Warnf("endorser connection close error: %v", err)
+		}
 	}
 
 	appLogger.Debug("graceful shutdown complete")

--- a/gateway/app/app_test.go
+++ b/gateway/app/app_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/hyperledger/fabric-x-sdk"
+
+	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/gateway/config"
+)
+
+func splitModeConfig() config.Config {
+	return config.Config{
+		Gateway: config.Gateway{
+			Endorsers: []common.ClientConfig{
+				{
+					Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 1234},
+					TLS: common.TLSConfig{
+						Mode:        "mtls",
+						CertPath:    "/no/such/cert.pem",
+						KeyPath:     "/no/such/key.pem",
+						CACertPaths: []string{"/no/such/ca.pem"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Test RPC needs a local KVS to snapshot/revert against, which split
+// deployment doesn't have - it must be rejected before any dialing happens.
+func TestNewApp_TestRPCRejectedInSplitMode(t *testing.T) {
+	_, err := newApp(context.Background(), splitModeConfig(), nil, true, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "test RPC is not supported") {
+		t.Errorf("error = %q, want it to mention test RPC is not supported", err.Error())
+	}
+}
+
+// Without test RPC, newApp routes split-mode configs into newSplitApp - a
+// dial failure there surfaces immediately, proving the routing happened.
+func TestNewApp_RoutesToSplitMode(t *testing.T) {
+	_, err := newApp(context.Background(), splitModeConfig(), nil, false, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "dial endorser 0") {
+		t.Errorf("error = %q, want it to have gone through newSplitApp", err.Error())
+	}
+}
+
+// A dial failure for one endorser must fail newSplitApp outright, before ever
+// reaching buildApp (no chain/db/network setup should be attempted).
+func TestNewSplitApp_DialFailureReturnsError(t *testing.T) {
+	logger := sdk.NewStdLogger("gateway")
+	_, err := newSplitApp(context.Background(), splitModeConfig(), nil, logger, false, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "dial endorser 0") {
+		t.Errorf("error = %q, want it to mention the failing endorser index", err.Error())
+	}
+}
+
+// If a later endorser fails to dial, connections already opened for earlier
+// ones must be closed rather than leaked.
+func TestNewSplitApp_ClosesEarlierConnsOnLaterFailure(t *testing.T) {
+	cfg := config.Config{
+		Gateway: config.Gateway{
+			Endorsers: []common.ClientConfig{
+				// Dials successfully: no TLS, no live server needed (lazy dial).
+				{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 1}},
+				// Fails at credential loading, before any network I/O.
+				{
+					Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 2},
+					TLS: common.TLSConfig{
+						Mode:        "mtls",
+						CertPath:    "/no/such/cert.pem",
+						KeyPath:     "/no/such/key.pem",
+						CACertPaths: []string{"/no/such/ca.pem"},
+					},
+				},
+			},
+		},
+	}
+	logger := sdk.NewStdLogger("gateway")
+
+	_, err := newSplitApp(context.Background(), cfg, nil, logger, false, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "dial endorser 1") {
+		t.Errorf("error = %q, want it to mention the second (failing) endorser", err.Error())
+	}
+}

--- a/gateway/app/app_test.go
+++ b/gateway/app/app_test.go
@@ -105,6 +105,26 @@ func TestNewSplitApp_ClosesEarlierConnsOnLaterFailure(t *testing.T) {
 	}
 }
 
+func endpoint(port int) common.ClientConfig {
+	return common.ClientConfig{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: port}}
+}
+
+// splitAppConfig returns a config that dials one endorser successfully
+// (lazy dial, no live server needed) and is otherwise ready for buildApp.
+func splitAppConfig(t *testing.T, dbConnString string) config.Config {
+	t.Helper()
+	return config.Config{
+		Network: common.Network{Protocol: "fabric-x", Channel: "mychannel", Namespace: "basic", NsVersion: "1.0", ChainID: 4011},
+		Gateway: config.Gateway{
+			Database:       config.DB{ConnString: dbConnString},
+			Orderers:       []common.ClientConfig{endpoint(1)},
+			Committer:      endpoint(2),
+			Endorsers:      []common.ClientConfig{endpoint(3)},
+			SubmitterCount: 1,
+		},
+	}
+}
+
 // The wiring underneath buildApp (orderer/committer/peer clients) dials
 // lazily, the same way endorser/client.Dial does - none of it requires a
 // reachable server to construct successfully. So a full split-deployment App
@@ -112,19 +132,7 @@ func TestNewSplitApp_ClosesEarlierConnsOnLaterFailure(t *testing.T) {
 // syntactically valid addresses.
 func TestNewSplitApp_Success(t *testing.T) {
 	dbPath := "file:" + filepath.Join(t.TempDir(), "gw.db")
-	endpoint := func(port int) common.ClientConfig {
-		return common.ClientConfig{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: port}}
-	}
-	cfg := config.Config{
-		Network: common.Network{Protocol: "fabric-x", Channel: "mychannel", Namespace: "basic", NsVersion: "1.0", ChainID: 4011},
-		Gateway: config.Gateway{
-			Database:       config.DB{ConnString: dbPath},
-			Orderers:       []common.ClientConfig{endpoint(1)},
-			Committer:      endpoint(2),
-			Endorsers:      []common.ClientConfig{endpoint(3)},
-			SubmitterCount: 1,
-		},
-	}
+	cfg := splitAppConfig(t, dbPath)
 	logger := sdk.NewStdLogger("gateway")
 
 	app, err := newSplitApp(context.Background(), cfg, nil, logger, false, "")
@@ -133,6 +141,46 @@ func TestNewSplitApp_Success(t *testing.T) {
 	}
 	if len(app.endorserConns) != 1 {
 		t.Errorf("endorserConns = %d, want 1", len(app.endorserConns))
+	}
+
+	if err := app.Shutdown(); err != nil {
+		t.Errorf("Shutdown: unexpected error: %v", err)
+	}
+}
+
+// If buildApp fails after every endorser dialed successfully, the already-open
+// endorser connections must still be closed rather than leaked.
+func TestNewSplitApp_BuildAppFailureClosesConns(t *testing.T) {
+	// A DB path inside a directory that doesn't exist: dialing the endorser
+	// succeeds first, then core.NewChain fails to open the database.
+	cfg := splitAppConfig(t, "file:/no/such/directory/gw.db")
+	logger := sdk.NewStdLogger("gateway")
+
+	_, err := newSplitApp(context.Background(), cfg, nil, logger, false, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to create chain") {
+		t.Errorf("error = %q, want it to come from chain creation", err.Error())
+	}
+}
+
+// Shutdown must not fail or block just because closing an endorser connection
+// errors - it logs and continues, the same way it already treats gateway.Stop
+// and chain.Close errors as non-fatal.
+func TestApp_Shutdown_ToleratesEndorserCloseError(t *testing.T) {
+	dbPath := "file:" + filepath.Join(t.TempDir(), "gw.db")
+	cfg := splitAppConfig(t, dbPath)
+	logger := sdk.NewStdLogger("gateway")
+
+	app, err := newSplitApp(context.Background(), cfg, nil, logger, false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Close it once ourselves so Shutdown's own Close() call errors (closing
+	// an already-closed *grpc.ClientConn returns a non-nil error).
+	if err := app.endorserConns[0].Close(); err != nil {
+		t.Fatalf("pre-close: unexpected error: %v", err)
 	}
 
 	if err := app.Shutdown(); err != nil {

--- a/gateway/app/app_test.go
+++ b/gateway/app/app_test.go
@@ -8,6 +8,7 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -101,5 +102,40 @@ func TestNewSplitApp_ClosesEarlierConnsOnLaterFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "dial endorser 1") {
 		t.Errorf("error = %q, want it to mention the second (failing) endorser", err.Error())
+	}
+}
+
+// The wiring underneath buildApp (orderer/committer/peer clients) dials
+// lazily, the same way endorser/client.Dial does - none of it requires a
+// reachable server to construct successfully. So a full split-deployment App
+// can be built and torn down with nothing but local disk (the chain DB) and
+// syntactically valid addresses.
+func TestNewSplitApp_Success(t *testing.T) {
+	dbPath := "file:" + filepath.Join(t.TempDir(), "gw.db")
+	endpoint := func(port int) common.ClientConfig {
+		return common.ClientConfig{Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: port}}
+	}
+	cfg := config.Config{
+		Network: common.Network{Protocol: "fabric-x", Channel: "mychannel", Namespace: "basic", NsVersion: "1.0", ChainID: 4011},
+		Gateway: config.Gateway{
+			Database:       config.DB{ConnString: dbPath},
+			Orderers:       []common.ClientConfig{endpoint(1)},
+			Committer:      endpoint(2),
+			Endorsers:      []common.ClientConfig{endpoint(3)},
+			SubmitterCount: 1,
+		},
+	}
+	logger := sdk.NewStdLogger("gateway")
+
+	app, err := newSplitApp(context.Background(), cfg, nil, logger, false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(app.endorserConns) != 1 {
+		t.Errorf("endorserConns = %d, want 1", len(app.endorserConns))
+	}
+
+	if err := app.Shutdown(); err != nil {
+		t.Errorf("Shutdown: unexpected error: %v", err)
 	}
 }

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -41,28 +41,30 @@ type Logging struct {
 	Spec string `mapstructure:"spec" yaml:"spec"`
 }
 
-// Gateway contains configuration for the gateway component.
-type Gateway struct {
-	Listen string `mapstructure:"listen" yaml:"listen"` // HTTP listen address for the Ethereum JSON-RPC API
-
-	Identity common.IdentityConfig `mapstructure:"identity" yaml:"identity"`
-
-	Database DB `mapstructure:"database" yaml:"database"`
-
-	Orderers  []common.ClientConfig `mapstructure:"orderers"  yaml:"orderers"`
-	Committer common.ClientConfig   `mapstructure:"committer" yaml:"committer"`
-
-	SyncTimeout time.Duration `mapstructure:"sync-timeout" yaml:"sync-timeout"`
-
-	WorkerCount         int `mapstructure:"worker-count"          yaml:"worker-count"`          // number of worker goroutines; defaults to 1 if not set
-	SubmitterCount      int `mapstructure:"submitter-count"       yaml:"submitter-count"`       // number of batch submitter worker goroutines; defaults to 16 if not set
-	EndorsementChanSize int `mapstructure:"endorsement-chan-size" yaml:"endorsement-chan-size"` // capacity of the endorsement channel; defaults to 1000 if not set
-}
-
 // DB holds the database paths for the gateway.
 type DB struct {
 	ConnString string `mapstructure:"connection-string" yaml:"connection-string"` // SQLite connection string for blocks, transactions, and logs
 	TriePath   string `mapstructure:"trie-path"         yaml:"trie-path"`         // PebbleDB directory for state root trie; empty = in-memory
+}
+
+// Gateway contains configuration for the gateway component.
+type Gateway struct {
+	Listen   string                `mapstructure:"listen" yaml:"listen"`
+	Identity common.IdentityConfig `mapstructure:"identity" yaml:"identity"`
+	Database DB                    `mapstructure:"database" yaml:"database"`
+
+	Orderers  []common.ClientConfig `mapstructure:"orderers" yaml:"orderers"`
+	Committer common.ClientConfig   `mapstructure:"committer" yaml:"committer"`
+
+	// Endorsers, when set, switches to split deployment: the gateway dials each
+	// entry over gRPC (co-located endorsers included, addressed on localhost)
+	// instead of building embedded endorsers from the top-level Endorsers list.
+	Endorsers   []common.ClientConfig `mapstructure:"endorsers" yaml:"endorsers"`
+	SyncTimeout time.Duration         `mapstructure:"sync-timeout" yaml:"sync-timeout"`
+
+	WorkerCount         int `mapstructure:"worker-count"  yaml:"worker-count"`
+	SubmitterCount      int `mapstructure:"submitter-count" yaml:"submitter-count"`
+	EndorsementChanSize int `mapstructure:"endorsement-chan-size"  yaml:"endorsement-chan-size"`
 }
 
 // Validate checks that required fields are set and values are within acceptable ranges.
@@ -100,11 +102,19 @@ func (cfg Config) Validate() error {
 			errs = append(errs, fmt.Errorf("gateway.orderers[%d]: %w", i, err))
 		}
 	}
-	if len(cfg.Endorsers) == 0 {
-		errs = append(errs, errors.New("endorsers must have at least one entry"))
-	}
-	for i := range cfg.Endorsers {
-		errs = append(errs, cfg.Endorsers[i].Validate())
+	if len(cfg.Gateway.Endorsers) == 0 {
+		if len(cfg.Endorsers) == 0 {
+			errs = append(errs, errors.New("endorsers must have at least one entry"))
+		}
+		for i := range cfg.Endorsers {
+			errs = append(errs, cfg.Endorsers[i].Validate())
+		}
+	} else {
+		for i, e := range cfg.Gateway.Endorsers {
+			if err := e.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("gateway.endorsers[%d]: %w", i, err))
+			}
+		}
 	}
 
 	return errors.Join(errs...)

--- a/gateway/config/validate_test.go
+++ b/gateway/config/validate_test.go
@@ -99,6 +99,14 @@ func TestConfigValidate(t *testing.T) {
 			c.Endorsers[0].Database.ConnString = ""
 			c.Endorsers[0].Database.Database = ""
 		}, "database"},
+		{"split mode: gateway.endorsers set, empty top-level endorsers is fine", func(c *config.Config) {
+			c.Gateway.Endorsers = []common.ClientConfig{c.Gateway.Committer}
+			c.Endorsers = nil
+		}, ""},
+		{"split mode: invalid gateway.endorsers entry reported", func(c *config.Config) {
+			c.Gateway.Endorsers = []common.ClientConfig{{}}
+			c.Endorsers = nil
+		}, "gateway.endorsers[0]"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #247. Design: #219 (part 4).

Enables the gRPC endorsement path through configuration the final PR in the #22/#247 series. Everything introduced dormant in #242–#245 becomes reachable here, and only when configured. Without the new configuration, gateway behavior remains exactly as it is today.

## Changes

### Dial the endorser over gRPC

- Added `endorser/client/dial.go` with:
  - `Dial(cfg common.ClientConfig) (*Client, error)`
- Builds mTLS-enabled gRPC transport credentials from `cfg.TLS`.
- Dials `cfg.Endpoint` and returns a `Client` implementing `api.Service`.
- Uses the same credential-building path already exercised end-to-end in #245.

### Config-driven split deployment

- Added `Gateway.Endorsers []common.ClientConfig` to `gateway/config/config.go`.
- When configured, the gateway dials all endorsers over gRPC (localhost for the co-located endorser, remote endpoints for other organizations) instead of constructing them in-process from the top-level `Endorsers` configuration.
- `Validate()` now branches by deployment mode:
  - Split mode validates gRPC dial targets and no longer requires the embedded endorser configuration.
  - Combined mode remains unchanged.

### Gateway wiring

- `gateway/app/app.go` introduces `newSplitApp`, selected automatically when `Gateway.Endorsers` is configured.
- Dialed gRPC clients are tracked on `App` and closed during `Shutdown`.
- Test RPC is explicitly disabled in split mode since it requires a local KVS for snapshot/revert support.

## Interface / API changes

- New exported `endorser/client.Dial`.
- New configuration field:
  - `config.Gateway.Endorsers []common.ClientConfig`
- `App` now owns an internal `endorserConns []*eclient.Client`, closed during shutdown.

## Tests

Added:

- `endorser/client/dial_test.go`
  - No-TLS success
  - Missing certificate file
  - Invalid certificate contents
- `gateway/config/validate_test.go`
  - Split mode accepts an empty top-level `Endorsers`
  - Invalid `Gateway.Endorsers` entries are rejected
- `gateway/app/app_test.go`
  - Split-mode routing
  - Dial failure
  - Cleanup of previously opened connections after a later dial failure
  - Successful split-mode application construction and shutdown
  - `buildApp` failure after successful dialing
  - Shutdown tolerating connection close errors

## Decisions from review
- **No standalone endorser process**: split deployment's gateway side is wired here, but there's nothing to actually dial yet separate entry points and deployment docs are tracked in #21.


## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` (clean)
- [x] `make checks`
- [x] `make unit-tests` (entire repository, including integration)
