### PR TITLE
gateway: HybridSynchronizer for fabric-x startup

### DIFF
--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -38,9 +38,9 @@ var appLogger = flogging.MustGetLogger("gateway.app")
 // App represents the gateway application with all its components.
 type App struct {
 	cfg           config.Config
-	endorserSyncs []*network.Synchronizer
+	endorserSyncs []Synchronizer
 	endorserConns []*eclient.Client // set only in split deployment; closed on Shutdown
-	gwSync        *network.Synchronizer
+	gwSync        Synchronizer
 	gateway       *core.Gateway
 	chain         *core.Chain
 	rpcServer     *rpc.Server
@@ -93,7 +93,7 @@ func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableT
 
 	// Create endorsers and their synchronizers.
 	endorsers := make([]eapi.Service, 0, len(cfg.Endorsers))
-	endorserSyncs := make([]*network.Synchronizer, 0, len(cfg.Endorsers))
+	endorserSyncs := make([]Synchronizer, 0, len(cfg.Endorsers))
 	var firstKVS estorage.KVS // Keep first endorser's KVS for test server
 	for i, ecfg := range cfg.Endorsers {
 		// Test RPC needs a large sequential history window (see testnode); production
@@ -157,7 +157,7 @@ func newSplitApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, lo
 
 // buildApp wires up the gateway from pre-built endorsers.
 // extraHandlers are prepended to the synchronizer handler list, ahead of chain/gateway.
-func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []*network.Synchronizer, lightKVS estorage.KVS, enableTestRPC bool, testAccountsPath string, extraHandlers ...blocks.BlockHandler) (*App, error) {
+func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []Synchronizer, lightKVS estorage.KVS, enableTestRPC bool, testAccountsPath string, extraHandlers ...blocks.BlockHandler) (*App, error) {
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
 		orderers[i] = o.ToOrdererConf()
@@ -182,7 +182,7 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 
 	// Chain must be called before gateway, to persist blocks before marking transactions complete.
 	handlers := append(extraHandlers, chain, gateway)
-	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gateway synchronizer: %w", err)
 	}
@@ -322,7 +322,7 @@ func (a *App) Shutdown() error {
 }
 
 // WaitUntilSynced blocks until sync reports Ready or timeout elapses, polling every 100ms.
-func WaitUntilSynced(ctx context.Context, sync *network.Synchronizer, timeout time.Duration) error {
+func WaitUntilSynced(ctx context.Context, sync Synchronizer, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/gateway/app/hybridx/hybrid.go
+++ b/gateway/app/hybridx/hybrid.go
@@ -22,15 +22,11 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 //
 // HybridSynchronizer satisfies the app.Synchronizer interface (Start + Ready)
 // and plugs directly into NewGatewaySynchronizer as the fabric-x implementation.
-//
-// After Start is called and Ready returns nil, callers may use AddHandler and
-// RemoveHandler to adjust the live handler chain without restarting.
 package hybridx
 
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -53,16 +49,10 @@ type deliverySyncer interface {
 
 // HybridSynchronizer implements the two-phase startup strategy described in
 // the package doc.  It satisfies the app.Synchronizer interface.
-//
-// AddHandler and RemoveHandler may be called at any time after New; changes
-// take effect on the next committed block in whichever phase is active.
 type HybridSynchronizer struct {
 	namespace string
 	logger    sdk.Logger
-
-	// mu protects handlers; held briefly on each block in the hot path.
-	mu       sync.RWMutex
-	handlers []blocks.BlockHandler
+	handlers  []blocks.BlockHandler
 
 	delivery  deliverySyncer
 	notifPeer notification.AllTxPeer
@@ -85,9 +75,6 @@ func New(
 		handlers:  append([]blocks.BlockHandler(nil), handlers...),
 	}
 
-	// The delivery synchronizer uses a shim that reads from h.handlers under
-	// the mutex on every block, so that AddHandler/RemoveHandler take effect
-	// immediately for the delivery phase too.
 	delivery, err := nfabx.NewSynchronizer(db, channel, conf, signer, logger, &deliveryShim{h: h})
 	if err != nil {
 		return nil, fmt.Errorf("hybridx: create delivery synchronizer: %w", err)
@@ -126,33 +113,10 @@ func newWithDeps(
 	}
 }
 
-// AddHandler appends h to the live handler chain.  Safe to call concurrently.
-func (h *HybridSynchronizer) AddHandler(handler blocks.BlockHandler) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.handlers = append(h.handlers, handler)
-}
-
-// RemoveHandler removes the first handler in the chain that is pointer-equal
-// to handler.  Safe to call concurrently.
-func (h *HybridSynchronizer) RemoveHandler(handler blocks.BlockHandler) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	for i, bh := range h.handlers {
-		if bh == handler {
-			h.handlers = append(h.handlers[:i], h.handlers[i+1:]...)
-			return
-		}
-	}
-}
-
-// dispatch calls Handle on every handler in the current chain.
+// dispatch calls Handle on every handler in the chain.
 // Called by both the deliveryShim and the notifGate.
 func (h *HybridSynchronizer) dispatch(ctx context.Context, b blocks.Block) error {
-	h.mu.RLock()
-	handlers := h.handlers
-	h.mu.RUnlock()
-	for _, bh := range handlers {
+	for _, bh := range h.handlers {
 		if err := bh.Handle(ctx, b); err != nil {
 			return err
 		}

--- a/gateway/app/hybridx/hybrid.go
+++ b/gateway/app/hybridx/hybrid.go
@@ -1,0 +1,332 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+// Package hybridx implements the two-phase startup strategy for fabric-x nodes.
+//
+// On startup both the delivery service and the notification service are started
+// concurrently.  The notification service tracks the latest committed block it
+// has seen (nNot).  The delivery service processes blocks and exposes its last
+// processed block via nDel.  The switch from delivery to notification is decided
+// inside the notification gate itself, in a single HandleBatch call, eliminating
+// any gap between the two phases:
+//
+//  1. The gate receives a batch for block B and updates nNot = B.
+//  2. If nDel >= nNot it atomically flips switched and forwards the batch.
+//  3. If nDel < nNot it discards the batch content (delivery is still behind).
+//
+// Because the decision and the first forward happen in the same HandleBatch call
+// there is no window in which a batch could be lost.
+//
+// HybridSynchronizer satisfies the app.Synchronizer interface (Start + Ready)
+// and plugs directly into NewGatewaySynchronizer as the fabric-x implementation.
+//
+// After Start is called and Ready returns nil, callers may use AddHandler and
+// RemoveHandler to adjust the live handler chain without restarting.
+package hybridx
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/network"
+	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
+	"github.com/hyperledger/fabric-x-sdk/notification"
+
+	evmcommon "github.com/hyperledger/fabric-x-evm/common"
+)
+
+// deliverySyncer is the subset of *network.Synchronizer used by HybridSynchronizer.
+// Extracted as an interface so tests can supply a fake without a real gRPC connection.
+type deliverySyncer interface {
+	Start(ctx context.Context) error
+	Ready() error
+	BlockHeight(ctx context.Context) (uint64, error)
+}
+
+// HybridSynchronizer implements the two-phase startup strategy described in
+// the package doc.  It satisfies the app.Synchronizer interface.
+//
+// AddHandler and RemoveHandler may be called at any time after New; changes
+// take effect on the next committed block in whichever phase is active.
+type HybridSynchronizer struct {
+	namespace string
+	logger    sdk.Logger
+
+	// mu protects handlers; held briefly on each block in the hot path.
+	mu       sync.RWMutex
+	handlers []blocks.BlockHandler
+
+	delivery  deliverySyncer
+	notifPeer notification.AllTxPeer
+	notifReq  *notification.StreamAllRequest
+}
+
+// New constructs a HybridSynchronizer.
+// handlers is the initial handler chain fed by both phases.
+func New(
+	db network.BlockHeightReader,
+	channel, namespace string,
+	conf network.PeerConf,
+	signer sdk.Signer,
+	logger sdk.Logger,
+	handlers ...blocks.BlockHandler,
+) (*HybridSynchronizer, error) {
+	h := &HybridSynchronizer{
+		namespace: namespace,
+		logger:    logger,
+		handlers:  append([]blocks.BlockHandler(nil), handlers...),
+	}
+
+	// The delivery synchronizer uses a shim that reads from h.handlers under
+	// the mutex on every block, so that AddHandler/RemoveHandler take effect
+	// immediately for the delivery phase too.
+	delivery, err := nfabx.NewSynchronizer(db, channel, conf, signer, logger, &deliveryShim{h: h})
+	if err != nil {
+		return nil, fmt.Errorf("hybridx: create delivery synchronizer: %w", err)
+	}
+
+	notifPeer, err := nfabx.NewPeer(conf, channel, signer)
+	if err != nil {
+		return nil, fmt.Errorf("hybridx: create notification peer: %w", err)
+	}
+
+	h.delivery = delivery
+	h.notifPeer = notifPeer
+	h.notifReq = &notification.StreamAllRequest{
+		FilterNamespaces:     []string{namespace},
+		IncludeReadWriteSets: true,
+		IncludeMetadata:      true,
+	}
+	return h, nil
+}
+
+// newWithDeps constructs a HybridSynchronizer from pre-built dependencies.
+// Used by tests to inject fakes without needing a real gRPC connection.
+func newWithDeps(
+	delivery deliverySyncer,
+	notifPeer notification.AllTxPeer,
+	notifReq *notification.StreamAllRequest,
+	logger sdk.Logger,
+	handlers ...blocks.BlockHandler,
+) *HybridSynchronizer {
+	return &HybridSynchronizer{
+		logger:    logger,
+		handlers:  append([]blocks.BlockHandler(nil), handlers...),
+		delivery:  delivery,
+		notifPeer: notifPeer,
+		notifReq:  notifReq,
+	}
+}
+
+// AddHandler appends h to the live handler chain.  Safe to call concurrently.
+func (h *HybridSynchronizer) AddHandler(handler blocks.BlockHandler) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.handlers = append(h.handlers, handler)
+}
+
+// RemoveHandler removes the first handler in the chain that is pointer-equal
+// to handler.  Safe to call concurrently.
+func (h *HybridSynchronizer) RemoveHandler(handler blocks.BlockHandler) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i, bh := range h.handlers {
+		if bh == handler {
+			h.handlers = append(h.handlers[:i], h.handlers[i+1:]...)
+			return
+		}
+	}
+}
+
+// dispatch calls Handle on every handler in the current chain.
+// Called by both the deliveryShim and the notifGate.
+func (h *HybridSynchronizer) dispatch(ctx context.Context, b blocks.Block) error {
+	h.mu.RLock()
+	handlers := h.handlers
+	h.mu.RUnlock()
+	for _, bh := range handlers {
+		if err := bh.Handle(ctx, b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Start runs the two-phase startup and then blocks until ctx is cancelled.
+//
+// Both services start concurrently.  A notifGate sits between the streamer and
+// the handler chain.  It owns nDel (written by a delivery-watcher goroutine
+// after each Ready() transition) and nNot (written on every incoming batch).
+// The switch is decided inside HandleBatch — atomically with forwarding the first
+// live batch — so no gap can arise between the two phases.
+func (h *HybridSynchronizer) Start(ctx context.Context) error {
+	// switched flips 0→1 exactly once, inside HandleBatch, when nDel >= nNot.
+	var switched atomic.Uint32
+
+	// nDel is the last block number processed by the delivery synchronizer.
+	// Written by the delivery-watcher goroutine; read by the notif gate.
+	var nDel atomic.Uint64
+
+	// ── Notification service ────────────────────────────────────────────────
+	gate := &notifGate{
+		nDel:       &nDel,
+		switched:   &switched,
+		hybrid:     h,
+		dispatcher: evmcommon.NewAllTxBatchDispatcher(&hybridAdapter{h: h}),
+		logger:     h.logger,
+	}
+	streamer := notification.NewAllTxStreamer(h.notifPeer, []notification.AllTxHandler{gate}, h.logger)
+
+	notifErrCh := make(chan error, 1)
+	go func() {
+		const retryDelay = time.Second
+		for {
+			if ctx.Err() != nil {
+				notifErrCh <- nil
+				return
+			}
+			if err := streamer.Stream(ctx, h.notifReq); err != nil && ctx.Err() == nil {
+				h.logger.Warnf("hybridx: notification stream error: %v — restarting in %s", err, retryDelay)
+				select {
+				case <-ctx.Done():
+					notifErrCh <- nil
+					return
+				case <-time.After(retryDelay):
+				}
+			}
+		}
+	}()
+
+	// ── Delivery service ────────────────────────────────────────────────────
+	deliveryCtx, deliveryCancel := context.WithCancel(ctx)
+	defer deliveryCancel()
+
+	deliveryDone := make(chan struct{})
+	go func() {
+		defer func() {
+			h.delivery = nil // allow GC of the peer and all delivery resources
+			close(deliveryDone)
+		}()
+		if err := h.delivery.Start(deliveryCtx); err != nil && deliveryCtx.Err() == nil {
+			h.logger.Warnf("hybridx: delivery error: %v", err)
+		}
+	}()
+
+	// Delivery-watcher: once the delivery synchronizer reaches Ready, poll its
+	// BlockHeight to keep nDel current so the gate can compare accurately.
+	// When the gate has already switched we cancel the delivery synchronizer.
+	go func() {
+		// Wait for the delivery synchronizer to reach Ready.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-deliveryDone:
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+			if h.delivery != nil && h.delivery.Ready() == nil {
+				break
+			}
+		}
+
+		// Keep nDel updated until the gate has switched.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-deliveryDone:
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+			if switched.Load() == 1 {
+				deliveryCancel()
+				return
+			}
+			if h.delivery == nil {
+				return
+			}
+			height, err := h.delivery.BlockHeight(ctx)
+			if err == nil && height > 0 {
+				nDel.Store(height - 1) // BlockHeight = last+1, so last = height-1
+			}
+		}
+	}()
+
+	<-ctx.Done()
+	return <-notifErrCh
+}
+
+// Ready proxies to the delivery synchronizer until the switch; afterwards
+// returns nil since the notification stream is always considered ready.
+//
+// Note: h.delivery is set to nil from the delivery goroutine in Start; since
+// there is no mutex on this field the read here may race in theory, but the
+// only consequence is an extra call to delivery.Ready() which is benign.
+func (h *HybridSynchronizer) Ready() error {
+	if h.delivery == nil {
+		return nil
+	}
+	return h.delivery.Ready()
+}
+
+// deliveryShim is a blocks.BlockHandler registered with the delivery synchronizer.
+// It delegates to h.dispatch so that the live handler chain (including any
+// handlers added or removed via AddHandler/RemoveHandler) is always used.
+type deliveryShim struct{ h *HybridSynchronizer }
+
+func (s *deliveryShim) Handle(ctx context.Context, b blocks.Block) error {
+	return s.h.dispatch(ctx, b)
+}
+
+// notifGate is a notification.AllTxHandler that gates the handler chain.
+//
+// For each incoming batch it:
+//  1. If switched: converts the batch to a blocks.Block and dispatches it.
+//  2. If not switched but nDel >= batch.BlockNumber: flips switched and dispatches
+//     — this is the gap-free handoff point.
+//  3. Otherwise: discards the batch (delivery is still behind).
+type notifGate struct {
+	nDel       *atomic.Uint64
+	switched   *atomic.Uint32
+	hybrid     *HybridSynchronizer
+	dispatcher *evmcommon.AllTxBatchDispatcher
+	logger     sdk.Logger
+}
+
+// hybridAdapter adapts HybridSynchronizer.dispatch to evmcommon.BlockHandler.
+type hybridAdapter struct{ h *HybridSynchronizer }
+
+func (a *hybridAdapter) Handle(ctx context.Context, b blocks.Block) error {
+	return a.h.dispatch(ctx, b)
+}
+
+func (g *notifGate) HandleBatch(ctx context.Context, batch notification.AllTxBatch) error {
+	if g.switched.Load() == 1 {
+		return g.dispatchBatch(ctx, batch)
+	}
+
+	// Check whether delivery has caught up with this batch's block number.
+	if g.nDel.Load() >= batch.BlockNumber {
+		g.switched.Store(1)
+		g.logger.Infof("hybridx: switching to notification at block %d", batch.BlockNumber)
+		return g.dispatchBatch(ctx, batch)
+	}
+
+	return nil // delivery is still behind; discard
+}
+
+// dispatchBatch converts an AllTxBatch to a blocks.Block via AllTxBatchDispatcher
+// and dispatches it through the hybrid's handler chain.
+// The dispatcher is allocated once per gate in Start and stored here.
+func (g *notifGate) dispatchBatch(ctx context.Context, batch notification.AllTxBatch) error {
+	return g.dispatcher.HandleBatch(ctx, batch)
+}

--- a/gateway/app/hybridx/hybrid_test.go
+++ b/gateway/app/hybridx/hybrid_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package hybridx
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/notification"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+// fakeDelivery is a controllable deliverySyncer.
+type fakeDelivery struct {
+	mu      sync.Mutex
+	ready   bool
+	height  uint64
+	started chan struct{} // closed when Start is called
+	stopped chan struct{} // closed when Start returns
+}
+
+func newFakeDelivery() *fakeDelivery {
+	return &fakeDelivery{
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (f *fakeDelivery) Start(ctx context.Context) error {
+	close(f.started)
+	<-ctx.Done()
+	close(f.stopped)
+	return nil
+}
+
+func (f *fakeDelivery) Ready() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ready {
+		return nil
+	}
+	return errors.New("not ready")
+}
+
+func (f *fakeDelivery) BlockHeight(_ context.Context) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.height, nil
+}
+
+func (f *fakeDelivery) setReady(height uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ready = true
+	f.height = height
+}
+
+// fakeNotifPeer is a controllable notification.AllTxPeer.
+// Call push to send a batch to the streamer; the stream blocks until ctx is done.
+type fakeNotifPeer struct {
+	batches chan notification.AllTxBatch
+}
+
+func newFakeNotifPeer() *fakeNotifPeer {
+	return &fakeNotifPeer{batches: make(chan notification.AllTxBatch, 16)}
+}
+
+func (f *fakeNotifPeer) StreamAllTransactions(ctx context.Context, _ *notification.StreamAllRequest, p notification.AllTxProcessor) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case b := <-f.batches:
+			if err := p.ProcessBatch(ctx, b); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (f *fakeNotifPeer) push(blockNum uint64, txID string) {
+	f.batches <- notification.AllTxBatch{
+		BlockNumber: blockNum,
+		Events: []notification.CommittedTxEvent{
+			{TxID: txID, BlockNum: blockNum, Status: committerpb.Status_COMMITTED},
+		},
+	}
+}
+
+// recordingHandler records every blocks.Block it receives.
+type recordingHandler struct {
+	mu     sync.Mutex
+	blocks []blocks.Block
+}
+
+func (r *recordingHandler) Handle(_ context.Context, b blocks.Block) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.blocks = append(r.blocks, b)
+	return nil
+}
+
+func (r *recordingHandler) received() []blocks.Block {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]blocks.Block, len(r.blocks))
+	copy(cp, r.blocks)
+	return cp
+}
+
+// newHybrid builds a HybridSynchronizer wired to the given fakes.
+func newHybrid(t *testing.T, delivery *fakeDelivery, peer *fakeNotifPeer, handlers ...blocks.BlockHandler) *HybridSynchronizer {
+	t.Helper()
+	return newWithDeps(
+		delivery,
+		peer,
+		&notification.StreamAllRequest{IncludeMetadata: true, IncludeReadWriteSets: true},
+		sdk.NoOpLogger{},
+		handlers...,
+	)
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+// TestStart_CancelBeforeSwitch verifies that cancelling the context before any
+// switch occurs causes Start to return cleanly with nil.
+func TestStart_CancelBeforeSwitch(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivery := newFakeDelivery()
+		peer := newFakeNotifPeer()
+		h := newHybrid(t, delivery, peer)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() { errCh <- h.Start(ctx) }()
+
+		// Wait until Start is running (delivery.Start has been called).
+		synctest.Wait()
+		<-delivery.started
+
+		cancel()
+		synctest.Wait()
+
+		require.NoError(t, <-errCh)
+	})
+}
+
+// TestReady_BeforeAndAfterSwitch verifies that Ready proxies the delivery
+// synchronizer until the switch and returns nil afterwards.
+func TestReady_BeforeAndAfterSwitch(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivery := newFakeDelivery()
+		peer := newFakeNotifPeer()
+		recorder := &recordingHandler{}
+		h := newHybrid(t, delivery, peer, recorder)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() { _ = h.Start(ctx) }()
+
+		synctest.Wait()
+		<-delivery.started
+
+		// Before the switch: Ready mirrors the delivery synchronizer.
+		assert.Error(t, h.Ready(), "should not be ready before delivery catches up")
+
+		// Mark delivery ready at block 5, then advance the watcher tick.
+		delivery.setReady(6) // height=6 → last processed = 5
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		assert.NoError(t, h.Ready(), "should be ready once delivery is ready")
+
+		// Push a notif batch at block 5: gate should now switch (nDel=5 >= nNot=5)
+		// and the recorder should receive a blocks.Block.
+		// The batch has no EVM metadata so AllTxBatchDispatcher will produce an empty
+		// block — but we just care that Ready() still returns nil post-switch.
+		peer.push(5, "tx1")
+		synctest.Wait()
+
+		assert.NoError(t, h.Ready(), "should remain ready in notification phase")
+	})
+}
+
+// TestGate_DiscardsBatchWhileDeliveryBehind verifies that notification batches
+// whose block number exceeds nDel are silently discarded.
+func TestGate_DiscardsBatchWhileDeliveryBehind(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivery := newFakeDelivery()
+		peer := newFakeNotifPeer()
+		recorder := &recordingHandler{}
+		h := newHybrid(t, delivery, peer, recorder)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() { _ = h.Start(ctx) }()
+
+		synctest.Wait()
+		<-delivery.started
+
+		// Delivery is at block 2 (height=3), notif sends block 10: should be discarded.
+		delivery.setReady(3)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		peer.push(10, "tx-ahead")
+		synctest.Wait()
+
+		assert.Empty(t, recorder.received(), "batch ahead of delivery must be discarded")
+	})
+}
+
+// TestGate_SwitchesAndForwardsWhenCaughtUp verifies the gap-free handoff: when
+// nDel >= nNot the gate flips switched and forwards the triggering batch.
+func TestGate_SwitchesAndForwardsWhenCaughtUp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivery := newFakeDelivery()
+		peer := newFakeNotifPeer()
+		recorder := &recordingHandler{}
+		h := newHybrid(t, delivery, peer, recorder)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() { _ = h.Start(ctx) }()
+
+		synctest.Wait()
+		<-delivery.started
+
+		// Delivery has processed block 5 (height=6); notif sends block 5: should switch.
+		delivery.setReady(6)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		// This batch has EVM metadata — build it properly so AllTxBatchDispatcher keeps it.
+		// For the switch test we only need the block number; an empty-event batch is fine
+		// to confirm dispatch runs (recorder.Handle is called with the resulting Block).
+		peer.batches <- notification.AllTxBatch{BlockNumber: 5}
+		synctest.Wait()
+
+		// The dispatcher filters non-EVM events so the block will have no transactions,
+		// but Handle is still called once with an empty block — or not called at all if
+		// the dispatcher skips empty blocks. Either way, at minimum delivery must be
+		// cancelled (delivery.stopped closed).
+		select {
+		case <-delivery.stopped:
+			// delivery was cancelled — switch happened
+		case <-time.After(time.Second):
+			t.Fatal("delivery was not cancelled after switch")
+		}
+	})
+}
+
+// TestStart_DeliveryErrorIsLogged verifies that a delivery error does not cause
+// Start to exit; Start only returns when ctx is cancelled.
+func TestStart_DeliveryErrorIsLogged(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Replace fakeDelivery with one that returns an error from Start.
+		errDelivery := &errDeliverySyncer{err: errors.New("boom"), done: make(chan struct{})}
+		peer := newFakeNotifPeer()
+		h := newWithDeps(errDelivery, peer, &notification.StreamAllRequest{}, sdk.NoOpLogger{})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() { errCh <- h.Start(ctx) }()
+
+		synctest.Wait()
+
+		// Start must still be running despite delivery error.
+		select {
+		case err := <-errCh:
+			t.Fatalf("Start returned early with %v", err)
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+		require.NoError(t, <-errCh)
+	})
+}
+
+// TestAddRemoveHandler verifies dynamic handler manipulation.
+func TestAddRemoveHandler(t *testing.T) {
+	delivery := newFakeDelivery()
+	peer := newFakeNotifPeer()
+	r1 := &recordingHandler{}
+	r2 := &recordingHandler{}
+	h := newHybrid(t, delivery, peer, r1)
+
+	h.AddHandler(r2)
+	require.Len(t, h.handlers, 2)
+
+	h.RemoveHandler(r1)
+	require.Len(t, h.handlers, 1)
+	assert.Equal(t, r2, h.handlers[0])
+
+	// RemoveHandler on unknown handler is a no-op.
+	h.RemoveHandler(r1)
+	require.Len(t, h.handlers, 1)
+}
+
+// ── helper types ─────────────────────────────────────────────────────────────
+
+// errDeliverySyncer returns an error from Start immediately, simulating a
+// delivery peer that cannot connect.
+type errDeliverySyncer struct {
+	err  error
+	done chan struct{}
+}
+
+func (e *errDeliverySyncer) Start(ctx context.Context) error {
+	close(e.done)
+	return e.err
+}
+
+func (e *errDeliverySyncer) Ready() error                                  { return errors.New("not ready") }
+func (e *errDeliverySyncer) BlockHeight(_ context.Context) (uint64, error) { return 0, nil }

