### PR TITLE
fix: complete leaked TxQueue entries on submission failure

### DIFF
--- a/gateway/app/wiring.go
+++ b/gateway/app/wiring.go
@@ -91,8 +91,13 @@ func BuildGateway(ctx context.Context, endorsers []eapi.Service, gwSigner sdk.Si
 	if endorsementChanSize <= 0 {
 		endorsementChanSize = 1000
 	}
-	endorsementChan := make(chan sdk.Endorsement, endorsementChanSize)
-	batchSubmitter := core.NewBatchSubmitter(submitters, endorsementChan, submitterCount, txPerSec)
+	if txQueue == nil {
+		txQueue = core.NewTxQueue()
+	}
+	endorsementChan := make(chan core.EndorsedTx, endorsementChanSize)
+	// txQueue as Completer: a submission failure means the tx will never reach a block, so
+	// it must be completed here instead of leaking forever waiting for a commit that won't come.
+	batchSubmitter := core.NewBatchSubmitter(submitters, endorsementChan, submitterCount, txPerSec, txQueue)
 	batchSubmitter.Start(ctx)
 
 	gw, err := core.New(ec, batchSubmitter, chain, netCfg.ChainID, workerCount, txQueue, endorsementChan)

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -84,7 +84,7 @@ type Gateway struct {
 	workerCount     int
 	wg              sync.WaitGroup
 	stopOnce        sync.Once
-	endorsementChan chan sdk.Endorsement // Channel to send endorsements to BatchSubmitter
+	endorsementChan chan EndorsedTx // Channel to send endorsements to BatchSubmitter
 }
 
 type Store interface {
@@ -106,7 +106,7 @@ type Store interface {
 // If txQueue is nil, NewTxQueue() will be used as the default.
 // batchSubmitter handles all endorsement submissions and is owned by the Gateway.
 // endorsementChan is the channel to send endorsements to the BatchSubmitter.
-func New(ec *EndorsementClient, batchSubmitter *BatchSubmitter, store Store, chainID int64, workerCount int, txQueue TxQueueInterface, endorsementChan chan sdk.Endorsement) (*Gateway, error) {
+func New(ec *EndorsementClient, batchSubmitter *BatchSubmitter, store Store, chainID int64, workerCount int, txQueue TxQueueInterface, endorsementChan chan EndorsedTx) (*Gateway, error) {
 	if workerCount <= 0 {
 		workerCount = 1
 	}
@@ -164,7 +164,7 @@ func (g *Gateway) processTx(ctx context.Context, tx *types.Transaction) error {
 	if err != nil {
 		return err
 	}
-	if err := g.SubmitFabricTx(ctx, end); err != nil {
+	if err := g.SubmitFabricTx(ctx, tx.Hash(), end); err != nil {
 		return err
 	}
 
@@ -196,11 +196,13 @@ func (g *Gateway) ExecuteEthTx(ctx context.Context, tx *types.Transaction) (sdk.
 	return g.endorsers.ExecuteTransaction(ctx, tx)
 }
 
-// SubmitFabricTx submits a Fabric envelope via the BatchSubmitter.
-func (g *Gateway) SubmitFabricTx(ctx context.Context, end sdk.Endorsement) error {
+// SubmitFabricTx submits a Fabric envelope via the BatchSubmitter. hash is the originating
+// Ethereum transaction's hash, used to complete it in TxQueue if the submission fails
+// (meaning it will never reach a block and commit-based completion will never see it).
+func (g *Gateway) SubmitFabricTx(ctx context.Context, hash common.Hash, end sdk.Endorsement) error {
 	// Send endorsement to BatchSubmitter via channel
 	select {
-	case g.endorsementChan <- end:
+	case g.endorsementChan <- EndorsedTx{Hash: hash, End: end}:
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled while sending endorsement: %w", ctx.Err())

--- a/gateway/core/batch_submitter.go
+++ b/gateway/core/batch_submitter.go
@@ -32,6 +32,20 @@ var SubmissionTimestampsMu sync.Mutex
 // If non-nil, it will be called to report the current queue size.
 var SetBatchSubmitterQueueSizeMetric func(size int)
 
+// EndorsedTx pairs an endorsement with the Ethereum transaction hash it originated from.
+// The hash is needed because a submission failure means the transaction will never reach
+// a block, so it must be reported back to a Completer instead of leaking in whatever is
+// tracking the transaction's lifecycle.
+type EndorsedTx struct {
+	Hash common.Hash
+	End  sdk.Endorsement
+}
+
+// Completer marks a transaction hash as finished. TxQueueInterface satisfies this.
+type Completer interface {
+	Complete(hash common.Hash)
+}
+
 // BatchSubmitter reads endorsements from a channel, optionally records them in the
 // pending-tx cache (when cache != nil), then submits each one to the orderer.
 // The cache is used by AllTxBatchDispatcher to correlate commit events with the
@@ -42,11 +56,12 @@ var SetBatchSubmitterQueueSizeMetric func(size int)
 // does not exceed the configured limit.
 type BatchSubmitter struct {
 	submitters  []Submitter // One submitter per worker for parallel submission
-	inputChan   chan sdk.Endorsement
+	inputChan   chan EndorsedTx
 	stopChan    chan struct{}
 	doneChan    chan struct{}
 	numWorkers  int
 	rateLimiter *rate.Limiter // Shared rate limiter across all workers (nil if disabled)
+	completer   Completer     // Notified when a submission fails permanently (nil = no-op)
 }
 
 const DefaultNumWorkers = 16
@@ -55,12 +70,14 @@ const DefaultNumWorkers = 16
 // numWorkers specifies the number of parallel submission goroutines (default: 16).
 // Creates one submitter instance per worker for optimal parallel performance.
 // txPerSec sets the aggregate submission rate limit across all workers; when zero,
-// rate limiting is disabled.
+// rate limiting is disabled. completer is notified of a hash when its submission fails
+// permanently; nil is fine if the caller doesn't need that (e.g. tests).
 func NewBatchSubmitter(
 	submitters []Submitter,
-	inputChan chan sdk.Endorsement,
+	inputChan chan EndorsedTx,
 	numWorkers int,
 	txPerSec int,
+	completer Completer,
 ) *BatchSubmitter {
 	if numWorkers <= 0 {
 		numWorkers = DefaultNumWorkers
@@ -84,6 +101,7 @@ func NewBatchSubmitter(
 		doneChan:    make(chan struct{}),
 		numWorkers:  numWorkers,
 		rateLimiter: rateLimiter,
+		completer:   completer,
 	}
 }
 
@@ -147,8 +165,11 @@ func (bs *BatchSubmitter) worker(ctx context.Context, workerID int, wg *sync.Wai
 			if !ok {
 				return
 			}
-			if err := bs.submitOne(ctx, workerID, end); err != nil {
+			if err := bs.submitOne(ctx, workerID, end.End); err != nil {
 				batchLogger.Errorf("Worker %d: submit failed: %v", workerID, err)
+				if bs.completer != nil {
+					bs.completer.Complete(end.Hash)
+				}
 			}
 		}
 	}

--- a/gateway/core/batch_submitter_test.go
+++ b/gateway/core/batch_submitter_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	sdk "github.com/hyperledger/fabric-x-sdk"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSubmitter always returns err from Submit, so tests can force a submission failure
+// without needing a real packager/orderer (e.g. the ExecFailure case, where PackageTx
+// rejects the response status before anything is ever broadcast).
+type stubSubmitter struct{ err error }
+
+func (s stubSubmitter) Submit(context.Context, sdk.Endorsement) error { return s.err }
+func (s stubSubmitter) Close() error                                  { return nil }
+
+// stubCompleter records which hashes were completed, guarded for concurrent worker access.
+type stubCompleter struct {
+	mu        sync.Mutex
+	completed []common.Hash
+}
+
+func (c *stubCompleter) Complete(hash common.Hash) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.completed = append(c.completed, hash)
+}
+
+func (c *stubCompleter) all() []common.Hash {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]common.Hash(nil), c.completed...)
+}
+
+// TestBatchSubmitter_FailedSubmissionCompletesTx reproduces the leak: a transaction whose
+// submission is rejected (e.g. ExecFailure's out-of-range status, or a real orderer/network
+// failure) must be completed so it doesn't sit in TxQueue forever waiting for a commit that
+// will never come — see docs/ISSUE_DRAFT_execfailure_commit.md.
+func TestBatchSubmitter_FailedSubmissionCompletesTx(t *testing.T) {
+	completer := &stubCompleter{}
+	submitErr := errors.New("package proposal: proposal response was not successful, error code 460, msg invalid opcode: INVALID")
+	bs := NewBatchSubmitter([]Submitter{stubSubmitter{err: submitErr}}, make(chan EndorsedTx, 1), 1, 0, completer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bs.Start(ctx)
+	defer bs.Stop()
+
+	hash := common.HexToHash("0x1")
+	bs.inputChan <- EndorsedTx{Hash: hash, End: sdk.Endorsement{}}
+
+	require.Eventually(t, func() bool {
+		return len(completer.all()) == 1
+	}, time.Second, time.Millisecond, "failed submission should complete the tx instead of leaking it")
+	require.Equal(t, hash, completer.all()[0])
+}
+
+// TestBatchSubmitter_SuccessfulSubmissionDoesNotComplete verifies the completer is only
+// used for permanent failures. A successful submission still needs a real block commit
+// before it's done (handled by TxQueue.Handle, not here) — completing it early would let a
+// second, conflicting transaction reuse the same tracking slot before the first actually lands.
+func TestBatchSubmitter_SuccessfulSubmissionDoesNotComplete(t *testing.T) {
+	completer := &stubCompleter{}
+	bs := NewBatchSubmitter([]Submitter{stubSubmitter{err: nil}}, make(chan EndorsedTx, 1), 1, 0, completer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bs.Start(ctx)
+	defer bs.Stop()
+
+	bs.inputChan <- EndorsedTx{Hash: common.HexToHash("0x2"), End: sdk.Endorsement{}}
+
+	// Give the worker a chance to process the (successful) submission, then confirm
+	// nothing was completed as a side effect of it.
+	require.Never(t, func() bool {
+		return len(completer.all()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+// TestBatchSubmitter_NilCompleterIsSafe: completer is optional (e.g. tests that don't care
+// about failure tracking); a failed submission must not panic when it's nil.
+func TestBatchSubmitter_NilCompleterIsSafe(t *testing.T) {
+	bs := NewBatchSubmitter([]Submitter{stubSubmitter{err: errors.New("boom")}}, make(chan EndorsedTx, 1), 1, 0, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bs.Start(ctx)
+	defer bs.Stop()
+
+	bs.inputChan <- EndorsedTx{Hash: common.HexToHash("0x3"), End: sdk.Endorsement{}}
+	time.Sleep(50 * time.Millisecond) // let the worker process it; no assertion needed beyond "didn't panic"
+}

--- a/integration/state_primer.go
+++ b/integration/state_primer.go
@@ -322,7 +322,7 @@ func (sp *StatePrimer) fakeEthTx() (*types.Transaction, []byte, error) {
 func (sp *StatePrimer) commitAndWait(end sdk.Endorsement, tx *types.Transaction, wait bool) error {
 	if wait {
 		// submit through the gateway (asynchronous)
-		if err := sp.gw.SubmitFabricTx(context.Background(), end); err != nil {
+		if err := sp.gw.SubmitFabricTx(context.Background(), tx.Hash(), end); err != nil {
 			return err
 		}
 	} else {

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -573,7 +573,7 @@ func processCommon(t *testing.T, gw *core.Gateway, commit bool, tx *types.Transa
 	}
 
 	if commit {
-		if err := gw.SubmitFabricTx(t.Context(), env); err != nil {
+		if err := gw.SubmitFabricTx(t.Context(), tx.Hash(), env); err != nil {
 			t.Fatal(err)
 		}
 
@@ -709,17 +709,17 @@ func querySmartContractExpect(t *testing.T, client *EthClient, addr ethcommon.Ad
 func submit(t *testing.T, gw *core.Gateway, end sdk.Endorsement) {
 	t.Helper()
 
-	if err := gw.SubmitFabricTx(t.Context(), end); err != nil {
-		t.Error(err)
-	}
-
-	ec, err := NewNativeEthClient(gw)
+	// Extract the Ethereum transaction from the proposal
+	tx, err := extractEthTxFromProposal(end.Proposal)
 	if err != nil {
 		t.Error(err)
 	}
 
-	// Extract the Ethereum transaction from the proposal
-	tx, err := extractEthTxFromProposal(end.Proposal)
+	if err := gw.SubmitFabricTx(t.Context(), tx.Hash(), end); err != nil {
+		t.Error(err)
+	}
+
+	ec, err := NewNativeEthClient(gw)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
A submission failure after endorsement (e.g. ExecFailure, or a real orderer/network error) was silently dropped in BatchSubmitter — no TxQueue.Complete() call, so it leaked forever, permanently inflating in-flight transaction counts which caused issues with txFence too.

Thread the tx hash through BatchSubmitter and call Complete() on failure so it's cleaned up instead of leaking.