### PR TITLE
fix: advance chain tip only after SQL commit

### DIFF
--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -69,8 +69,14 @@ func NewChain(dbConnStr, triePath string, withTrie bool) (*Chain, error) {
 	return &Chain{Store: blockStore, db: db, ts: ts, prevHash: prevHash}, nil
 }
 
-// Handle implements blocks.BlockHandler. It commits the block's write sets to the trie,
-// then persists the block and its transactions to the database.
+// Handle implements blocks.BlockHandler. Order matters for tip safety (#304):
+//  1. Build the domain block and stamp ParentHash from the current tip.
+//  2. Commit write sets to the trie when enabled (flush stays here so a crash
+//     after SQL but before a deferred flush cannot leave SQL ahead of the MPT;
+//     trie apply is idempotent on resubscribe replay).
+//  3. Persist the block via InsertBlock.
+//  4. Advance prevHash only after SQL returns nil, so a failed insert never
+//     publishes a tip that the store does not hold.
 func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 	ebl := ConvertToDomain(b)
 
@@ -84,12 +90,12 @@ func (c *Chain) Handle(ctx context.Context, b blocks.Block) error {
 	} else {
 		ebl.StateRoot = types.EmptyRootHash[:]
 	}
-	c.prevHash = common.BytesToHash(ebl.BlockHash)
 
 	if err := c.Store.InsertBlock(ctx, ebl); err != nil {
 		return err
 	}
 
+	c.prevHash = common.BytesToHash(ebl.BlockHash)
 	return nil
 }
 

--- a/gateway/core/chain_resilience_test.go
+++ b/gateway/core/chain_resilience_test.go
@@ -129,3 +129,128 @@ func TestHandle_ReprocessingSameBlockKeepsIndexesAndTrieStable(t *testing.T) {
 	require.Len(t, logEntries, 1)
 	require.Equal(t, ethTx.Hash().Bytes(), logEntries[0].TxHash)
 }