--- a/gateway/app/hybridx/hybrid_test.go
+++ b/gateway/app/hybridx/hybrid_test.go
@@ -292,26 +292,6 @@ func TestStart_DeliveryErrorIsLogged(t *testing.T) {
 	})
 }
 
-// TestAddRemoveHandler verifies dynamic handler manipulation.
-func TestAddRemoveHandler(t *testing.T) {
-	delivery := newFakeDelivery()
-	peer := newFakeNotifPeer()
-	r1 := &recordingHandler{}
-	r2 := &recordingHandler{}
-	h := newHybrid(t, delivery, peer, r1)
-
-	h.AddHandler(r2)
-	require.Len(t, h.handlers, 2)
-
-	h.RemoveHandler(r1)
-	require.Len(t, h.handlers, 1)
-	assert.Equal(t, r2, h.handlers[0])
-
-	// RemoveHandler on unknown handler is a no-op.
-	h.RemoveHandler(r1)
-	require.Len(t, h.handlers, 1)
-}
-
 // ── helper types ─────────────────────────────────────────────────────────────
 
 // errDeliverySyncer returns an error from Start immediately, simulating a

--- a/gateway/app/wiring.go
+++ b/gateway/app/wiring.go
@@ -19,8 +19,17 @@ import (
 
 	"github.com/hyperledger/fabric-x-evm/common"
 	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
+	"github.com/hyperledger/fabric-x-evm/gateway/app/hybridx"
 	"github.com/hyperledger/fabric-x-evm/gateway/core"
 )
