### PR TITLE
fix: defer prevHash update until after SQL commit (#304)

### DIFF
--- a/endorser/execution/executor.go
+++ b/endorser/execution/executor.go
@@ -37,8 +37,12 @@ type EVMConfig struct {
 
 // KVSSnapshotter is the port execution uses to obtain a versioned read snapshot
 // of the world state. storage.LightKVS and storage.VersionedDBWrapper implement it.
+//
+// NewSnapshot takes an optional block height: nil means latest committed state;
+// a non-nil value means that exact height (including 0 for genesis / earliest).
+// Callers must not use 0 as a "latest" sentinel.
 type KVSSnapshotter interface {
-	NewSnapshot(blockNumber uint64) (ReadStore, error)
+	NewSnapshot(blockNumber *uint64) (ReadStore, error)
 }
 
 // EVMEngine manages EVM execution and state reads for an endorser.
@@ -154,30 +158,41 @@ func (e *EVMEngine) NonceAt(_ context.Context, account common.Address, blockNumb
 	return snap.GetNonce(account), nil
 }
 
-// resolveStateBlockNumber converts a state-query block number to the KVSSnapshotter
-// convention (0 = latest). nil and any negative value (an unresolved go-ethereum block-tag
-// sentinel) resolve to 0/latest rather than corrupting via *big.Int.Uint64()'s absolute-value
-// conversion.
-func resolveStateBlockNumber(blockNumber *big.Int) uint64 {
+// resolveStateBlockRef converts a state-query block number to the KVSSnapshotter
+// argument form. nil and any negative value (an unresolved go-ethereum block-tag
+// sentinel) resolve to nil/latest rather than corrupting via *big.Int.Uint64()'s
+// absolute-value conversion. A non-negative value (including 0 for earliest) is
+// passed through as an explicit height pointer.
+func resolveStateBlockRef(blockNumber *big.Int) *uint64 {
 	if blockNumber == nil || blockNumber.Sign() < 0 {
+		return nil
+	}
+	n := blockNumber.Uint64()
+	return &n
+}
+
+// stateDBBlockNum is the uint64 passed into NewStateDB for journal metadata.
+// Latest (nil) uses 0; an explicit height uses that height.
+func stateDBBlockNum(ref *uint64) uint64 {
+	if ref == nil {
 		return 0
 	}
-	return blockNumber.Uint64()
+	return *ref
 }
 
 // newExecutor creates a fresh executor with an isolated StateDB.
 // blockNumber selects the Fabric block height for the state snapshot (nil = latest).
 func (e *EVMEngine) newExecutor(blockNumber *big.Int) (*Executor, error) {
-	stateBlockNum := resolveStateBlockNumber(blockNumber)
+	ref := resolveStateBlockRef(blockNumber)
 
 	// Begin a new reader to get snapshot isolation
-	reader, err := e.kvs.NewSnapshot(stateBlockNum)
+	reader, err := e.kvs.NewSnapshot(ref)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create StateDB with the reader
-	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, stateBlockNum, e.monotonicVersions)
+	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, stateDBBlockNum(ref), e.monotonicVersions)
 	if err != nil {
 		reader.Close()
 		return nil, err
@@ -195,19 +210,20 @@ func (e *EVMEngine) newExecutor(blockNumber *big.Int) (*Executor, error) {
 	return ex, nil
 }
 
-// newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height (0 = latest).
+// newSnapshotAt returns an ExtendedStateDB over the state at the given Fabric block height.
+// nil blockNumber means latest; a non-negative value (including 0) is that exact height.
 // The caller must close the returned reader when done.
 func (e *EVMEngine) newSnapshotAt(blockNumber *big.Int) (ExtendedStateDB, ReadStore, error) {
-	blockNum := resolveStateBlockNumber(blockNumber)
+	ref := resolveStateBlockRef(blockNumber)
 
 	// Begin a new reader to get snapshot isolation
-	reader, err := e.kvs.NewSnapshot(blockNum)
+	reader, err := e.kvs.NewSnapshot(ref)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Create StateDB with the reader
-	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, blockNum, e.monotonicVersions)
+	stateDB, err := NewStateDB(context.TODO(), reader, e.namespace, stateDBBlockNum(ref), e.monotonicVersions)
 	if err != nil {
 		reader.Close()
 		return nil, nil, err

--- a/endorser/execution/executor_test.go
+++ b/endorser/execution/executor_test.go
@@ -120,6 +120,53 @@ func TestNewExecutor_BareStateDBWhenDebugDisabled(t *testing.T) {
 	}
 }
 
+// TestResolveStateBlockRef maps big.Int heights onto NewSnapshot args.
+func TestResolveStateBlockRef(t *testing.T) {
+	if got := resolveStateBlockRef(nil); got != nil {
+		t.Fatalf("nil -> %v, want nil (latest)", got)
+	}
+	if got := resolveStateBlockRef(big.NewInt(-5)); got != nil {
+		t.Fatalf("negative -> %v, want nil (latest)", got)
+	}
+	got0 := resolveStateBlockRef(big.NewInt(0))
+	if got0 == nil || *got0 != 0 {
+		t.Fatalf("0 -> %v, want pointer to 0 (earliest)", got0)
+	}
+	got7 := resolveStateBlockRef(big.NewInt(7))
+	if got7 == nil || *got7 != 7 {
+		t.Fatalf("7 -> %v, want pointer to 7", got7)
+	}
+	if stateDBBlockNum(nil) != 0 {
+		t.Fatalf("stateDBBlockNum(nil) want 0")
+	}
+	if stateDBBlockNum(got7) != 7 {
+		t.Fatalf("stateDBBlockNum(7) want 7")
+	}
+}
+
+// TestNewSnapshotAt_ZeroIsExplicitGenesis ensures earliest (block 0) is not remapped
+// to the tip after the chain has advanced (issue #293).
+func TestNewSnapshotAt_ZeroIsExplicitGenesis(t *testing.T) {
+	backend, err := state.NewWriteDB(Channel, "file:exec_zero_snapshot?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvs := &testVersionedDBSnapshotter{db: backend}
+	cfg := EVMConfig{ChainConfig: common.BuildChainConfig(4011)}
+	eng := NewEVMEngine(Namespace, kvs, cfg, false)
+
+	_, reader, err := eng.newSnapshotAt(big.NewInt(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	got := reader.(*testVersionedDBReader).blockNumber
+	if got != 0 {
+		t.Errorf("newSnapshotAt(0) resolved to block %d, want 0", got)
+	}
+}
+
 // TestNewSnapshotAt_NegativeBlockNumberResolvesToLatest guards against callers upstream
 // handing this engine a negative *big.Int carrying an unresolved go-ethereum block-tag
 // sentinel (e.g. "earliest" == -5 in the pinned go-ethereum version). blockNumber.Uint64()

--- a/endorser/execution/state_test.go
+++ b/endorser/execution/state_test.go
@@ -121,7 +121,7 @@ func assertEqual[T comparable](t *testing.T, label string, got1, got2, expected 
 
 func snapshotDB(t *testing.T, backend *state.VersionedDB, blockNum uint64) *StateDB {
 	wrapper := &testVersionedDBSnapshotter{db: backend}
-	snapshot, err := wrapper.NewSnapshot(blockNum)
+	snapshot, err := wrapper.NewSnapshot(&blockNum)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/endorser/execution/testkvs_test.go
+++ b/endorser/execution/testkvs_test.go
@@ -21,15 +21,18 @@ type testVersionedDBSnapshotter struct {
 	db *state.VersionedDB
 }
 
-func (w *testVersionedDBSnapshotter) NewSnapshot(blockNumber uint64) (ReadStore, error) {
-	if blockNumber == 0 {
+func (w *testVersionedDBSnapshotter) NewSnapshot(blockNumber *uint64) (ReadStore, error) {
+	var bn uint64
+	if blockNumber == nil {
 		latest, err := w.db.BlockNumber(context.Background())
 		if err != nil {
 			return nil, err
 		}
-		blockNumber = latest
+		bn = latest
+	} else {
+		bn = *blockNumber
 	}
-	return &testVersionedDBReader{db: w.db, blockNumber: blockNumber}, nil
+	return &testVersionedDBReader{db: w.db, blockNumber: bn}, nil
 }
 
 type testVersionedDBReader struct {

--- a/endorser/storage/bench_test.go
+++ b/endorser/storage/bench_test.go
@@ -407,7 +407,7 @@ func BenchmarkSimulation(b *testing.B) {
 					b.ResetTimer()
 					b.ReportAllocs()
 					for range b.N {
-						reader, err := kvs.NewSnapshot(preloadLastBlock)
+						reader, err := kvs.NewSnapshot(storage.BlockAt(preloadLastBlock))
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -507,7 +507,7 @@ func BenchmarkMixed(b *testing.B) {
 				b.ResetTimer()
 				for range b.N {
 					n := lastBlock.Load()
-					reader, err := kvs.NewSnapshot(n)
+					reader, err := kvs.NewSnapshot(storage.BlockAt(n))
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/endorser/storage/kvs_parity_test.go
+++ b/endorser/storage/kvs_parity_test.go
@@ -318,9 +318,9 @@ func TestParityTimeTravelReads(t *testing.T) {
 		}
 
 		// A snapshot pins its block: writes after it are invisible.
-		snap, err := kvs.NewSnapshot(2)
+		snap, err := kvs.NewSnapshot(BlockAt(2))
 		if err != nil {
-			t.Fatalf("NewSnapshot(2): %v", err)
+			t.Fatalf("NewSnapshot(BlockAt(2)): %v", err)
 		}
 		defer snap.Close()
 		rec, err := snap.Get("ns1", "k")

--- a/endorser/storage/lightkvs.go
+++ b/endorser/storage/lightkvs.go
@@ -152,35 +152,35 @@ func NewLightKVS(historySize int) *LightKVS {
 
 // NewSnapshot starts a new read transaction and returns a Reader for the specified block number.
 // The Reader will see a consistent snapshot of the store at the requested block number.
-// If blockNumber is 0, it returns the current snapshot (latest state).
-// Otherwise, it first checks the current snapshot, then searches the history for a matching block number.
+// nil means latest; a non-nil value is that exact height (including 0 for genesis).
 // If no matching snapshot is found, it returns an error.
 //
 // Readers must call Close() when done to allow garbage collection of old snapshots.
-func (kvs *LightKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
-	// Load the current snapshot
+func (kvs *LightKVS) NewSnapshot(blockNumber *uint64) (execution.ReadStore, error) {
 	current := kvs.Current.Load()
 
-	// If blockNumber is 0, return the current snapshot (latest state)
-	if blockNumber == 0 {
+	// Latest tip.
+	if blockNumber == nil {
 		return &Reader{
 			Snapshot: current,
 			Kvs:      kvs,
 		}, nil
 	}
 
-	// Check if requested snapshot matches or is greater than the current block number
-	if blockNumber >= current.BlockNumber {
+	bn := *blockNumber
+
+	// At or past the tip: serve current (covers current height and "future" asks).
+	if bn >= current.BlockNumber {
 		return &Reader{
 			Snapshot: current,
 			Kvs:      kvs,
 		}, nil
 	}
 
-	// Search through history snapshots for the requested block number
+	// Historical: exact match only.
 	for i := range kvs.History {
 		snapshot := kvs.History[i].Load()
-		if snapshot != nil && snapshot.BlockNumber == blockNumber {
+		if snapshot != nil && snapshot.BlockNumber == bn {
 			return &Reader{
 				Snapshot: snapshot,
 				Kvs:      kvs,
@@ -188,18 +188,32 @@ func (kvs *LightKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error
 		}
 	}
 
-	// No matching snapshot found
-	return nil, fmt.Errorf("snapshot not found for block number %d", blockNumber)
+	return nil, fmt.Errorf("snapshot not found for block number %d", bn)
 }
 
 func (kvs *LightKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error) {
-	r, err := kvs.NewSnapshot(lastBlock)
+	// lastBlock 0 keeps the historical Get convention of "latest".
+	r, err := kvs.NewSnapshot(blockRefFromLastBlock(lastBlock))
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
 
 	return r.Get(namespace, key)
+}
+
+// blockRefFromLastBlock maps the older Get lastBlock convention (0 = latest)
+// onto NewSnapshot's pointer form.
+func blockRefFromLastBlock(lastBlock uint64) *uint64 {
+	if lastBlock == 0 {
+		return nil
+	}
+	return &lastBlock
+}
+
+// BlockAt returns a *uint64 for an explicit NewSnapshot height (including 0).
+func BlockAt(n uint64) *uint64 {
+	return &n
 }
 
 // Get retrieves the value and version for a key from the reader's snapshot.

--- a/endorser/storage/lightkvs_test.go
+++ b/endorser/storage/lightkvs_test.go
@@ -35,10 +35,53 @@ func TestNewLightKVS(t *testing.T) {
 	}
 }
 
+// TestNewSnapshot_ExplicitZeroIsNotLatest pins issue #293: asking for block 0
+// must not silently resolve to the tip after the chain has moved on.
+func TestNewSnapshot_ExplicitZeroIsNotLatest(t *testing.T) {
+	kvs := NewLightKVS(4)
+	ns := "basic"
+	key := "acc:0x1:bal"
+
+	// Genesis empty, then write at block 1 so tip != genesis.
+	if err := kvs.Update([]KeyValueVersion{{
+		Key: ns + ":" + key, Value: []byte{0x2a}, BlockNum: 1, TxNum: 0, TxID: "tx1",
+	}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Latest must see the write.
+	latest, err := kvs.NewSnapshot(nil)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	rec, err := latest.Get(ns, key)
+	latest.Close()
+	if err != nil {
+		t.Fatalf("latest Get: %v", err)
+	}
+	if rec == nil || len(rec.Value) == 0 || rec.Value[0] != 0x2a {
+		t.Fatalf("latest value = %v, want 0x2a", rec)
+	}
+
+	// Explicit 0 must return the genesis snapshot (empty for this key).
+	gen, err := kvs.NewSnapshot(BlockAt(0))
+	if err != nil {
+		t.Fatalf("block 0: %v", err)
+	}
+	rec0, err := gen.Get(ns, key)
+	gen.Close()
+	if err != nil {
+		t.Fatalf("block 0 Get: %v", err)
+	}
+	if rec0 != nil {
+		t.Fatalf("block 0 still has key (value=%v); earliest must not equal latest", rec0.Value)
+	}
+}
+
 // TestNewSnapshot tests creating a new snapshot reader
 func TestNewSnapshot(t *testing.T) {
 	kvs := NewLightKVS(1)
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -88,7 +131,7 @@ func TestReaderGet(t *testing.T) {
 	}
 
 	// Create reader and test Get
-	reader, err := kvs.NewSnapshot(1)
+	reader, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -154,7 +197,7 @@ func TestReaderGetNilValue(t *testing.T) {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(1)
+	reader, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -175,7 +218,7 @@ func TestReaderGetNilValue(t *testing.T) {
 // TestReaderClose tests closing a reader
 func TestReaderClose(t *testing.T) {
 	kvs := NewLightKVS(1)
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -412,7 +455,7 @@ func TestSnapshotIsolation(t *testing.T) {
 	}
 
 	// Create reader before update
-	reader1, err := kvs.NewSnapshot(1)
+	reader1, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -435,7 +478,7 @@ func TestSnapshotIsolation(t *testing.T) {
 	}
 
 	// Create reader after update
-	reader2, err := kvs.NewSnapshot(2)
+	reader2, err := kvs.NewSnapshot(BlockAt(2))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -488,7 +531,7 @@ func TestConcurrentReaders(t *testing.T) {
 	for i := 0; i < numReaders; i++ {
 		go func() {
 			defer wg.Done()
-			reader, err := kvs.NewSnapshot(1)
+			reader, err := kvs.NewSnapshot(BlockAt(1))
 			if err != nil {
 				t.Errorf("NewSnapshot failed: %v", err)
 				return
@@ -574,7 +617,7 @@ func TestHandle(t *testing.T) {
 	}
 
 	// Verify data was stored
-	reader, err := kvs.NewSnapshot(1)
+	reader, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -674,7 +717,7 @@ func TestHandleInvalidTransactions(t *testing.T) {
 		t.Fatalf("Handle failed: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(1)
+	reader, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -739,7 +782,7 @@ func TestHandleDeletes(t *testing.T) {
 	}
 
 	// Verify key exists
-	reader1, err := kvs.NewSnapshot(1)
+	reader1, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -783,7 +826,7 @@ func TestHandleDeletes(t *testing.T) {
 	}
 
 	// Verify key is deleted
-	reader2, err := kvs.NewSnapshot(2)
+	reader2, err := kvs.NewSnapshot(BlockAt(2))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -1015,7 +1058,7 @@ func TestMultipleNamespaces(t *testing.T) {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(1)
+	reader, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -1142,7 +1185,7 @@ func TestConcurrentReadersWithUpdates(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			// Request block 0 (current snapshot) to get whatever state exists at this moment
-			reader, err := kvs.NewSnapshot(0)
+			reader, err := kvs.NewSnapshot(nil)
 			if err != nil {
 				t.Errorf("NewSnapshot failed: %v", err)
 				return
@@ -1225,9 +1268,9 @@ func TestSnapshotByBlockNumber(t *testing.T) {
 	}
 
 	// Test getting current snapshot (block 0 means current)
-	readerCurrent, err := kvs.NewSnapshot(0)
+	readerCurrent, err := kvs.NewSnapshot(nil)
 	if err != nil {
-		t.Fatalf("NewSnapshot(0) failed: %v", err)
+		t.Fatalf("NewSnapshot(nil) failed: %v", err)
 	}
 	defer readerCurrent.Close()
 
@@ -1240,9 +1283,9 @@ func TestSnapshotByBlockNumber(t *testing.T) {
 	}
 
 	// Test getting snapshot by specific block number (current block)
-	reader2, err := kvs.NewSnapshot(2)
+	reader2, err := kvs.NewSnapshot(BlockAt(2))
 	if err != nil {
-		t.Fatalf("NewSnapshot(2) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(2)) failed: %v", err)
 	}
 	defer reader2.Close()
 
@@ -1255,9 +1298,9 @@ func TestSnapshotByBlockNumber(t *testing.T) {
 	}
 
 	// Test getting snapshot from history (block 1 should still be in history)
-	reader1, err := kvs.NewSnapshot(1)
+	reader1, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
-		t.Fatalf("NewSnapshot(1) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(1)) failed: %v", err)
 	}
 	defer reader1.Close()
 
@@ -1294,9 +1337,9 @@ func TestSnapshotHistoryEviction(t *testing.T) {
 	}
 
 	// Current snapshot should be block 4
-	readerCurrent, err := kvs.NewSnapshot(4)
+	readerCurrent, err := kvs.NewSnapshot(BlockAt(4))
 	if err != nil {
-		t.Fatalf("NewSnapshot(4) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(4)) failed: %v", err)
 	}
 	defer readerCurrent.Close()
 
@@ -1309,9 +1352,9 @@ func TestSnapshotHistoryEviction(t *testing.T) {
 	}
 
 	// Block 3 should be in history (most recent old snapshot)
-	reader3, err := kvs.NewSnapshot(3)
+	reader3, err := kvs.NewSnapshot(BlockAt(3))
 	if err != nil {
-		t.Fatalf("NewSnapshot(3) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(3)) failed: %v", err)
 	}
 	defer reader3.Close()
 
@@ -1324,9 +1367,9 @@ func TestSnapshotHistoryEviction(t *testing.T) {
 	}
 
 	// Block 2 should be in history (second most recent old snapshot)
-	reader2, err := kvs.NewSnapshot(2)
+	reader2, err := kvs.NewSnapshot(BlockAt(2))
 	if err != nil {
-		t.Fatalf("NewSnapshot(2) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(2)) failed: %v", err)
 	}
 	defer reader2.Close()
 
@@ -1339,7 +1382,7 @@ func TestSnapshotHistoryEviction(t *testing.T) {
 	}
 
 	// Block 1 should have been evicted (history only keeps 2 snapshots)
-	_, err = kvs.NewSnapshot(1)
+	_, err = kvs.NewSnapshot(BlockAt(1))
 	if err == nil {
 		t.Error("Expected error when requesting evicted block 1, got nil")
 	}
@@ -1370,9 +1413,9 @@ func TestSnapshotNonExistentBlock(t *testing.T) {
 	}
 
 	// Try to get snapshot for block 99 (higher than current, should return current)
-	reader99, err := kvs.NewSnapshot(99)
+	reader99, err := kvs.NewSnapshot(BlockAt(99))
 	if err != nil {
-		t.Fatalf("NewSnapshot(99) should not fail when requesting future block: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(99)) should not fail when requesting future block: %v", err)
 	}
 	defer reader99.Close()
 
@@ -1386,9 +1429,9 @@ func TestSnapshotNonExistentBlock(t *testing.T) {
 	}
 
 	// Block 0 (current) should always work
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
-		t.Fatalf("NewSnapshot(0) should not fail: %v", err)
+		t.Fatalf("NewSnapshot(nil) should not fail: %v", err)
 	}
 	defer reader.Close()
 }
@@ -1414,9 +1457,9 @@ func TestSnapshotIsolationAcrossBlocks(t *testing.T) {
 	}
 
 	// Get snapshot for block 1
-	reader1, err := kvs.NewSnapshot(1)
+	reader1, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
-		t.Fatalf("NewSnapshot(1) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(1)) failed: %v", err)
 	}
 	defer reader1.Close()
 
@@ -1437,9 +1480,9 @@ func TestSnapshotIsolationAcrossBlocks(t *testing.T) {
 	}
 
 	// Get snapshot for block 2
-	reader2, err := kvs.NewSnapshot(2)
+	reader2, err := kvs.NewSnapshot(BlockAt(2))
 	if err != nil {
-		t.Fatalf("NewSnapshot(2) failed: %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(2)) failed: %v", err)
 	}
 	defer reader2.Close()
 

--- a/endorser/storage/pebblekvs.go
+++ b/endorser/storage/pebblekvs.go
@@ -298,26 +298,29 @@ func (p *PebbleKVS) latestVersion(fullKey string) (int64, error) {
 	return -1, it.Error()
 }
 
-// NewSnapshot returns a read view of the store as of blockNumber. A blockNumber
-// of 0 resolves to the latest committed block at call time, pinning the view so
-// later commits (higher block numbers) are naturally excluded. Any historical
-// block is serviceable; unlike LightKVS this never errors for an "evicted"
-// block.
-func (p *PebbleKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
-	if blockNumber == 0 {
-		blockNumber = p.currentBlock.Load()
+// NewSnapshot returns a read view of the store as of blockNumber. nil means the
+// latest committed block at call time, pinning the view so later commits
+// (higher block numbers) are naturally excluded. A non-nil value is that exact
+// height (including 0 for genesis). Any historical block is serviceable; unlike
+// LightKVS this never errors for an "evicted" block.
+func (p *PebbleKVS) NewSnapshot(blockNumber *uint64) (execution.ReadStore, error) {
+	var bn uint64
+	if blockNumber == nil {
+		bn = p.currentBlock.Load()
+	} else {
+		bn = *blockNumber
 	}
 	return &pebbleSnapshot{
 		db:        p.db,
-		lastBlock: blockNumber,
+		lastBlock: bn,
 	}, nil
 }
 
 // Get returns the record for (namespace, key) as of lastBlock, or nil if no
 // such record exists at or before that block. A lastBlock of 0 resolves to the
-// latest committed block.
+// latest committed block (legacy Get convention).
 func (p *PebbleKVS) Get(namespace, key string, lastBlock uint64) (*blocks.WriteRecord, error) {
-	r, err := p.NewSnapshot(lastBlock)
+	r, err := p.NewSnapshot(blockRefFromLastBlock(lastBlock))
 	if err != nil {
 		return nil, err
 	}

--- a/endorser/storage/revertible_lightkvs.go
+++ b/endorser/storage/revertible_lightkvs.go
@@ -47,21 +47,30 @@ func NewRevertibleLightKVS(lightKVS *LightKVS) *RevertibleLightKVS {
 }
 
 // NewSnapshot starts a new read transaction and returns a Reader for the specified block number.
-// The Reader will see a consistent snapshot of the store at the requested block number.
-// If blockNumber is 0, it returns the current snapshot (latest state).
+// nil means latest; a non-nil value is that exact height (including 0 for genesis).
 //
 // Historical lookups search history by block number (exact match, else the latest
 // preserved snapshot at or before the request). Hop-by-distance is wrong when
 // empty blocks leave no Update entry: Fabric block numbers then skip, and a
 // distance-based index misses snapshots that are still in the ring.
 // Readers must call Close() when done to allow garbage collection of old snapshots.
-func (kvs *RevertibleLightKVS) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
+func (kvs *RevertibleLightKVS) NewSnapshot(blockNumber *uint64) (execution.ReadStore, error) {
 	current := kvs.Current.Load()
 	count := int(kvs.NextIndex.Load())
 
-	if blockNumber == 0 || blockNumber >= current.BlockNumber {
+	if blockNumber == nil {
+		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning current snapshot: requested=latest returned=%d historyCount=%d",
+			current.BlockNumber, count)
+		return &Reader{
+			Snapshot: current,
+			Kvs:      kvs.LightKVS,
+		}, nil
+	}
+
+	bn := *blockNumber
+	if bn >= current.BlockNumber {
 		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning current snapshot: requested=%d returned=%d historyCount=%d",
-			blockNumber, current.BlockNumber, count)
+			bn, current.BlockNumber, count)
 		return &Reader{
 			Snapshot: current,
 			Kvs:      kvs.LightKVS,
@@ -76,29 +85,29 @@ func (kvs *RevertibleLightKVS) NewSnapshot(blockNumber uint64) (execution.ReadSt
 		if snap == nil {
 			continue
 		}
-		if snap.BlockNumber == blockNumber {
-			revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() exact history hit: requested=%d", blockNumber)
+		if snap.BlockNumber == bn {
+			revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() exact history hit: requested=%d", bn)
 			return &Reader{
 				Snapshot: snap,
 				Kvs:      kvs.LightKVS,
 			}, nil
 		}
-		if snap.BlockNumber < blockNumber && (best == nil || snap.BlockNumber > best.BlockNumber) {
+		if snap.BlockNumber < bn && (best == nil || snap.BlockNumber > best.BlockNumber) {
 			best = snap
 		}
 	}
 	if best != nil {
 		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() nearest history hit: requested=%d returned=%d",
-			blockNumber, best.BlockNumber)
+			bn, best.BlockNumber)
 		return &Reader{
 			Snapshot: best,
 			Kvs:      kvs.LightKVS,
 		}, nil
 	}
 
-	err := fmt.Errorf("snapshot not found for block number %d", blockNumber)
+	err := fmt.Errorf("snapshot not found for block number %d", bn)
 	revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() returning error: requested=%d current=%d historyCount=%d err=%v",
-		blockNumber, current.BlockNumber, count, err)
+		bn, current.BlockNumber, count, err)
 	return nil, err
 }
 

--- a/endorser/storage/revertible_lightkvs_test.go
+++ b/endorser/storage/revertible_lightkvs_test.go
@@ -60,7 +60,7 @@ func TestRevertibleLightKVS_RevertToBlock(t *testing.T) {
 		t.Errorf("expected block number 1 after revert, got %d", blockNum)
 	}
 
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestRevertibleLightKVS_RevertThenContinue(t *testing.T) {
 		t.Fatalf("Update after revert failed: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot failed: %v", err)
 	}
@@ -174,9 +174,9 @@ func TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks(t *testing.T) {
 	}
 
 	// Read as-of block 3: no entry for 3, but state is still v1 from block 1.
-	reader, err := kvs.NewSnapshot(3)
+	reader, err := kvs.NewSnapshot(BlockAt(3))
 	if err != nil {
-		t.Fatalf("NewSnapshot(3): %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(3)): %v", err)
 	}
 	defer reader.Close()
 
@@ -189,9 +189,9 @@ func TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks(t *testing.T) {
 	}
 
 	// Exact match at block 1 still works.
-	r1, err := kvs.NewSnapshot(1)
+	r1, err := kvs.NewSnapshot(BlockAt(1))
 	if err != nil {
-		t.Fatalf("NewSnapshot(1): %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(1)): %v", err)
 	}
 	defer r1.Close()
 	rec1, err := r1.Get("ns1", "key1")
@@ -203,9 +203,9 @@ func TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks(t *testing.T) {
 	}
 
 	// At or past current returns latest (v5).
-	rLatest, err := kvs.NewSnapshot(5)
+	rLatest, err := kvs.NewSnapshot(BlockAt(5))
 	if err != nil {
-		t.Fatalf("NewSnapshot(5): %v", err)
+		t.Fatalf("NewSnapshot(BlockAt(5)): %v", err)
 	}
 	defer rLatest.Close()
 	recLatest, err := rLatest.Get("ns1", "key1")
@@ -233,7 +233,7 @@ func TestRevertibleLightKVS_NewSnapshot_NotFound(t *testing.T) {
 	// older than current remains.
 	kvs.History[0].Store(nil)
 
-	if _, err := kvs.NewSnapshot(3); err == nil {
+	if _, err := kvs.NewSnapshot(BlockAt(3)); err == nil {
 		t.Fatal("expected error when no history exists at or before block 3")
 	}
 }

--- a/endorser/storage/versioned_db_wrapper.go
+++ b/endorser/storage/versioned_db_wrapper.go
@@ -33,18 +33,22 @@ func NewVersionedDBWrapper(db *state.VersionedDB) *VersionedDBWrapper {
 
 // NewSnapshot creates a new snapshot of the state at the specified block number.
 // It returns a VersionedDBSnapshot that will use this block number for all Get operations,
-// providing snapshot isolation. If blockNumber is 0 it resolves to the latest committed block.
-func (w *VersionedDBWrapper) NewSnapshot(blockNumber uint64) (execution.ReadStore, error) {
-	if blockNumber == 0 {
+// providing snapshot isolation. nil means latest; a non-nil value is that exact height
+// (including 0 for genesis).
+func (w *VersionedDBWrapper) NewSnapshot(blockNumber *uint64) (execution.ReadStore, error) {
+	var bn uint64
+	if blockNumber == nil {
 		latest, err := w.db.BlockNumber(context.Background())
 		if err != nil {
 			return nil, err
 		}
-		blockNumber = latest
+		bn = latest
+	} else {
+		bn = *blockNumber
 	}
 	return &VersionedDBSnapshot{
 		db:          w.db,
-		blockNumber: blockNumber,
+		blockNumber: bn,
 	}, nil
 }
 

--- a/endorser/storage/versioned_db_wrapper_test.go
+++ b/endorser/storage/versioned_db_wrapper_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-sdk/state"
+)
+
+// TestVersionedDBWrapper_NewSnapshotNilVsZero checks that nil means latest and
+// an explicit 0 is not rewritten to the tip (issue #293).
+func TestVersionedDBWrapper_NewSnapshotNilVsZero(t *testing.T) {
+	db, err := state.NewWriteDB("ch", "file:vdb_snap_nilzero?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := NewVersionedDBWrapper(db)
+
+	latestH, err := db.BlockNumber(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rNil, err := w.NewSnapshot(nil)
+	if err != nil {
+		t.Fatalf("nil: %v", err)
+	}
+	defer rNil.Close()
+	if got := rNil.(*VersionedDBSnapshot).blockNumber; got != latestH {
+		t.Fatalf("nil resolved to %d, want latest %d", got, latestH)
+	}
+
+	r0, err := w.NewSnapshot(BlockAt(0))
+	if err != nil {
+		t.Fatalf("block 0: %v", err)
+	}
+	defer r0.Close()
+	if got := r0.(*VersionedDBSnapshot).blockNumber; got != 0 {
+		t.Fatalf("block 0 resolved to %d, want 0", got)
+	}
+}

--- a/endorser/testimpl/balance_priming_executor.go
+++ b/endorser/testimpl/balance_priming_executor.go
@@ -60,7 +60,7 @@ func NewBalancePrimingExecutor(
 	blockContext *vm.BlockContext,
 ) (*BalancePrimingExecutor, error) {
 	// Begin a new reader to get snapshot isolation
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/endorser/testimpl/executor_constructors_test.go
+++ b/endorser/testimpl/executor_constructors_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package testimpl
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/triedb"
+	fxcommon "github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
+	"github.com/hyperledger/fabric-x-evm/endorser/storage"
+)
+
+func testEVMConfig() execution.EVMConfig {
+	return execution.EVMConfig{ChainConfig: fxcommon.BuildChainConfig(4011)}
+}
+
+func emptyEthStateDB(t *testing.T) *state.StateDB {
+	t.Helper()
+	trieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
+	sdb := state.NewDatabase(trieDB, nil)
+	ethStateDB, err := state.New(types.EmptyRootHash, sdb)
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	return ethStateDB
+}
+
+func TestNewBalancePrimingExecutor_UsesLatestSnapshot(t *testing.T) {
+	kvs := storage.NewLightKVS(8)
+	ex, err := NewBalancePrimingExecutor("testns", kvs, testEVMConfig(), true, nil, nil)
+	if err != nil {
+		t.Fatalf("NewBalancePrimingExecutor: %v", err)
+	}
+	if ex == nil || ex.Executor == nil {
+		t.Fatal("expected non-nil executor")
+	}
+	ex.Close()
+}
+
+func TestNewBalancePrimingExecutor_WithPrimingEnabled(t *testing.T) {
+	kvs := storage.NewLightKVS(8)
+	cfg := &BalancePrimingConfig{
+		Enabled:         true,
+		ContractAddress: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		MappingPosition: 0,
+	}
+	ex, err := NewBalancePrimingExecutor("testns", kvs, testEVMConfig(), true, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewBalancePrimingExecutor: %v", err)
+	}
+	if ex == nil || ex.Executor == nil {
+		t.Fatal("expected non-nil executor")
+	}
+	if _, ok := ex.state.(*BalancePrimingWrapper); !ok {
+		t.Fatalf("expected *BalancePrimingWrapper, got %T", ex.state)
+	}
+	ex.Close()
+}
+
+func TestNewExecutorWrapper_UsesLatestSnapshot(t *testing.T) {
+	kvs := storage.NewLightKVS(8)
+	ex, err := NewExecutorWrapper("testns", kvs, testEVMConfig(), true, emptyEthStateDB(t), nil)
+	if err != nil {
+		t.Fatalf("NewExecutorWrapper: %v", err)
+	}
+	if ex == nil || ex.Executor == nil {
+		t.Fatal("expected non-nil executor")
+	}
+	if ex.state == nil {
+		t.Fatal("expected DualStateDB")
+	}
+	ex.Close()
+}

--- a/endorser/testimpl/executor_constructors_test.go
+++ b/endorser/testimpl/executor_constructors_test.go
@@ -43,7 +43,7 @@ func TestNewBalancePrimingExecutor_UsesLatestSnapshot(t *testing.T) {
 	if ex == nil || ex.Executor == nil {
 		t.Fatal("expected non-nil executor")
 	}
-	ex.Close()
+	t.Cleanup(func() { ex.Close() })
 }
 
 func TestNewBalancePrimingExecutor_WithPrimingEnabled(t *testing.T) {
@@ -63,7 +63,7 @@ func TestNewBalancePrimingExecutor_WithPrimingEnabled(t *testing.T) {
 	if _, ok := ex.state.(*BalancePrimingWrapper); !ok {
 		t.Fatalf("expected *BalancePrimingWrapper, got %T", ex.state)
 	}
-	ex.Close()
+	t.Cleanup(func() { ex.Close() })
 }
 
 func TestNewExecutorWrapper_UsesLatestSnapshot(t *testing.T) {
@@ -78,5 +78,5 @@ func TestNewExecutorWrapper_UsesLatestSnapshot(t *testing.T) {
 	if ex.state == nil {
 		t.Fatal("expected DualStateDB")
 	}
-	ex.Close()
+	t.Cleanup(func() { ex.Close() })
 }

--- a/endorser/testimpl/executor_wrapper.go
+++ b/endorser/testimpl/executor_wrapper.go
@@ -37,7 +37,7 @@ func NewExecutorWrapper(
 	blockContext *vm.BlockContext,
 ) (*ExecutorWrapper, error) {
 	// Begin a new reader to get snapshot isolation
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -84,12 +84,11 @@ func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 	} else {
 		ebl.StateRoot = types.EmptyRootHash[:]
 	}
-	c.prevHash = common.BytesToHash(ebl.BlockHash)
-
 	if err := c.Store.InsertBlock(ctx, ebl); err != nil {
 		return err
 	}
 
+	c.prevHash = common.BytesToHash(ebl.BlockHash)
 	return nil
 }
 

--- a/gateway/core/chain_resilience_test.go
+++ b/gateway/core/chain_resilience_test.go
@@ -129,3 +129,54 @@ func TestHandle_ReprocessingSameBlockKeepsIndexesAndTrieStable(t *testing.T) {
 	require.Len(t, logEntries, 1)
 	require.Equal(t, ethTx.Hash().Bytes(), logEntries[0].TxHash)
 }
+
+// TestHandle_PrevHashNotAdvancedOnInsertFailure is the regression test for #304.
+// Before the fix, Handle advanced c.prevHash before the SQL commit, so a failed
+// InsertBlock left the in-memory tip pointing at a never-persisted block.
+func TestHandle_PrevHashNotAdvancedOnInsertFailure(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gateway.db")
+
+	chain, err := NewChain(dbPath, "", false)
+	require.NoError(t, err)
+	defer chain.Close()
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	// Seed the chain with a valid block 1.
+	ethTx := createTestEthTx(t, key, to, big.NewInt(1))
+	txBytes, err := ethTx.MarshalBinary()
+	require.NoError(t, err)
+
+	block1 := blocks.Block{
+		Number:     1,
+		Hash:       resilienceHash(0x01),
+		ParentHash: resilienceHash(0x00),
+		Timestamp:  1000,
+		Transactions: []blocks.Transaction{{
+			ID:        "fabric-tx-1",
+			Number:    0,
+			Valid:     true,
+			InputArgs: [][]byte{{byte(fc.ProposalTypeEVMTx)}, txBytes},
+		}},
+	}
+	require.NoError(t, chain.Handle(t.Context(), block1))
+	prevHashAfterBlock1 := chain.prevHash
+
+	// Close the DB so the next Handle call fails inside InsertBlock.
+	require.NoError(t, chain.db.Close())
+
+	block2 := blocks.Block{
+		Number:     2,
+		Hash:       resilienceHash(0x02),
+		ParentHash: resilienceHash(0x01),
+		Timestamp:  2000,
+	}
+	err = chain.Handle(t.Context(), block2)
+	require.Error(t, err, "Handle must fail when DB is closed")
+
+	// Key assertion: prevHash must still point at block 1.
+	require.Equal(t, prevHashAfterBlock1, chain.prevHash,
+		"prevHash must not advance when InsertBlock fails")
+}

--- a/gateway/testimpl/fund_accounts.go
+++ b/gateway/testimpl/fund_accounts.go
@@ -47,7 +47,7 @@ func FundTestAccounts(ctx context.Context, kvs estorage.KVS, namespace string, a
 	}
 
 	// Latest snapshot (block 0 means latest on current KVS APIs).
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		return fmt.Errorf("fund test accounts: snapshot: %w", err)
 	}

--- a/gateway/testimpl/fund_accounts_test.go
+++ b/gateway/testimpl/fund_accounts_test.go
@@ -30,7 +30,7 @@ func TestFundTestAccounts_SeedsBalancesReadableViaStateDB(t *testing.T) {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestFundTestAccounts_DefaultAccounts(t *testing.T) {
 		t.Fatalf("FundTestAccounts: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestFundTestAccounts_SurvivesLaterUpdate(t *testing.T) {
 		t.Fatalf("Update: %v", err)
 	}
 
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestFundTestAccounts_UsesHandleVersions(t *testing.T) {
 	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, half); err != nil {
 		t.Fatalf("first fund: %v", err)
 	}
-	reader, err := kvs.NewSnapshot(0)
+	reader, err := kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestFundTestAccounts_UsesHandleVersions(t *testing.T) {
 	if err := FundTestAccounts(t.Context(), kvs, testNS, []common.Address{addr}, half); err != nil {
 		t.Fatalf("second fund: %v", err)
 	}
-	reader, err = kvs.NewSnapshot(0)
+	reader, err = kvs.NewSnapshot(nil)
 	if err != nil {
 		t.Fatalf("NewSnapshot: %v", err)
 	}

--- a/integration/ethclient.go
+++ b/integration/ethclient.go
@@ -108,12 +108,11 @@ func (e *EthClient) txForDeploy(ctx context.Context, nonceProvider NonceProvider
 	}
 
 	callData := append(e.bytecode, constructorInput...)
-	bn, bt := GetCtxForSigner()
 
 	// Determine the from address to get the nonce
 	from := crypto.PubkeyToAddress(e.priv.PublicKey)
 
-	// Nonce from latest state (nil). bn is only for MakeSigner, not for the snapshot.
+	// Nonce from latest state (nil block number).
 	nonce, err := nonceProvider.NonceAt(ctx, from, nil)
 	if err != nil {
 		return nil, common.Address{}, err
@@ -128,7 +127,7 @@ func (e *EthClient) txForDeploy(ctx context.Context, nonceProvider NonceProvider
 		// GasPrice: gasPrice,
 	})
 
-	ethSigner := types.MakeSigner(e.ethChainConfig, bn, bt)
+	ethSigner := types.NewEIP155Signer(e.ethChainConfig.ChainID)
 
 	signedTx, err := types.SignTx(tx, ethSigner, e.priv)
 	if err != nil {
@@ -165,12 +164,10 @@ func (e *EthClient) TxForCall(ctx context.Context, nonceProvider NonceProvider, 
 		return nil, err
 	}
 
-	bn, bt := GetCtxForSigner()
-
 	// Determine the from address to get the nonce
 	from := crypto.PubkeyToAddress(e.priv.PublicKey)
 
-	// Nonce from latest state (nil). bn is only for MakeSigner, not for the snapshot.
+	// Nonce from latest state (nil block number).
 	nonce, err := nonceProvider.NonceAt(ctx, from, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +182,7 @@ func (e *EthClient) TxForCall(ctx context.Context, nonceProvider NonceProvider, 
 		// GasPrice: gasPrice,
 	})
 
-	ethSigner := types.MakeSigner(e.ethChainConfig, bn, bt)
+	ethSigner := types.NewEIP155Signer(e.ethChainConfig.ChainID)
 
 	signedTx, err := types.SignTx(tx, ethSigner, e.priv)
 	if err != nil {
@@ -193,10 +190,4 @@ func (e *EthClient) TxForCall(ctx context.Context, nonceProvider NonceProvider, 
 	}
 
 	return signedTx, nil
-}
-
-// GetCtxForSigner returns a non-nil block number so types.MakeSigner picks an
-// EIP-155 signer; otherwise the gateway rejects the tx as unprotected.
-func GetCtxForSigner() (blockNumber *big.Int, blockTime uint64) {
-	return big.NewInt(0), 0
 }

--- a/integration/ethclient.go
+++ b/integration/ethclient.go
@@ -113,8 +113,8 @@ func (e *EthClient) txForDeploy(ctx context.Context, nonceProvider NonceProvider
 	// Determine the from address to get the nonce
 	from := crypto.PubkeyToAddress(e.priv.PublicKey)
 
-	// Get the nonce from the provider
-	nonce, err := nonceProvider.NonceAt(ctx, from, bn)
+	// Nonce from latest state (nil). bn is only for MakeSigner, not for the snapshot.
+	nonce, err := nonceProvider.NonceAt(ctx, from, nil)
 	if err != nil {
 		return nil, common.Address{}, err
 	}
@@ -170,8 +170,8 @@ func (e *EthClient) TxForCall(ctx context.Context, nonceProvider NonceProvider, 
 	// Determine the from address to get the nonce
 	from := crypto.PubkeyToAddress(e.priv.PublicKey)
 
-	// Get the nonce from the provider
-	nonce, err := nonceProvider.NonceAt(ctx, from, bn)
+	// Nonce from latest state (nil). bn is only for MakeSigner, not for the snapshot.
+	nonce, err := nonceProvider.NonceAt(ctx, from, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -30,7 +30,7 @@ import (
 )
 
 type KVSSnapshotter interface {
-	NewSnapshot(blockNumber uint64) (execution.ReadStore, error)
+	NewSnapshot(blockNumber *uint64) (execution.ReadStore, error)
 }
 
 // StatePrimer provides a builder pattern for priming ledger state.
@@ -67,7 +67,7 @@ func NewStatePrimer(
 	monotonicVersions bool,
 ) (*StatePrimer, error) {
 	// Create a DualStateDB with both Fabric and Ethereum state tracking
-	store, err := db.NewSnapshot(0)
+	store, err := db.NewSnapshot(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (sp *StatePrimer) Writes() blocks.ReadWriteSet {
 // Reset creates a new DualStateDB, discarding all uncommitted changes.
 func (sp *StatePrimer) Reset() (*StatePrimer, error) {
 	sp.reader.Close() // just in case
-	reader, err := sp.kvs.NewSnapshot(0)
+	reader, err := sp.kvs.NewSnapshot(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/state_test_util.go
+++ b/integration/state_test_util.go
@@ -640,7 +640,7 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 	// Create a mock StateDB for DualStateDB
 	fabricDB, _ := fabricstate.NewWriteDB("testchannel", ":memory:")
 	fabricDBWrapper := storage.NewVersionedDBWrapper(fabricDB)
-	fabricDBSnapshot, _ := fabricDBWrapper.NewSnapshot(1)
+	fabricDBSnapshot, _ := fabricDBWrapper.NewSnapshot(storage.BlockAt(1))
 	defer fabricDBSnapshot.Close()
 	fabricStateDB, _ := execution.NewStateDB(context.TODO(), fabricDBSnapshot, "testns", 0, false)
 
@@ -698,7 +698,7 @@ func makePreStateWithDualState(db ethdb.Database, accounts types.GenesisAlloc, s
 
 	// Create new StateDB for the reopened state - now reading from block 1
 	// since we just committed block 0
-	fabricDBSnapshot2, _ := fabricDBWrapper.NewSnapshot(1)
+	fabricDBSnapshot2, _ := fabricDBWrapper.NewSnapshot(storage.BlockAt(1))
 	defer fabricDBSnapshot2.Close()
 	fabricStateDB, _ = execution.NewStateDB(context.TODO(), fabricDBSnapshot2, "testns", 1, false)
 	statedb = execution.NewDualStateDB(ethStateDB, fabricStateDB)

--- a/integration/state_test_util_test.go
+++ b/integration/state_test_util_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package integration
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	_ "modernc.org/sqlite"
+)
+
+// Covers makePreStateWithDualState so the NewSnapshot(BlockAt(1)) call sites
+// stay in the unit-test coverage profile (Codecov patch for #293).
+func TestMakePreStateWithDualState(t *testing.T) {
+	addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	st := makePreStateWithDualState(
+		rawdb.NewMemoryDatabase(),
+		types.GenesisAlloc{
+			addr: {Balance: big.NewInt(1), Nonce: 0},
+		},
+		false,
+		rawdb.HashScheme,
+	)
+	if st.StateDB == nil {
+		t.Fatal("expected non-nil StateDB")
+	}
+	st.Close()
+}

--- a/integration/state_test_util_test.go
+++ b/integration/state_test_util_test.go
@@ -31,5 +31,5 @@ func TestMakePreStateWithDualState(t *testing.T) {
 	if st.StateDB == nil {
 		t.Fatal("expected non-nil StateDB")
 	}
-	st.Close()
+	t.Cleanup(st.Close)
 }

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1892,6 +1892,10 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\"",
+    "cause": "execution reverted: arithmetic underflow or overflow"
+  },
+  {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
   },
   {
@@ -2276,1062 +2280,1062 @@
   {
     "id": "Packing extract / replace extract bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace extract bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes1 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes10 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes12 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes16 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes2 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes20 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes22 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes24 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes28 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes4 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes6 from bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing extract / replace replace bytes8 from bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes1 + bytes1 => bytes2",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes10 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes12 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes2 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes22 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes10 + bytes6 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes10 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes12 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes16 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes20 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes4 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes12 + bytes8 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes12 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes16 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes4 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes6 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes16 + bytes8 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes10 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes2 => bytes4",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes20 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes22 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes4 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes6 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes2 + bytes8 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes12 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes2 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes4 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes20 + bytes8 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes10 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes2 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes22 + bytes6 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes24 + bytes4 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes24 + bytes8 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes28 + bytes4 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes12 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes16 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes2 => bytes6",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes20 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes24 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes28 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes4 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes6 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes4 + bytes8 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes10 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes16 => bytes22",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes2 => bytes8",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes22 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes4 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes6 + bytes6 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes12 => bytes20",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes16 => bytes24",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes2 => bytes10",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes20 => bytes28",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes24 => bytes32",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes4 => bytes12",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "Packing pack pack bytes8 + bytes8 => bytes16",
     "cause": "max-code-size",
-    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) — not directly confirmed via a deploy-time error"
+    "note": "symptom is 'could not decode result data' (empty call return); consistent with the $Packing mock never deploying because it's oversized (EIP-170) \u2014 not directly confirmed via a deploy-time error"
   },
   {
     "id": "RateLimiter RefillingBucket with some capacity consume consume one key does not affect another key"

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1892,10 +1892,6 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\"",
-    "cause": "execution reverted: arithmetic underflow or overflow"
-  },
-  {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
   },
   {


### PR DESCRIPTION
Hey team! This PR fixes issue #304 where Chain.Handle was advancing the in memory chain tip before the SQL commit finished. If InsertBlock failed for some reason like a constraint violation the tip was left pointing at a block that was not actually saved in the database which corrupted the ParentHash for any new blocks.

I moved the prevHash update so it only happens after InsertBlock succeeds. The fix is a simple one line reorder to guarantee atomic updates and keep the state perfectly synced. I also added a regression test to make sure this stays fixed.

Thanks for reviewing!