### PR TITLE
add flag for flaky hardhat tests

### DIFF
--- a/cmd/baseline/baseline.go
+++ b/cmd/baseline/baseline.go
@@ -40,11 +40,14 @@ type Result struct {
 
 // Entry is one checked-in baseline record: a test expected to fail today.
 // Cause and Note are optional human annotations, filled in opportunistically —
-// never required for an entry to be valid.
+// never required for an entry to be valid. Flaky marks a test whose pass/fail
+// outcome is not deterministic (e.g. a race condition, not a clean incompatibility);
+// see Diff and Quarantined for how that changes gating.
 type Entry struct {
 	ID    string `json:"id"`
 	Cause string `json:"cause,omitempty"`
 	Note  string `json:"note,omitempty"`
+	Flaky bool   `json:"flaky,omitempty"`
 }
 
 // ExpectedFailure pairs a currently-failing result with the baseline entry that
@@ -54,16 +57,27 @@ type ExpectedFailure struct {
 	Entry  Entry
 }
 
+// QuarantinedResult pairs a Flaky baseline entry with whatever it actually did
+// this run. Result is the zero value (Status "") if the test didn't run at all —
+// which, for a flaky entry, is itself an unreliable signal, not evidence the
+// test was removed.
+type QuarantinedResult struct {
+	Result Result
+	Entry  Entry
+}
+
 // DiffResult is the outcome of comparing current results against a baseline.
 type DiffResult struct {
-	Regressions []Result          // failing, not in the baseline
-	Stale       []Entry           // in the baseline, but not failing (or missing) now
-	Expected    []ExpectedFailure // failing, in the baseline — the normal case
+	Regressions []Result            // failing, not in the baseline
+	Stale       []Entry             // in the baseline (and not Flaky), but not failing (or missing) now
+	Expected    []ExpectedFailure   // failing, in the baseline, not Flaky — the normal case
+	Quarantined []QuarantinedResult // Flaky baseline entries, whatever they did this run — never gates
 }
 
 // Regressed reports whether the diff should fail CI: any regression, or any stale
 // entry (a listed test that no longer fails is exactly as much "baseline doesn't
-// match reality" as a new failure).
+// match reality" as a new failure). Quarantined (Flaky) entries never contribute
+// here, by design.
 func (d DiffResult) Regressed() bool {
 	return len(d.Regressions) > 0 || len(d.Stale) > 0
 }
@@ -189,7 +203,9 @@ func SaveBaseline(path string, entries []Entry) error {
 // expected (the normal case), failing-and-unlisted is a regression, and
 // listed-but-not-failing (including a listed ID that no longer appears in
 // results at all — renamed or removed upstream) is stale and should be
-// removed from the baseline.
+// removed from the baseline. A Flaky entry is carved out of all three of
+// those into Quarantined instead, regardless of what it did this run — its
+// outcome isn't reliable enough to gate on, by definition.
 func Diff(results []Result, baseline []Entry) DiffResult {
 	byID := make(map[string]Entry, len(baseline))
 	for _, e := range baseline {
@@ -203,6 +219,8 @@ func Diff(results []Result, baseline []Entry) DiffResult {
 		entry, listed := byID[r.ID]
 
 		switch {
+		case listed && entry.Flaky:
+			out.Quarantined = append(out.Quarantined, QuarantinedResult{Result: r, Entry: entry})
 		case r.Status == StatusFail && listed:
 			out.Expected = append(out.Expected, ExpectedFailure{Result: r, Entry: entry})
 		case r.Status == StatusFail && !listed:
@@ -213,11 +231,18 @@ func Diff(results []Result, baseline []Entry) DiffResult {
 	}
 
 	// Baseline entries whose ID never appeared in this run at all (upstream
-	// renamed/removed the test) are safe to remove, same as a passing test.
+	// renamed/removed the test) are safe to remove, same as a passing test —
+	// unless Flaky, in which case "didn't run" is just as unreliable a signal
+	// as any other outcome, so it goes to Quarantined instead.
 	for _, e := range baseline {
-		if !seen[e.ID] {
-			out.Stale = append(out.Stale, e)
+		if seen[e.ID] {
+			continue
 		}
+		if e.Flaky {
+			out.Quarantined = append(out.Quarantined, QuarantinedResult{Entry: e})
+			continue
+		}
+		out.Stale = append(out.Stale, e)
 	}
 
 	return out
@@ -350,8 +375,9 @@ func bySuite(results []Result) []suiteStats {
 
 // WriteReport prints a human-readable summary: headline counts and pass rate, a
 // per-suite breakdown (to see where compatibility is improving), regressions,
-// stale entries, and a cause histogram of expected failures (grouped by the
-// entry's Cause tag, falling back to the raw failure message when blank).
+// stale entries, quarantined (Flaky) entries, and a cause histogram of expected
+// failures (grouped by the entry's Cause tag, falling back to the raw failure
+// message when blank).
 func WriteReport(w io.Writer, suite string, results []Result, diff DiffResult) {
 	var pass, fail, skip int
 	for _, r := range results {
@@ -389,6 +415,22 @@ func WriteReport(w io.Writer, suite string, results []Result, diff DiffResult) {
 		fmt.Fprintf(w, "## Stale baseline entries (%d) — remove these\n\n", len(diff.Stale))
 		for _, e := range diff.Stale {
 			fmt.Fprintf(w, "- `%s`\n", e.ID)
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(diff.Quarantined) > 0 {
+		fmt.Fprintf(w, "## Quarantined (flaky) (%d) — for visibility only, never gates\n\n", len(diff.Quarantined))
+		for _, q := range diff.Quarantined {
+			status := "did not run"
+			if q.Result.Status != "" {
+				status = string(q.Result.Status)
+			}
+			note := q.Entry.Note
+			if note == "" {
+				note = "(no note)"
+			}
+			fmt.Fprintf(w, "- `%s`: %s — %s\n", q.Entry.ID, status, note)
 		}
 		fmt.Fprintln(w)
 	}
@@ -448,6 +490,7 @@ type Summary struct {
 	BySuite     []SuiteSummary `json:"bySuite"`
 	Regressions []Regression   `json:"regressions"`
 	Stale       []string       `json:"stale"`
+	Quarantined []Quarantined  `json:"quarantined"`
 	Causes      []CauseCount   `json:"causes"`
 }
 
@@ -466,6 +509,14 @@ type Regression struct {
 type CauseCount struct {
 	Cause string `json:"cause"`
 	Count int    `json:"count"`
+}
+
+// Quarantined is a Flaky entry's outcome this run, for the JSON summary.
+// Status is "" if the test didn't run at all this suite.
+type Quarantined struct {
+	ID     string `json:"id"`
+	Status Status `json:"status"`
+	Note   string `json:"note,omitempty"`
 }
 
 // BuildSummary computes Summary from the same inputs WriteReport renders from,
@@ -505,6 +556,11 @@ func BuildSummary(suite string, results []Result, diff DiffResult) Summary {
 		stale = append(stale, e.ID)
 	}
 
+	quarantined := []Quarantined{}
+	for _, q := range diff.Quarantined {
+		quarantined = append(quarantined, Quarantined{ID: q.Entry.ID, Status: q.Result.Status, Note: q.Entry.Note})
+	}
+
 	causes := []CauseCount{}
 	for _, group := range groupExpected(diff.Expected) {
 		causes = append(causes, CauseCount{Cause: group.key, Count: len(group.items)})
@@ -522,6 +578,7 @@ func BuildSummary(suite string, results []Result, diff DiffResult) Summary {
 		BySuite:     bySuiteList,
 		Regressions: regressions,
 		Stale:       stale,
+		Quarantined: quarantined,
 		Causes:      causes,
 	}
 }

--- a/cmd/baseline/baseline_test.go
+++ b/cmd/baseline/baseline_test.go
@@ -229,6 +229,75 @@ func TestDiff_NothingWrong(t *testing.T) {
 	}
 }
 
+// TestDiff_Quarantined verifies a Flaky entry never lands in Regressions,
+// Stale, or Expected, and never trips Regressed(), regardless of whether it
+// failed, passed, or didn't run at all this time.
+func TestDiff_Quarantined(t *testing.T) {
+	results := []Result{
+		{ID: "flaky-failing", Status: StatusFail, Message: "arithmetic underflow or overflow"},
+		{ID: "flaky-passing", Status: StatusPass},
+		// flaky-absent deliberately has no Result at all this run.
+		{ID: "real-regression", Status: StatusFail, Message: "genuinely new"},
+	}
+	baseline := []Entry{
+		{ID: "flaky-failing", Flaky: true, Note: "races on concurrent tx"},
+		{ID: "flaky-passing", Flaky: true, Note: "races on concurrent tx"},
+		{ID: "flaky-absent", Flaky: true, Note: "races on concurrent tx"},
+	}
+
+	diff := Diff(results, baseline)
+
+	if len(diff.Regressions) != 1 || diff.Regressions[0].ID != "real-regression" {
+		t.Fatalf("regressions = %+v", diff.Regressions)
+	}
+	if len(diff.Stale) != 0 {
+		t.Fatalf("expected no stale entries (flaky ones must not count), got %+v", diff.Stale)
+	}
+	if len(diff.Expected) != 0 {
+		t.Fatalf("expected flaky-failing to land in Quarantined, not Expected, got %+v", diff.Expected)
+	}
+	byID := make(map[string]QuarantinedResult, len(diff.Quarantined))
+	for _, q := range diff.Quarantined {
+		byID[q.Entry.ID] = q
+	}
+	if len(diff.Quarantined) != 3 {
+		t.Fatalf("quarantined = %+v", diff.Quarantined)
+	}
+	if byID["flaky-failing"].Result.Status != StatusFail {
+		t.Errorf("flaky-failing: got status %q", byID["flaky-failing"].Result.Status)
+	}
+	if byID["flaky-passing"].Result.Status != StatusPass {
+		t.Errorf("flaky-passing: got status %q", byID["flaky-passing"].Result.Status)
+	}
+	if byID["flaky-absent"].Result.Status != "" {
+		t.Errorf("flaky-absent: expected zero-value Result (didn't run), got %+v", byID["flaky-absent"].Result)
+	}
+
+	// A real regression is still real: Regressed() is driven by it alone, not
+	// by any of the three flaky outcomes above.
+	if !diff.Regressed() {
+		t.Fatal("expected Regressed() true from the one real regression")
+	}
+}
+
+// TestDiff_QuarantinedOnlyMeansClean confirms that when every anomaly is
+// Flaky and there's no independent real regression, Regressed() is false —
+// this is the entire point of the mechanism.
+func TestDiff_QuarantinedOnlyMeansClean(t *testing.T) {
+	results := []Result{
+		{ID: "flaky-failing", Status: StatusFail, Message: "arithmetic underflow or overflow"},
+	}
+	baseline := []Entry{
+		{ID: "flaky-failing", Flaky: true},
+		{ID: "flaky-absent", Flaky: true},
+	}
+
+	diff := Diff(results, baseline)
+	if diff.Regressed() {
+		t.Fatalf("expected Regressed() false, got regressions=%+v stale=%+v", diff.Regressions, diff.Stale)
+	}
+}
+
 func TestBuildSummary(t *testing.T) {
 	results := []Result{
 		{ID: "regression", Status: StatusFail, Message: "new break", File: "test/token/ERC20.test.js"},
@@ -264,6 +333,26 @@ func TestBuildSummary(t *testing.T) {
 	}
 }
 
+func TestBuildSummary_Quarantined(t *testing.T) {
+	results := []Result{
+		{ID: "flaky-failing", Status: StatusFail, Message: "arithmetic underflow or overflow"},
+	}
+	baseline := []Entry{
+		{ID: "flaky-failing", Flaky: true, Note: "races on concurrent tx"},
+	}
+
+	diff := Diff(results, baseline)
+	summary := BuildSummary("oz-hardhat", results, diff)
+
+	if len(summary.Stale) != 0 {
+		t.Fatalf("expected no stale entries, got %+v", summary.Stale)
+	}
+	want := Quarantined{ID: "flaky-failing", Status: StatusFail, Note: "races on concurrent tx"}
+	if len(summary.Quarantined) != 1 || summary.Quarantined[0] != want {
+		t.Fatalf("quarantined = %+v, want [%+v]", summary.Quarantined, want)
+	}
+}
+
 func TestBuildSummary_EmptySlicesMarshalAsEmptyArraysNotNull(t *testing.T) {
 	results := []Result{{ID: "unlisted-pass", Status: StatusPass}}
 	summary := BuildSummary("oz-hardhat", results, Diff(results, nil))
@@ -277,7 +366,7 @@ func TestBuildSummary_EmptySlicesMarshalAsEmptyArraysNotNull(t *testing.T) {
 	// this JSON should never need to guard against a missing/null key. bySuite
 	// isn't asserted here: a single result always yields exactly one suiteStats
 	// bucket (grouped under suiteOf("") == ""), never zero — see TestSuiteOf.
-	for _, field := range []string{`"regressions":[]`, `"stale":[]`, `"causes":[]`} {
+	for _, field := range []string{`"regressions":[]`, `"stale":[]`, `"quarantined":[]`, `"causes":[]`} {
 		if !bytes.Contains(data, []byte(field)) {
 			t.Fatalf("expected %s in JSON, got %s", field, data)
 		}
@@ -348,5 +437,24 @@ func TestReconcile(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestReconcile_LeavesFlakyEntriesUntouched: a Flaky entry lands in
+// Quarantined, not Stale, regardless of outcome — so update must never drop
+// it, whether it passed, failed, or didn't run this time. Graduating a Flaky
+// entry back to normal is a deliberate human edit, not something update does.
+func TestReconcile_LeavesFlakyEntriesUntouched(t *testing.T) {
+	baseline := []Entry{
+		{ID: "flaky-passing", Flaky: true, Note: "races on concurrent tx"},
+	}
+	results := []Result{
+		{ID: "flaky-passing", Status: StatusPass},
+	}
+
+	got := Reconcile(baseline, Diff(results, baseline))
+
+	if !reflect.DeepEqual(got, baseline) {
+		t.Fatalf("got %+v, want unchanged %+v", got, baseline)
 	}
 }

--- a/cmd/baseline/main.go
+++ b/cmd/baseline/main.go
@@ -233,20 +233,18 @@ func runUpdate(args []string) int {
 	return 0
 }
 
-// tagMatching sets Cause (and Note, if given) on every baseline entry that is
-// still failing (present in messageByID) and whose ID or current message
-// contains match. Returns how many entries changed. A human decision, made in
-// bulk instead of one JSON edit at a time.
+// tagMatching sets Cause and/or Flaky (and Note, if given) on every baseline
+// entry that is still failing (present in messageByID) and whose ID or current
+// message contains match. Returns how many entries changed. A human decision,
+// made in bulk instead of one JSON edit at a time.
 //
-// An entry that already has a Cause is left untouched unless force is true —
-// a broad ID match (e.g. a whole describe block) can otherwise silently
-// clobber a more specific tag an earlier pass already got right.
-func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, note string, force bool) int {
+// Cause and Flaky are each left untouched on an entry that already has that
+// annotation, unless force is true — a broad match (e.g. a whole describe
+// block) can otherwise silently clobber a more specific tag an earlier pass
+// already got right.
+func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, note string, flaky, force bool) int {
 	n := 0
 	for i, e := range baseline {
-		if e.Cause != "" && !force {
-			continue
-		}
 		msg, stillFailing := messageByID[e.ID]
 		if !stillFailing {
 			continue
@@ -254,11 +252,22 @@ func tagMatching(baseline []Entry, messageByID map[string]string, match, cause, 
 		if !strings.Contains(e.ID, match) && !strings.Contains(msg, match) {
 			continue
 		}
-		baseline[i].Cause = cause
-		if note != "" {
-			baseline[i].Note = note
+		changed := false
+		if cause != "" && (e.Cause == "" || force) {
+			baseline[i].Cause = cause
+			changed = true
 		}
-		n++
+		if flaky && (!e.Flaky || force) {
+			baseline[i].Flaky = true
+			changed = true
+		}
+		if note != "" && (e.Note == "" || force) {
+			baseline[i].Note = note
+			changed = true
+		}
+		if changed {
+			n++
+		}
 	}
 	return n
 }
@@ -271,15 +280,16 @@ func runTag(args []string) int {
 	format := fs.String("format", "mocha-json", "raw results format (mocha-json)")
 	match := fs.String("match", "", "substring to match against each entry's ID or current failure message")
 	cause := fs.String("cause", "", "cause to assign to every matching entry")
-	note := fs.String("note", "", "optional note to assign alongside cause")
-	force := fs.Bool("force", false, "overwrite entries that already have a cause (default: leave them untouched)")
+	note := fs.String("note", "", "optional note to assign alongside cause/flaky")
+	flaky := fs.Bool("flaky", false, "mark every matching entry Flaky (nondeterministic outcome; never gates check, see Diff)")
+	force := fs.Bool("force", false, "overwrite entries that already have a cause or are already Flaky (default: leave them untouched)")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
 	applySuiteDefaults(*suite, baselinePath, resultsGlob)
-	if *baselinePath == "" || *resultsGlob == "" || *match == "" || *cause == "" {
-		fmt.Fprintln(os.Stderr, "usage: baseline tag --suite <name> --match <substring> --cause <name> [--baseline <path>] [--results <glob>] [--note <text>] [--force]")
+	if *baselinePath == "" || *resultsGlob == "" || *match == "" || (*cause == "" && !*flaky) {
+		fmt.Fprintln(os.Stderr, "usage: baseline tag --suite <name> --match <substring> (--cause <name> | --flaky) [--baseline <path>] [--results <glob>] [--note <text>] [--force]")
 		return 2
 	}
 
@@ -294,17 +304,21 @@ func runTag(args []string) int {
 		return 2
 	}
 
-	diff := Diff(results, baseline)
-	messageByID := make(map[string]string, len(diff.Expected))
-	for _, exp := range diff.Expected {
-		messageByID[exp.Entry.ID] = exp.Result.Message
+	// Built from raw results, not Diff's Expected bucket: an entry already
+	// Flaky lives in Quarantined instead, and must still be retaggable (e.g.
+	// to update its note) as long as it's still failing this run.
+	messageByID := make(map[string]string, len(results))
+	for _, r := range results {
+		if r.Status == StatusFail {
+			messageByID[r.ID] = r.Message
+		}
 	}
 
-	n := tagMatching(baseline, messageByID, *match, *cause, *note, *force)
+	n := tagMatching(baseline, messageByID, *match, *cause, *note, *flaky, *force)
 	if err := SaveBaseline(*baselinePath, baseline); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
-	fmt.Printf("%s: tagged %d entries matching %q with cause %q\n", *baselinePath, n, *match, *cause)
+	fmt.Printf("%s: tagged %d entries matching %q\n", *baselinePath, n, *match)
 	return 0
 }

--- a/cmd/baseline/main_test.go
+++ b/cmd/baseline/main_test.go
@@ -95,7 +95,7 @@ func TestTagMatching(t *testing.T) {
 		"unrelated test":   "something else entirely",
 	}
 
-	n := tagMatching(baseline, messageByID, "Packing", "max-code-size", "", false)
+	n := tagMatching(baseline, messageByID, "Packing", "max-code-size", "", false, false)
 
 	if n != 2 {
 		t.Fatalf("expected 2 tagged, got %d", n)
@@ -115,7 +115,7 @@ func TestTagMatching_MatchesOnMessageToo(t *testing.T) {
 	baseline := []Entry{{ID: "some test"}}
 	messageByID := map[string]string{"some test": "max code size exceeded: code size 25144 limit 24576"}
 
-	n := tagMatching(baseline, messageByID, "max code size exceeded", "max-code-size", "confirmed via logs", false)
+	n := tagMatching(baseline, messageByID, "max code size exceeded", "max-code-size", "confirmed via logs", false, false)
 
 	if n != 1 || baseline[0].Cause != "max-code-size" || baseline[0].Note != "confirmed via logs" {
 		t.Fatalf("got %+v", baseline)
@@ -130,13 +130,39 @@ func TestTagMatching_SkipsAlreadyTaggedUnlessForced(t *testing.T) {
 		"AccessControlDefaultAdminRules ERC165 uses less than 30k gas": "expected 10000000 to be at most 30000.",
 	}
 
-	n := tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", false)
+	n := tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", false, false)
 	if n != 0 || baseline[0].Cause != "gas-stub" {
 		t.Fatalf("expected the existing tag to survive untouched, got %+v", baseline)
 	}
 
-	n = tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", true)
+	n = tagMatching(baseline, messageByID, "AccessControlDefaultAdminRules", "fixed-block-context", "", false, true)
 	if n != 1 || baseline[0].Cause != "fixed-block-context" {
 		t.Fatalf("expected --force to overwrite, got %+v", baseline)
+	}
+}
+
+func TestTagMatching_Flaky(t *testing.T) {
+	baseline := []Entry{{ID: "Governor before each hook"}}
+	messageByID := map[string]string{"Governor before each hook": "arithmetic underflow or overflow"}
+
+	n := tagMatching(baseline, messageByID, "Governor", "", "races on concurrent delegate+transfer", true, false)
+
+	if n != 1 || !baseline[0].Flaky || baseline[0].Cause != "" || baseline[0].Note != "races on concurrent delegate+transfer" {
+		t.Fatalf("got %+v", baseline)
+	}
+}
+
+func TestTagMatching_FlakySkipsAlreadyFlakyUnlessForced(t *testing.T) {
+	baseline := []Entry{{ID: "Governor before each hook", Flaky: true, Note: "original note"}}
+	messageByID := map[string]string{"Governor before each hook": "arithmetic underflow or overflow"}
+
+	n := tagMatching(baseline, messageByID, "Governor", "", "new note", true, false)
+	if n != 0 || baseline[0].Note != "original note" {
+		t.Fatalf("expected the existing flaky tag and note to survive untouched, got %+v", baseline)
+	}
+
+	n = tagMatching(baseline, messageByID, "Governor", "", "new note", true, true)
+	if n != 1 || baseline[0].Note != "new note" {
+		t.Fatalf("expected --force to overwrite the note, got %+v", baseline)
 	}
 }

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -1591,7 +1591,10 @@
     "id": "Governor using $ERC20Votes should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20Votes should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "Governor using $ERC20Votes should revert on vote by signature \"before each\" hook for \"if signature does not match signer\"",
+    "cause": "concurrent-tx-race",
+    "note": "Races: GovernorHelper.delegate() submits self-delegate + transfer concurrently (Promise.all, no confirmation wait) against a freshly-funded account; the endorsement-time read snapshot goes stale before commit.",
+    "flaky": true
   },
   {
     "id": "Governor using $ERC20Votes should revert on vote if support value is invalid"
@@ -1726,7 +1729,10 @@
     "id": "Governor using $ERC20VotesLegacyMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesLegacyMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "Governor using $ERC20VotesLegacyMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\"",
+    "cause": "concurrent-tx-race",
+    "note": "Races: GovernorHelper.delegate() submits self-delegate + transfer concurrently (Promise.all, no confirmation wait) against a freshly-funded account; the endorsement-time read snapshot goes stale before commit.",
+    "flaky": true
   },
   {
     "id": "Governor using $ERC20VotesLegacyMock should revert on vote if support value is invalid"
@@ -1855,7 +1861,10 @@
     "id": "Governor using $ERC20VotesTimestampMock should revert on queue reverts with GovernorProposalQueueingFailed when _queueOperations returns 0"
   },
   {
-    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "Governor using $ERC20VotesTimestampMock should revert on vote by signature \"before each\" hook for \"if signature does not match signer\"",
+    "cause": "concurrent-tx-race",
+    "note": "Races: GovernorHelper.delegate() submits self-delegate + transfer concurrently (Promise.all, no confirmation wait) against a freshly-funded account; the endorsement-time read snapshot goes stale before commit.",
+    "flaky": true
   },
   {
     "id": "Governor using $ERC20VotesTimestampMock should revert on vote if support value is invalid"
@@ -1885,6 +1894,11 @@
     "id": "Governor using $ERC20VotesTimestampMock vote with signature votes with an EOA signature on two proposals"
   },
   {
+    "id": "GovernorCountingFractional using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorCountingFractional using $ERC20Votes nominal is unaffected"
   },
   {
@@ -1907,6 +1921,11 @@
   },
   {
     "id": "GovernorCountingFractional using $ERC20Votes voting with a fraction of the weight twice"
+  },
+  {
+    "id": "GovernorCountingFractional using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorCountingFractional using $ERC20VotesTimestampMock nominal is unaffected"
@@ -1933,16 +1952,31 @@
     "id": "GovernorCountingFractional using $ERC20VotesTimestampMock voting with a fraction of the weight twice"
   },
   {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock cast override vote \"before each\" hook for \"override after delegate vote\""
   },
   {
     "id": "GovernorCountingOverridable using $ERC20VotesExtendedMock nominal is unaffected"
   },
   {
+    "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock cast override vote \"before each\" hook for \"override after delegate vote\""
   },
   {
     "id": "GovernorCountingOverridable using $ERC20VotesExtendedTimestampMock nominal is unaffected"
+  },
+  {
+    "id": "GovernorCrosschain \"before each\" hook for \"execute with executor\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorCrosschain execute with executor"
@@ -1952,14 +1986,39 @@
   },
   {
     "id": "GovernorERC721 using $ERC721Votes \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "cause": "concurrent-tx-race",
+    "note": "Races: the fixture mints 5 NFTs concurrently (Promise.all, no confirmation wait), then GovernorHelper.delegate() looks up ownerOf(tokenId) for each — if a mint hasn't committed yet, the read is stale. Same root cause as the ERC20 Governor delegate/transfer race. Fabric-x-sdk MVCC fix makes a detected conflict fail cleanly, but does not eliminate the race. Un-flag once dependency-aware tx scheduling lands and this is confirmed to pass consistently.",
+    "flaky": true
+  },
+  {
+    "id": "GovernorERC721 using $ERC721Votes deployment check",
+    "cause": "concurrent-tx-race",
+    "note": "Races: the fixture mints 5 NFTs concurrently (Promise.all, no confirmation wait), then GovernorHelper.delegate() looks up ownerOf(tokenId) for each — if a mint hasn't committed yet, the read is stale. Same root cause as the ERC20 Governor delegate/transfer race. Fabric-x-sdk MVCC fix makes a detected conflict fail cleanly, but does not eliminate the race. Un-flag once dependency-aware tx scheduling lands and this is confirmed to pass consistently.",
+    "flaky": true
+  },
+  {
+    "id": "GovernorERC721 using $ERC721Votes voting with ERC721 token",
+    "cause": "fixed-block-number",
+    "note": "Races: the fixture mints 5 NFTs concurrently (Promise.all, no confirmation wait); when the mint race corrupts state this also surfaces as the already-known fixed-block-number issue (waitForSnapshot's mineUpTo target vs. the real, ever-growing committed height) depending on how many blocks have accumulated suite-wide by the time this test runs. Not purely deterministic either way — un-flag once dependency-aware tx scheduling lands and this is confirmed to pass consistently.",
+    "flaky": true
   },
   {
     "id": "GovernorERC721 using $ERC721VotesTimestampMock \"before each\" hook for \"deployment check\"",
-    "cause": "insufficient-funds"
+    "cause": "concurrent-tx-race",
+    "note": "Races: the fixture mints 5 NFTs concurrently (Promise.all, no confirmation wait), then GovernorHelper.delegate() looks up ownerOf(tokenId) for each — if a mint hasn't committed yet, the read is stale. Same root cause as the ERC20 Governor delegate/transfer race. Fabric-x-sdk MVCC fix makes a detected conflict fail cleanly, but does not eliminate the race. Un-flag once dependency-aware tx scheduling lands and this is confirmed to pass consistently.",
+    "flaky": true
   },
   {
-    "id": "GovernorNoncesKeyed on vote by signature \"before each\" hook for \"if signature does not match signer\""
+    "id": "GovernorERC721 using $ERC721VotesTimestampMock voting with ERC721 token",
+    "cause": "concurrent-tx-race",
+    "note": "Races: the fixture mints 5 NFTs concurrently (Promise.all, no confirmation wait), then GovernorHelper.delegate() looks up ownerOf(tokenId) for each — if a mint hasn't committed yet, the read is stale. Same root cause as the ERC20 Governor delegate/transfer race. Fabric-x-sdk MVCC fix makes a detected conflict fail cleanly, but does not eliminate the race. Un-flag once dependency-aware tx scheduling lands and this is confirmed to pass consistently.",
+    "flaky": true
+  },
+  {
+    "id": "GovernorNoncesKeyed on vote by signature \"before each\" hook for \"if signature does not match signer\"",
+    "cause": "concurrent-tx-race",
+    "note": "Races: GovernorHelper.delegate() submits self-delegate + transfer concurrently (Promise.all, no confirmation wait) against a freshly-funded account; the endorsement-time read snapshot goes stale before commit.",
+    "flaky": true
   },
   {
     "id": "GovernorNoncesKeyed vote with signature with default nonce votes with a valid EIP-1271 signature"
@@ -1980,6 +2039,11 @@
     "id": "GovernorNoncesKeyed vote with signature with keyed nonce votes with an EOA signature with reason"
   },
   {
+    "id": "GovernorPreventLateQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorPreventLateQuorum using $ERC20Votes Delay is extended to prevent last minute take-over"
   },
   {
@@ -1987,6 +2051,11 @@
   },
   {
     "id": "GovernorPreventLateQuorum using $ERC20Votes onlyGovernance updates can setLateQuorumVoteExtension through governance"
+  },
+  {
+    "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorPreventLateQuorum using $ERC20VotesTimestampMock Delay is extended to prevent last minute take-over"
@@ -2006,7 +2075,17 @@
     "cause": "hardhat_setBalance"
   },
   {
+    "id": "GovernorSequentialProposalId using $ERC20Votes \"before each\" hook for \"sequential proposal ids\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorSequentialProposalId using $ERC20Votes nominal workflow"
+  },
+  {
+    "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock \"before each\" hook for \"sequential proposal ids\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorSequentialProposalId using $ERC20VotesTimestampMock nominal workflow"
@@ -2017,9 +2096,24 @@
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
   },
   {
+    "id": "GovernorStorage using $ERC20Votes proposal indexing \"before each\" hook for \"before propose\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorStorage using $ERC20VotesTimestampMock \"before each\" hook for \"queue and execute by id\"",
     "cause": "fixed-timestamp",
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
+  },
+  {
+    "id": "GovernorStorage using $ERC20VotesTimestampMock proposal indexing \"before each\" hook for \"before propose\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorSuperQuorum using $ERC20Votes proposal is queued if super quorum is reached and eta is set"
@@ -2032,6 +2126,11 @@
   },
   {
     "id": "GovernorSuperQuorum using $ERC20Votes proposal succeeds early when super quorum is reached"
+  },
+  {
+    "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorSuperQuorum using $ERC20VotesTimestampMock proposal is queued if super quorum is reached and eta is set"
@@ -2064,6 +2163,11 @@
     "id": "GovernorTimelockCompound using $ERC20VotesTimestampMock \"before each\" hook for \"doesn't accept ether transfers\"",
     "cause": "fixed-timestamp",
     "note": "block.timestamp is hardcoded (see COMPATIBILITY.md); manifests as timestamp diffs, delay/schedule assertions, or (for ERC20Votes-style checkpoints) an undercount since votes never actually advance in time"
+  },
+  {
+    "id": "GovernorTimelockControl using $ERC20Votes \"before each\" hook for \"doesn't accept ether transfers\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorTimelockControl using $ERC20Votes cancel cancel after queue prevents executing"
@@ -2111,6 +2215,11 @@
     "id": "GovernorTimelockControl using $ERC20Votes should revert on queue if already queued"
   },
   {
+    "id": "GovernorTimelockControl using $ERC20VotesTimestampMock \"before each\" hook for \"doesn't accept ether transfers\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorTimelockControl using $ERC20VotesTimestampMock cancel cancel after queue prevents executing"
   },
   {
@@ -2153,6 +2262,11 @@
     "id": "GovernorTimelockControl using $ERC20VotesTimestampMock should revert on queue if already queued"
   },
   {
+    "id": "GovernorVotesQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorVotesQuorumFraction using $ERC20Votes deployment check"
   },
   {
@@ -2166,6 +2280,11 @@
   },
   {
     "id": "GovernorVotesQuorumFraction using $ERC20Votes quorum reached"
+  },
+  {
+    "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock deployment check"
@@ -2183,6 +2302,11 @@
     "id": "GovernorVotesQuorumFraction using $ERC20VotesTimestampMock quorum reached"
   },
   {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes deployment check"
   },
   {
@@ -2192,6 +2316,11 @@
     "id": "GovernorVotesSuperQuorumFraction using $ERC20Votes super quorum updates can update super quorum through governance"
   },
   {
+    "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
+  },
+  {
     "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock deployment check"
   },
   {
@@ -2199,6 +2328,11 @@
   },
   {
     "id": "GovernorVotesSuperQuorumFraction using $ERC20VotesTimestampMock super quorum updates can update super quorum through governance"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20Votes \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorWithParams using $ERC20Votes Voting with params is properly supported"
@@ -2217,6 +2351,11 @@
   },
   {
     "id": "GovernorWithParams using $ERC20Votes voting by signature supports EOA signatures"
+  },
+  {
+    "id": "GovernorWithParams using $ERC20VotesTimestampMock \"before each\" hook for \"deployment check\"",
+    "note": "Predicted, not yet directly observed failing — this file's fixture uses the identical vulnerable pattern already confirmed racy in 8 other Governor-family entries (GovernorHelper.delegate()'s Promise.all of dependent writes, no confirmation wait, endorsement-time read snapshot goes stale before commit).",
+    "flaky": true
   },
   {
     "id": "GovernorWithParams using $ERC20VotesTimestampMock Voting with params is properly supported"


### PR DESCRIPTION
the pipeline regularly fails for the "Governor" tests; due to a race condition it's not predictable whether the test will fail or succeed. The real issue is that hardhat assumes sequential processing, with the second transaction operating on the state of the first. In our case, the first transaction is not always committed yet (even with the `fabrictest` backend there is a very small delay). This _should_ cause an MVCC conflict, but the validator is too lenient in fabrictest (fix pending in https://github.com/hyperledger/fabric-x-sdk/pull/53). Now it causes a more cryptic error message.

This PR adds a "flaky" flag to the baseline tool, so that these tests never fail the CI. The outcome is still reported, so that we can see when they're not flaky anymore. This particular issue could be solved with dependency aware scheduling, so hopefully when that works we can remove the flaky flag for these tests.