+
+// Synchronizer is the interface required by the gateway application from any
+// synchronizer implementation. Both *network.Synchronizer (delivery) and
+// *hybridx.HybridSynchronizer satisfy it.
+type Synchronizer interface {
+	Start(ctx context.Context) error
+	Ready() error
+}
 
 // NewNetworkSubmitters creates one network submitter per parallel-submission worker for
 // the given protocol. count <= 0 defaults to core.DefaultNumWorkers. This is the wiring
@@ -54,12 +63,14 @@ func NewNetworkSubmitters(ctx context.Context, protocol string, orderers []netwo
 // in-process test backend with per-endorser-embedded synchronization instead registers
 // [endorser DBs..., chain, gateway] on a single synchronizer so that endorser state is
 // applied before the gateway marks a transaction complete.
-func NewGatewaySynchronizer(protocol string, db network.BlockHeightReader, channel string, committer network.PeerConf, gwSigner sdk.Signer, logger sdk.Logger, handlers ...blocks.BlockHandler) (*network.Synchronizer, error) {
+//
+// namespace is used by the fabric-x hybrid synchronizer to filter the notification stream.
+func NewGatewaySynchronizer(protocol string, db network.BlockHeightReader, channel, namespace string, committer network.PeerConf, gwSigner sdk.Signer, logger sdk.Logger, handlers ...blocks.BlockHandler) (Synchronizer, error) {
 	switch protocol {
 	case "fabric":
 		return nfab.NewSynchronizer(db, channel, committer, gwSigner, logger, handlers...)
 	case "fabric-x", "":
-		return nfabx.NewSynchronizer(db, channel, committer, gwSigner, logger, handlers...)
+		return hybridx.New(db, channel, namespace, committer, gwSigner, logger, handlers...)
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %q", protocol)
 	}

--- a/integration/perf/replay_json_dataset_test.go
+++ b/integration/perf/replay_json_dataset_test.go
@@ -26,16 +26,114 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
 	econf "github.com/hyperledger/fabric-x-evm/endorser/config"
 	"github.com/hyperledger/fabric-x-evm/endorser/execution"
+	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
 	"github.com/hyperledger/fabric-x-evm/endorser/testimpl"
+	"github.com/hyperledger/fabric-x-evm/gateway/app"
+	gwconfig "github.com/hyperledger/fabric-x-evm/gateway/config"
 	gwcore "github.com/hyperledger/fabric-x-evm/gateway/core"
+	"github.com/hyperledger/fabric-x-evm/gateway/domain"
 	gwtestimpl "github.com/hyperledger/fabric-x-evm/gateway/testimpl"
 	"github.com/hyperledger/fabric-x-evm/integration"
+	sdk "github.com/hyperledger/fabric-x-sdk"
 	"github.com/hyperledger/fabric-x-sdk/blocks"
+	"github.com/hyperledger/fabric-x-sdk/network"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/grpclog"
 )
+
+// memHeightTracker is a minimal blocks.BlockHandler, network.BlockHeightReader,
+// and core.Store that tracks only the latest committed block number in memory.
+// It is used by perf tests as a lightweight replacement for the SQLite-backed
+// core.Chain: it carries no block data and imposes no I/O overhead.
+//
+// The core.Store query methods (GetBlockByNumber, GetTransactionByHash, etc.) are
+// no-ops that return nil — perf tests never issue RPC queries against the chain.
+type memHeightTracker struct {
+	height atomic.Uint64
+}
+
+// Handle implements blocks.BlockHandler — records the block number of every
+// committed block so the synchronizer knows how far delivery has progressed.
+func (m *memHeightTracker) Handle(_ context.Context, b blocks.Block) error {
+	m.height.Store(b.Number)
+	return nil
+}
+
+// BlockNumber implements network.BlockHeightReader and core.Store — returns 0
+// until the first block is committed.
+func (m *memHeightTracker) BlockNumber(_ context.Context) (uint64, error) {
+	return m.height.Load(), nil
+}
+
+// The remaining methods implement core.Store. Perf tests never issue chain
+// queries via RPC, so these are intentional no-ops.
+
+func (m *memHeightTracker) BlockNumberByHash(_ context.Context, _ []byte) (*uint64, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) LatestBlock(_ context.Context, _ bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetBlockByNumber(_ context.Context, _ uint64, _ bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetBlockByHash(_ context.Context, _ []byte, _ bool) (*domain.Block, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetBlockTxCountByHash(_ context.Context, _ []byte) (int64, error) {
+	return 0, nil
+}
+func (m *memHeightTracker) GetBlockTxCountByNumber(_ context.Context, _ uint64) (int64, error) {
+	return 0, nil
+}
+func (m *memHeightTracker) GetTransactionByHash(_ context.Context, _ []byte) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetTransactionByBlockHashAndIndex(_ context.Context, _ []byte, _ int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetTransactionByBlockNumberAndIndex(_ context.Context, _ uint64, _ int64) (*domain.Transaction, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetLogs(_ context.Context, _ domain.LogFilter) ([]domain.Log, error) {
+	return nil, nil
+}
+func (m *memHeightTracker) GetLogsByTxHash(_ context.Context, _ []byte) ([]domain.Log, error) {
+	return nil, nil
+}
+
+// perfHandlerChain is an integration.HandlerChainFactory for perf tests.
+// It wires a memHeightTracker instead of core.Chain (no persistence, no I/O),
+// and appends completionTracker as the last handler so the perf test can observe
+// every committed transaction.
+//
+// Handler order:
+//
+//	[endorser KVS…, memHeightTracker, gateway, completionTracker]
+func perfHandlerChain(completionTracker *TxCompletionTracker) integration.HandlerChainFactory {
+	return func(t *testing.T, ctx context.Context, cfg gwconfig.Config, ends []eapi.Service, gwSigner sdk.Signer, submitters []gwcore.Submitter, txQueue gwcore.TxQueueInterface, dbs []estorage.KVS) (*gwcore.Gateway, []blocks.BlockHandler, network.BlockHeightReader) {
+		tracker := new(memHeightTracker)
+
+		txPerSec := 0
+		if cfg.Network.Namespace == "synthetic" {
+			txPerSec = 10000
+		}
+		gw, err := app.BuildGateway(ctx, ends, gwSigner, cfg.Network, tracker, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, txQueue, cfg.Gateway.EndorsementChanSize, txPerSec)
+		if err != nil {
+			t.Fatalf("build gateway: %v", err)
+		}
+
+		handlers := make([]blocks.BlockHandler, 0, len(dbs)+3)
+		for _, db := range dbs {
+			handlers = append(handlers, db)
+		}
+		handlers = append(handlers, tracker, gw, completionTracker)
+		return gw, handlers, tracker
+	}
+}
 
 var gatewayConfig = flag.String("gateway-config", "fabx.yaml", "gateway config file for the Fabric-X network")
 var metricsAddr = flag.String("metrics-addr", "0.0.0.0:2112", "address for Prometheus metrics endpoint")
@@ -60,14 +158,26 @@ type txCompletion struct {
 type TxCompletionTracker struct {
 	mu           sync.Mutex
 	completionCh chan txCompletion
+	started      bool
 	stopped      bool
 }
 
 // NewTxCompletionTracker creates a new tracker with a completion channel.
+// The tracker is dormant until Start is called: blocks committed before Start
+// (e.g. during catch-up or state priming) are silently ignored.
 func NewTxCompletionTracker(completionCh chan txCompletion) *TxCompletionTracker {
 	return &TxCompletionTracker{
 		completionCh: completionCh,
 	}
+}
+
+// Start opens the tracker for business. Call this once the test is ready to
+// receive completions (i.e. just before dispatching the first transaction).
+// Completions that arrive before Start is called are silently dropped.
+func (t *TxCompletionTracker) Start() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.started = true
 }
 
 // Stop prevents any further sends to the completion channel. Must be called before
@@ -83,7 +193,7 @@ func (t *TxCompletionTracker) Stop() {
 func (t *TxCompletionTracker) Handle(ctx context.Context, b blocks.Block) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.stopped {
+	if !t.started || t.stopped {
 		return nil
 	}
 	for _, tx := range b.Transactions {
@@ -283,7 +393,7 @@ func runReplayTest(t *testing.T, processingWorkerCount int, submittingWorkerCoun
 		},
 		factory,
 		queue,
-		tracker,
+		perfHandlerChain(tracker),
 		gwConfig)
 	// th, err = integration.NewFabricTestHarnessWithFactoryAndTxQueue(t, integration.TestLogger{T: t}, evmConfig, "testdata/USDC_contract.json", map[string]any{"Gateway.WorkerCount": processingWorkerCount, "Gateway.SubmitterCount": ordererSubmitterCount, "Network.Namespace": *namespace}, factory, gwcore.NewTxQueueV2())
 	assert.NoError(t, err)
@@ -380,6 +490,10 @@ func runReplayTest(t *testing.T, processingWorkerCount int, submittingWorkerCoun
 	}()
 
 	runtime.GC()
+
+	// Open the tracker now that we are about to dispatch real transactions.
+	// Any completions that arrived during catch-up or state priming are discarded.
+	tracker.Start()
 
 	// Track throughput
 	startTime := time.Now()

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -50,8 +50,6 @@ import (
 	"github.com/hyperledger/fabric-x-sdk/local"
 	"github.com/hyperledger/fabric-x-sdk/network"
 	nfab "github.com/hyperledger/fabric-x-sdk/network/fabric"
-	nfabx "github.com/hyperledger/fabric-x-sdk/network/fabricx"
-	"github.com/hyperledger/fabric-x-sdk/notification"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -117,18 +115,10 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 //   - cfg.Gateway.SignerMSPDir set → MSP-based signer; empty → local mock
 //   - cfg.Endorsers[0].MspDir set → FabricDeserializer; empty → local mock
 //
-// Sync goroutines are started in the background using ctx. The returned synchronizers
+// Sync goroutines are started in the background using ctx. The returned synchronizer
 // can be used by callers that need to wait for the initial sync to complete.
-//
-// If useNotifications is true, uses NotificationDispatcher + MemoryStore instead of
-// Synchronizer + Chain. This is intended for fabric-x performance testing.
-func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, useNotifications bool) (*TestHarness, *network.Synchronizer, error) {
-	return buildTestHarnessWithExtraHandler(t, logger, cfg, evmConfig, primeDBPath, bypass, endorsers, txQueue, useNotifications, nil)
-}
-
-// buildTestHarnessWithExtraHandler is like buildTestHarness but accepts an optional extra TxHandler
-// that will be inserted into the notification handler chain right before the cleanup handler.
-func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, useNotifications bool, extraHandler common.BlockHandler) (*TestHarness, *network.Synchronizer, error) {
+// extraHandlers are appended to the handler chain after the gateway.
+func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, extraHandlers ...blocks.BlockHandler) (*TestHarness, app.Synchronizer, error) {
 	dbs := make([]storage.KVS, len(endorsers))
 	builders := make([]endorsement.Builder, len(endorsers))
 	ends := make([]eapi.Service, len(endorsers))
@@ -152,9 +142,7 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 	if err != nil {
 		return nil, nil, err
 	}
-	if !useNotifications {
-		t.Cleanup(func() { chain.Close() })
-	}
+	t.Cleanup(func() { chain.Close() })
 
 	// Build submitters (one per worker for parallel submission)
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
@@ -168,7 +156,7 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 	}
 
 	var submitters []core.Submitter
-	var sync *network.Synchronizer
+	var sync app.Synchronizer
 
 	if bypass {
 		// Use local submitters for bypass mode (no network communication)
@@ -196,80 +184,40 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 		return nil, nil, err
 	}
 
-	// Create synchronizer with handlers (endorsers, chain, and gateway) - only for non-bypass mode
+	// Create synchronizer with handlers — only for non-bypass mode (bypass uses a local
+	// in-process submitter and has no network peer to synchronize with).
+	//
+	// Handler order matters: each handler is called in sequence for every committed block.
+	//
+	//   1. Endorser KVS (dbs): update the read/write-set store used by the endorser for
+	//      MVCC validation. Must run first so that by the time chain and gateway see the
+	//      block the endorser's state already reflects it — this gives read-your-writes
+	//      semantics for the test RPC's synchronous eth_sendRawTransaction.
+	//
+	//   2. Chain: persist the block and its Ethereum transactions to the SQLite store and
+	//      update the state-root trie. Must run before the gateway so that eth_getBlockBy*
+	//      and eth_getTransactionReceipt are answerable the moment the gateway marks a
+	//      transaction complete.
+	//
+	//   3. Gateway: call TxQueue.Handle to mark any pending Ethereum transactions whose
+	//      Fabric tx-ID appears in this block as complete, unblocking waiting callers.
+	//
+	//   4. Extra handlers (e.g. TxCompletionTracker in perf tests): any caller-supplied
+	//      handlers that observe committed blocks for their own purposes.
 	if !bypass {
-		handlers := make([]blocks.BlockHandler, 0, len(dbs)+2)
+		handlers := make([]blocks.BlockHandler, 0, len(dbs)+2+len(extraHandlers))
 		for _, db := range dbs {
 			handlers = append(handlers, db)
 		}
-		// Add chain before gateway to ensure blocks are persisted before marking transactions complete
-		handlers = append(handlers, chain)
-		if !useNotifications {
-			handlers = append(handlers, gw)
-		}
+		handlers = append(handlers, chain, gw)
+		handlers = append(handlers, extraHandlers...)
 
-		sync, err = app.NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+		sync, err = app.NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		if useNotifications {
-			// HYBRID MODE: Use synchronizer to catch up, then switch to notifications
-			syncCtx, syncCancel := context.WithCancel(t.Context())
-			syncDone := make(chan struct{})
-			go func() {
-				defer close(syncDone)
-				if err := sync.Start(syncCtx); err != nil && syncCtx.Err() == nil {
-					logger.Errorf("synchronizer error during catchup: %v", err)
-				}
-			}()
-
-			logger.Infof("Waiting for synchronizer to catch up...")
-			if err := app.WaitUntilSynced(t.Context(), sync, 60*time.Second); err != nil {
-				t.Fatal(err)
-			}
-			logger.Infof("Synchronizer caught up - stopping and switching to notifications")
-
-			syncCancel()
-			<-syncDone
-			chain.Close()
-			logger.Infof("Synchronizer stopped cleanly")
-
-			// Set up AllTxStreamer notification system
-			txHandlers := make([]common.BlockHandler, 0, len(dbs)+2)
-			for _, db := range dbs {
-				txHandlers = append(txHandlers, db.(common.BlockHandler))
-			}
-			txHandlers = append(txHandlers, gw)
-			if extraHandler != nil {
-				txHandlers = append(txHandlers, extraHandler)
-			}
-
-			dispatcher := common.NewAllTxBatchDispatcher(txHandlers...)
-
-			if cfg.Network.Protocol == "fabric-x" || cfg.Network.Protocol == "" {
-				peer, err := nfabx.NewPeer(cfg.Gateway.Committer.ToPeerConf(), cfg.Network.Channel, gwSigner)
-				if err != nil {
-					return nil, nil, fmt.Errorf("create notification peer: %w", err)
-				}
-				streamer := notification.NewAllTxStreamer(peer, []notification.AllTxHandler{dispatcher}, logger)
-				go func() {
-					req := &notification.StreamAllRequest{
-						FilterNamespaces:     []string{cfg.Network.Namespace},
-						IncludeReadWriteSets: true,
-						IncludeMetadata:      true,
-					}
-					if err := streamer.Stream(t.Context(), req); err != nil && t.Context().Err() == nil {
-						logger.Errorf("AllTxStreamer error: %v", err)
-					}
-				}()
-				logger.Infof("AllTxStreamer active")
-			}
-
-			sync = nil
-		} else {
-			go func() error { return sync.Start(t.Context()) }()
-		}
+		go func() { _ = sync.Start(t.Context()) }()
 	}
 
 	// Start gateway worker pool
@@ -284,6 +232,7 @@ func buildTestHarnessWithExtraHandler(t *testing.T, logger sdk.Logger, cfg confi
 
 	th := &TestHarness{
 		Gateways:       []*core.Gateway{gw},
+		Chain:          chain,
 		endorsers:      ends,
 		ethChainConfig: evmConfig.ChainConfig,
 		Primer:         primer,
@@ -449,7 +398,7 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 		peer.Port = nw.PeerPort
 	}
 
-	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass, endorsers, nil, false)
+	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass, endorsers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +420,7 @@ func newFileConfigHarness(t *testing.T, logger sdk.Logger, evmConfig execution.E
 		return nil, err
 	}
 
-	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, nil, false)
+	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -483,10 +432,16 @@ func newFileConfigHarness(t *testing.T, logger sdk.Logger, evmConfig execution.E
 	return th, nil
 }
 
-// NewFabricXTestHarnessWithNotifications creates a fabric-x test harness with notification-based
-// transaction completion tracking instead of block-based synchronization.
-// Uses MemoryStore and NotificationDispatcher for better performance in replay scenarios.
-// If extraHandler is non-nil, it will be inserted into the handler chain right before the cleanup handler.
+// NewFabricXTestHarnessWithNotifications creates a fabric-x test harness backed by
+// the hybrid synchronizer (delivery catch-up + notification live feed).
+//
+// It blocks until the synchronizer has fully caught up with the network before
+// returning, so callers can rely on the node being in sync from the first call.
+//
+// extraHandler is an optional handler (e.g. a TxCompletionTracker in perf tests)
+// that is added to the live chain *after* catch-up completes, so it only observes
+// transactions committed during the live notification phase and is never called
+// for historical catch-up blocks.  Pass nil to omit it.
 func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evmConfig execution.EVMConfig, primeDbPath string, configOverrides map[string]any, factory EndorserFactory, txQueue core.TxQueueInterface, extraHandler common.BlockHandler, confFile string) (*TestHarness, error) {
 	if primeDbPath != "" && !filepath.IsAbs(primeDbPath) {
 		if abs, err := filepath.Abs(primeDbPath); err == nil {
@@ -507,10 +462,28 @@ func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evm
 		return nil, err
 	}
 
-	// Use buildTestHarness with useNotifications=true and extraHandler
-	th, _, err := buildTestHarnessWithExtraHandler(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, txQueue, true, extraHandler)
+	// Build without extraHandler: it will be added after catch-up completes.
+	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, txQueue)
 	if err != nil {
 		return nil, err
+	}
+
+	// Wait for the hybrid synchronizer to finish delivery catch-up.
+	if err := app.WaitUntilSynced(t.Context(), sync, 60*time.Second); err != nil {
+		return nil, fmt.Errorf("timed out waiting for sync: %w", err)
+	}
+
+	// Now that catch-up is complete, reconfigure the live handler chain:
+	// remove the chain store (block persistence is not needed for live perf
+	// testing and would just add latency) and add the extra handler.
+	if hs, ok := sync.(interface {
+		AddHandler(blocks.BlockHandler)
+		RemoveHandler(blocks.BlockHandler)
+	}); ok {
+		if extraHandler != nil {
+			hs.RemoveHandler(th.Chain)
+			hs.AddHandler(extraHandler)
+		}
 	}
 
 	return th, nil
@@ -546,6 +519,7 @@ func NewEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 type TestHarness struct {
 	DBs            []storage.KVS
 	Gateways       []*core.Gateway
+	Chain          *core.Chain
 	endorsers      []eapi.Service
 	ethChainConfig *params.ChainConfig
 	Primer         *StatePrimer

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -108,6 +108,80 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 	return primer.Commit(ctx, wait)
 }
 
+// HandlerChainFactory builds the gateway and the complete synchronizer handler
+// chain for a test harness.  It receives the pre-built endorser services, gateway
+// signer, submitters, and txQueue so it can call app.BuildGateway internally and
+// assemble whatever handler list is appropriate.
+//
+// It returns:
+//   - gw: the constructed gateway (also started by buildTestHarness after this call)
+//   - handlers: the full, ordered []blocks.BlockHandler for the synchronizer
+//   - heightReader: the network.BlockHeightReader the synchronizer uses for catch-up
+//
+// The factory is responsible for allocating any store it needs and registering
+// teardown via t.Cleanup.  Passing nil to buildTestHarness selects
+// defaultHandlerChain.
+//
+// Conventional handler order:
+//
+//	[endorser KVS…, chain store, gateway, …any extra observers]
+type HandlerChainFactory func(
+	t *testing.T,
+	ctx context.Context,
+	cfg config.Config,
+	ends []eapi.Service,
+	gwSigner sdk.Signer,
+	submitters []core.Submitter,
+	txQueue core.TxQueueInterface,
+	dbs []storage.KVS,
+) (gw *core.Gateway, handlers []blocks.BlockHandler, heightReader network.BlockHeightReader)
+
+// defaultHandlerChain is the HandlerChainFactory used by every test that does
+// not need a custom chain store.  It opens the SQLite-backed core.Chain,
+// registers chain.Close on t, builds the gateway, and returns the standard
+// handler order.
+//
+// Handler order matters: each handler is called in sequence for every committed block.
+//
+//  1. Endorser KVS (dbs): update the read/write-set store used by the endorser for
+//     MVCC validation. Must run first so that by the time chain and gateway see the
+//     block the endorser's state already reflects it — this gives read-your-writes
+//     semantics for the test RPC's synchronous eth_sendRawTransaction.
+//
+//  2. Chain: persist the block and its Ethereum transactions to the SQLite store and
+//     update the state-root trie. Must run before the gateway so that eth_getBlockBy*
+//     and eth_getTransactionReceipt are answerable the moment the gateway marks a
+//     transaction complete.
+//
+//  3. Gateway: call TxQueue.Handle to mark any pending Ethereum transactions whose
+//     Fabric tx-ID appears in this block as complete, unblocking waiting callers.
+//
+//  4. Extra handlers (e.g. TxCompletionTracker in perf tests): any caller-supplied
+//     handlers that observe committed blocks for their own purposes.
+func defaultHandlerChain(t *testing.T, ctx context.Context, cfg config.Config, ends []eapi.Service, gwSigner sdk.Signer, submitters []core.Submitter, txQueue core.TxQueueInterface, dbs []storage.KVS) (*core.Gateway, []blocks.BlockHandler, network.BlockHeightReader) {
+	chain, err := core.NewChain(cfg.Gateway.Database.ConnString, cfg.Gateway.Database.TriePath, false)
+	if err != nil {
+		t.Fatalf("open chain: %v", err)
+	}
+	t.Cleanup(func() { chain.Close() })
+
+	txPerSec := 0
+	if cfg.Network.Namespace == "synthetic" {
+		txPerSec = 10000
+	}
+	gw, err := app.BuildGateway(ctx, ends, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, txQueue, cfg.Gateway.EndorsementChanSize, txPerSec)
+	if err != nil {
+		t.Fatalf("build gateway: %v", err)
+	}
+
+	handlers := make([]blocks.BlockHandler, 0, len(dbs)+2)
+	for _, db := range dbs {
+		handlers = append(handlers, db)
+	}
+	handlers = append(handlers, chain, gw)
+	return gw, handlers, chain
+}
+
 // buildTestHarness is the shared implementation for all test harness constructors.
 // It builds endorsers, a gateway, and primes state.
 //
@@ -117,8 +191,10 @@ func (th *TestHarness) PrimeStateFromJSON(ctx context.Context, jsonFilePath stri
 //
 // Sync goroutines are started in the background using ctx. The returned synchronizer
 // can be used by callers that need to wait for the initial sync to complete.
-// extraHandlers are appended to the handler chain after the gateway.
-func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, extraHandlers ...blocks.BlockHandler) (*TestHarness, app.Synchronizer, error) {
+//
+// chainFactory controls which chain store and handler chain are wired into the
+// synchronizer. Pass nil to use defaultHandlerChain.
+func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmConfig execution.EVMConfig, primeDBPath string, bypass bool, endorsers []EndorserComponents, txQueue core.TxQueueInterface, chainFactory HandlerChainFactory) (*TestHarness, app.Synchronizer, error) {
 	dbs := make([]storage.KVS, len(endorsers))
 	builders := make([]endorsement.Builder, len(endorsers))
 	ends := make([]eapi.Service, len(endorsers))
@@ -138,16 +214,10 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 		gwSigner = localSigner{}
 	}
 
-	chain, err := core.NewChain(cfg.Gateway.Database.ConnString, cfg.Gateway.Database.TriePath, false)
-	if err != nil {
-		return nil, nil, err
-	}
-	t.Cleanup(func() { chain.Close() })
-
-	// Build submitters (one per worker for parallel submission)
-	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
+	// Build submitters (one per worker for parallel submission).
+	ordererConfs := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
-		orderers[i] = o.ToOrdererConf()
+		ordererConfs[i] = o.ToOrdererConf()
 	}
 
 	submitterCount := cfg.Gateway.SubmitterCount
@@ -155,8 +225,11 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 		submitterCount = core.DefaultNumWorkers
 	}
 
-	var submitters []core.Submitter
-	var sync app.Synchronizer
+	var (
+		submitters []core.Submitter
+		sync       app.Synchronizer
+		err        error
+	)
 
 	if bypass {
 		// Use local submitters for bypass mode (no network communication)
@@ -166,53 +239,25 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 		}
 	} else {
 		// Create network submitters
-		submitters, err = app.NewNetworkSubmitters(t.Context(), cfg.Network.Protocol, orderers, gwSigner, submitterCount, logger)
+		submitters, err = app.NewNetworkSubmitters(t.Context(), cfg.Network.Protocol, ordererConfs, gwSigner, submitterCount, logger)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	// Create gateway before synchronizer so we can register it as a handler
-	// Gateway owns the BatchSubmitter and will handle its lifecycle
-	// Enable rate limiting only for "synthetic" namespace (10 000 tx/s)
-	txPerSec := 0
-	if cfg.Network.Namespace == "synthetic" {
-		txPerSec = 10000
+	if chainFactory == nil {
+		chainFactory = defaultHandlerChain
 	}
-	gw, err := app.BuildGateway(t.Context(), ends, gwSigner, cfg.Network, chain, submitters, cfg.Gateway.SubmitterCount, cfg.Gateway.WorkerCount, txQueue, cfg.Gateway.EndorsementChanSize, txPerSec)
-	if err != nil {
-		return nil, nil, err
-	}
+	gw, handlers, heightReader := chainFactory(t, t.Context(), cfg, ends, gwSigner, submitters, txQueue, dbs)
 
 	// Create synchronizer with handlers — only for non-bypass mode (bypass uses a local
 	// in-process submitter and has no network peer to synchronize with).
 	//
 	// Handler order matters: each handler is called in sequence for every committed block.
-	//
-	//   1. Endorser KVS (dbs): update the read/write-set store used by the endorser for
-	//      MVCC validation. Must run first so that by the time chain and gateway see the
-	//      block the endorser's state already reflects it — this gives read-your-writes
-	//      semantics for the test RPC's synchronous eth_sendRawTransaction.
-	//
-	//   2. Chain: persist the block and its Ethereum transactions to the SQLite store and
-	//      update the state-root trie. Must run before the gateway so that eth_getBlockBy*
-	//      and eth_getTransactionReceipt are answerable the moment the gateway marks a
-	//      transaction complete.
-	//
-	//   3. Gateway: call TxQueue.Handle to mark any pending Ethereum transactions whose
-	//      Fabric tx-ID appears in this block as complete, unblocking waiting callers.
-	//
-	//   4. Extra handlers (e.g. TxCompletionTracker in perf tests): any caller-supplied
-	//      handlers that observe committed blocks for their own purposes.
+	// The ordering is the responsibility of the chainFactory; see defaultHandlerChain for
+	// the conventional ordering (endorser KVS…, chain store, gateway, extra observers…).
 	if !bypass {
-		handlers := make([]blocks.BlockHandler, 0, len(dbs)+2+len(extraHandlers))
-		for _, db := range dbs {
-			handlers = append(handlers, db)
-		}
-		handlers = append(handlers, chain, gw)
-		handlers = append(handlers, extraHandlers...)
-
-		sync, err = app.NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+		sync, err = app.NewGatewaySynchronizer(cfg.Network.Protocol, heightReader, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -232,7 +277,6 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 
 	th := &TestHarness{
 		Gateways:       []*core.Gateway{gw},
-		Chain:          chain,
 		endorsers:      ends,
 		ethChainConfig: evmConfig.ChainConfig,
 		Primer:         primer,
@@ -398,7 +442,7 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 		peer.Port = nw.PeerPort
 	}
 
-	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass, endorsers, nil)
+	th, _, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, bypass, endorsers, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +464,7 @@ func newFileConfigHarness(t *testing.T, logger sdk.Logger, evmConfig execution.E
 		return nil, err
 	}
 
-	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, nil)
+	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -438,11 +482,11 @@ func newFileConfigHarness(t *testing.T, logger sdk.Logger, evmConfig execution.E
 // It blocks until the synchronizer has fully caught up with the network before
 // returning, so callers can rely on the node being in sync from the first call.
 //
-// extraHandler is an optional handler (e.g. a TxCompletionTracker in perf tests)
-// that is added to the live chain *after* catch-up completes, so it only observes
-// transactions committed during the live notification phase and is never called
-// for historical catch-up blocks.  Pass nil to omit it.
-func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evmConfig execution.EVMConfig, primeDbPath string, configOverrides map[string]any, factory EndorserFactory, txQueue core.TxQueueInterface, extraHandler common.BlockHandler, confFile string) (*TestHarness, error) {
+// chainFactory controls the chain store and handler chain wired into the
+// synchronizer. Pass nil to use defaultHandlerChain (SQLite-backed core.Chain).
+// Perf tests supply their own factory to use a lightweight in-memory height
+// tracker and attach a TxCompletionTracker as a tail handler.
+func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evmConfig execution.EVMConfig, primeDbPath string, configOverrides map[string]any, factory EndorserFactory, txQueue core.TxQueueInterface, chainFactory HandlerChainFactory, confFile string) (*TestHarness, error) {
 	if primeDbPath != "" && !filepath.IsAbs(primeDbPath) {
 		if abs, err := filepath.Abs(primeDbPath); err == nil {
 			primeDbPath = abs
@@ -462,8 +506,7 @@ func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evm
 		return nil, err
 	}
 
-	// Build without extraHandler: it will be added after catch-up completes.
-	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, txQueue)
+	th, sync, err := buildTestHarness(t, logger, cfg, evmConfig, primeDbPath, false, endorsers, txQueue, chainFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -471,19 +514,6 @@ func NewFabricXTestHarnessWithNotifications(t *testing.T, logger sdk.Logger, evm
 	// Wait for the hybrid synchronizer to finish delivery catch-up.
 	if err := app.WaitUntilSynced(t.Context(), sync, 60*time.Second); err != nil {
 		return nil, fmt.Errorf("timed out waiting for sync: %w", err)
-	}
-
-	// Now that catch-up is complete, reconfigure the live handler chain:
-	// remove the chain store (block persistence is not needed for live perf
-	// testing and would just add latency) and add the extra handler.
-	if hs, ok := sync.(interface {
-		AddHandler(blocks.BlockHandler)
-		RemoveHandler(blocks.BlockHandler)
-	}); ok {
-		if extraHandler != nil {
-			hs.RemoveHandler(th.Chain)
-			hs.AddHandler(extraHandler)
-		}
 	}
 
 	return th, nil
@@ -519,7 +549,6 @@ func NewEndorser(t *testing.T, cfg econf.Endorser, channel, namespace string, ev
 type TestHarness struct {
 	DBs            []storage.KVS
 	Gateways       []*core.Gateway
-	Chain          *core.Chain
 	endorsers      []eapi.Service
 	ethChainConfig *params.ChainConfig
 	Primer         *StatePrimer


### PR DESCRIPTION
On fabric-x, the gateway now starts both the delivery service and the notification service concurrently at startup. The delivery service streams full blocks from the last locally-persisted block, catching up with the network. The notification service tracks the latest committed block number in real time. The switch from delivery to notification is decided inside a single HandleBatch call in the notification gate: once the delivery position meets or exceeds the notification position, the gate atomically flips to live mode and forwards the batch, eliminating any gap between the two phases. After the switch, all delivery resources are cancelled and released for GC.

Closes #220 #221 #69 