+
+// TestHandle_PrevHashAdvancesOnlyAfterSuccessfulInsert locks the happy path:
+// the published tip moves exactly once per durable block.
+func TestHandle_PrevHashAdvancesOnlyAfterSuccessfulInsert(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gateway.db")
+	chain, err := NewChain(dbPath, "", false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = chain.Close() })
+
+	require.Equal(t, common.Hash{}, chain.prevHash)
+
+	block1 := emptyResilienceBlock(1, 0x01, 1000)
+	require.NoError(t, chain.Handle(t.Context(), block1))
+	require.Equal(t, common.BytesToHash(block1.Hash), chain.prevHash)
+
+	block2 := emptyResilienceBlock(2, 0x02, 2000)
+	require.NoError(t, chain.Handle(t.Context(), block2))
+	require.Equal(t, common.BytesToHash(block2.Hash), chain.prevHash)
+
+	latest, err := chain.LatestBlock(t.Context(), false)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	require.Equal(t, uint64(2), latest.BlockNumber)
+	require.Equal(t, block1.Hash, latest.ParentHash)
+}
+
+// TestHandle_PrevHashNotAdvancedOnInsertFailure is the regression for #304
+// without the trie (production withTrie=false path).
+func TestHandle_PrevHashNotAdvancedOnInsertFailure(t *testing.T) {
+	testPrevHashNotAdvancedOnInsertFailure(t, false)
+}
+
+// TestHandle_PrevHashNotAdvancedOnInsertFailure_WithTrie covers the same tip
+// invariant when the MPT is enabled. Trie commit may still run before SQL
+// (intentional; replay is idempotent). Only the published prevHash tip is gated
+// on InsertBlock success.
+func TestHandle_PrevHashNotAdvancedOnInsertFailure_WithTrie(t *testing.T) {
+	testPrevHashNotAdvancedOnInsertFailure(t, true)
+}
+
+func emptyResilienceBlock(number uint64, hashPrefix byte, ts int64) blocks.Block {
+	return blocks.Block{
+		Number:     number,
+		Hash:       resilienceHash(hashPrefix),
+		ParentHash: resilienceHash(0x00),
+		Timestamp:  ts,
+	}
+}
+
+func testPrevHashNotAdvancedOnInsertFailure(t *testing.T, withTrie bool) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "gateway.db")
+	triePath := ""
+	if withTrie {
+		triePath = filepath.Join(t.TempDir(), "trie")
+	}
+
+	chain, err := NewChain(dbPath, triePath, withTrie)
+	require.NoError(t, err)
+	// Close may return an error after we deliberately close the DB below.
+	t.Cleanup(func() { _ = chain.Close() })
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	ethTx := createTestEthTx(t, key, to, big.NewInt(1))
+	txBytes, err := ethTx.MarshalBinary()
+	require.NoError(t, err)
+
+	block1 := blocks.Block{
+		Number:     1,
+		Hash:       resilienceHash(0x01),
+		ParentHash: resilienceHash(0x00),
+		Timestamp:  1000,
+		Transactions: []blocks.Transaction{{
+			ID:        "fabric-tx-1",
+			Number:    0,
+			Valid:     true,
+			InputArgs: [][]byte{{byte(fc.ProposalTypeEVMTx)}, txBytes},
+			NsRWS: []blocks.NsReadWriteSet{{
+				Namespace: "evmcc",
+				RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+					resilienceBalanceWrite(from, 99),
+					resilienceNonceWrite(from, 1),
+					resilienceBalanceWrite(to, 1),
+				}},
+			}},
+		}},
+	}
+	require.NoError(t, chain.Handle(t.Context(), block1))
+	prevHashAfterBlock1 := chain.prevHash
+	require.Equal(t, common.BytesToHash(block1.Hash), prevHashAfterBlock1)
+
+	// Force InsertBlock to fail after any trie work by closing the SQL handle.
+	require.NoError(t, chain.db.Close())
+
+	block2 := blocks.Block{
+		Number:     2,
+		Hash:       resilienceHash(0x02),
+		ParentHash: resilienceHash(0x01),
+		Timestamp:  2000,
+		Transactions: []blocks.Transaction{{
+			ID:        "fabric-tx-2",
+			Number:    0,
+			Valid:     true,
+			InputArgs: [][]byte{{byte(fc.ProposalTypeEVMTx)}, txBytes},
+			NsRWS: []blocks.NsReadWriteSet{{
+				Namespace: "evmcc",
+				RWS: blocks.ReadWriteSet{Writes: []blocks.KVWrite{
+					resilienceBalanceWrite(from, 98),
+					resilienceNonceWrite(from, 2),
+					resilienceBalanceWrite(to, 2),
+				}},
+			}},
+		}},
+	}
+	err = chain.Handle(t.Context(), block2)
+	require.Error(t, err, "Handle must fail when InsertBlock cannot run")
+
+	require.Equal(t, prevHashAfterBlock1, chain.prevHash,
+		"prevHash must not advance when InsertBlock fails")
+}


### PR DESCRIPTION
Fixes #304

Chain.Handle used to set prevHash before InsertBlock finished. If SQL failed after that, the in memory tip already pointed at a block the store never held, so later blocks could pick a parent that was not on disk. Same class of issue as #148, with more detail on the withTrie false path production uses today.

Agreed direction from the issue: advance prevHash only after InsertBlock returns nil. Trie commit and flush stay before SQL so a crash cannot leave SQL ahead of the MPT. Replay on resubscribe is still fine because the trie path is idempotent. Retryable vs hard fail handling is left as a follow up.

## Change

gateway/core/chain.go moves the prevHash update to after a successful InsertBlock. ParentHash for the new block still comes from the current tip before the write.

## Tests

* go test ./gateway/core/
* go test ./gateway/... short
* go vet ./gateway/core/

New coverage in chain_resilience_test.go for the happy path, insert failure without the trie, and insert failure with the trie on.
