### PR TITLE
docs: correct the EIP-7610 create-collision explanation

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -221,7 +221,7 @@ Implementation note: clearing storage slots requires enumerating all keys for th
 (non-trivial) and may produce an impractically large RWSet for contracts with many storage entries.
 
 **`GetStorageRoot` is a stub**: it returns the zero hash. This is a state-introspection gap that
-affects storage-root queries and proofs (tracked in #85); it does **not** affect EVM execution or
+affects storage-root queries and proofs; it does **not** affect EVM execution or
 the EIP-7610 collision guard, which never reads it (see below).
 
 **EIP-7610 create-collision divergence (inherited from go-ethereum)**: per EIP-7610 a
@@ -232,7 +232,7 @@ collision guard checks nonce + code + that static set, never the storage root. T
 `eip7610_create_collision` fixtures use synthetic addresses that hold storage but are not in geth's
 list, so geth's guard — and therefore ours — does not treat them as collisions. This divergence is
 inherited from go-ethereum and affects any geth-based client; it is not a fabric-x-evm bug and is
-unrelated to the `GetStorageRoot` stub. Tracked as a known divergence in #276.
+unrelated to the `GetStorageRoot` stub.
 
 **How these surface in equivalence tests**: the conformance harness runs the EVM against our
 StateDB while mirroring every write to a reference go-ethereum StateDB, then compares the state
@@ -243,7 +243,7 @@ currently cause any fixture to diverge). This is deliberate and inherited from u
 regression.
 
 These known-divergent cases are quarantined in `testdata/eth_tests.skip`: the EIP-7610
-create-collision fixtures above (an inherited go-ethereum divergence, see #276). All other
+create-collision fixtures above (an inherited go-ethereum divergence). All other
 Osaka-forward state tests pass.
 
 **Native ETH balances not funded**: balances are implemented but unused. Accounts have zero ETH 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -220,21 +220,31 @@ when a call or test targets an older fork.
 Implementation note: clearing storage slots requires enumerating all keys for the address
 (non-trivial) and may produce an impractically large RWSet for contracts with many storage entries.
 
-**`GetStorageRoot` is a stub**: it returns the zero hash. geth uses an account's storage root for
-the EIP-7610 collision guard — a `CREATE`/`CREATE2` must fail if the target address already holds
-storage. With the stub that guard is effectively disabled: a contract can be deployed onto an
-address that has storage (but no code or nonce). Collisions detected via code or nonce still apply.
+**`GetStorageRoot` is a stub**: it returns the zero hash. This is a state-introspection gap that
+affects storage-root queries and proofs (tracked in #85); it does **not** affect EVM execution or
+the EIP-7610 collision guard, which never reads it (see below).
+
+**EIP-7610 create-collision divergence (inherited from go-ethereum)**: per EIP-7610 a
+`CREATE`/`CREATE2` onto an address that already holds storage (but no code or nonce) must fail. We
+run go-ethereum v1.17.3's EVM create path unchanged, and geth v1.17.3 implements EIP-7610 not as a
+general storage check but as a hardcoded allowlist of 28 historical mainnet addresses — the
+collision guard checks nonce + code + that static set, never the storage root. The execution-specs
+`eip7610_create_collision` fixtures use synthetic addresses that hold storage but are not in geth's
+list, so geth's guard — and therefore ours — does not treat them as collisions. This divergence is
+inherited from go-ethereum and affects any geth-based client; it is not a fabric-x-evm bug and is
+unrelated to the `GetStorageRoot` stub. Tracked as a known divergence in #276.
 
 **How these surface in equivalence tests**: the conformance harness runs the EVM against our
 StateDB while mirroring every write to a reference go-ethereum StateDB, then compares the state
-root against each fixture's expected root. Because the EVM reads account state (existence,
-`HasSelfDestructed`, storage root) from *our* StateDB, the two deviations above make a small, known
-set of vectors diverge on the final root — SELFDESTRUCT and CREATE/CREATE2-collision / empty-account
-cases. These divergences are deliberate consequences of the modern-only semantics above, not
-regressions.
+root against each fixture's expected root. The only fixtures that diverge on the final root are the
+EIP-7610 create-collision cases above — and that divergence comes from go-ethereum's create path,
+not from our StateDB (the always-on EIP-6780 SELFDESTRUCT semantics differ in behavior but do not
+currently cause any fixture to diverge). This is deliberate and inherited from upstream, not a
+regression.
 
 These known-divergent cases are quarantined in `testdata/eth_tests.skip`: the EIP-7610
-create-collision fixtures above. All other Osaka-forward state tests pass.
+create-collision fixtures above (an inherited go-ethereum divergence, see #276). All other
+Osaka-forward state tests pass.
 
 **Native ETH balances not funded**: balances are implemented but unused. Accounts have zero ETH 
 balance by default. Value transfers inside the EVM (`CALL` with value, `SELFDESTRUCT` beneficiary, 

--- a/testdata/eth_tests.skip
+++ b/testdata/eth_tests.skip
@@ -1,14 +1,14 @@
 # execution-specs state_tests that are skipped in ALL modes, quarantined here so the
-# conformance suite stays green in CI. Full failure evidence is in the PR description.
+# conformance suite stays green in CI.
 #
-# --- EIP-7610 create-collision divergence (Cancun+), inherited from go-ethereum (#276):
+# --- EIP-7610 create-collision divergence (Cancun+), inherited from go-ethereum:
 #     CREATE/CREATE2 onto an address that already holds storage should fail per EIP-7610,
 #     but go-ethereum v1.17.3 implements the check as a hardcoded 28-address mainnet
 #     allowlist (guard = nonce + code + that static set, never the storage root), not a
 #     general storage check. These fixtures use synthetic addresses that hold storage but
 #     are not in geth's list, so geth's guard — and therefore ours, since we run geth's EVM
 #     create path unchanged — does not treat them as collisions. Not a fabric-x-evm bug and
-#     unrelated to the GetStorageRoot stub (#85); affects any geth-based client.
+#     unrelated to the GetStorageRoot stub; affects any geth-based client.
 ../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json

--- a/testdata/eth_tests.skip
+++ b/testdata/eth_tests.skip
@@ -1,9 +1,14 @@
-# execution-specs state_tests that are skipped in ALL modes.
-# Each entry is a genuine fabric-x-evm bug (filed separately), quarantined here so the
+# execution-specs state_tests that are skipped in ALL modes, quarantined here so the
 # conformance suite stays green in CI. Full failure evidence is in the PR description.
 #
-# --- EIP-7610 create-collision divergence (Cancun+): CREATE/CREATE2 into an account that
-#     already has storage/code produces a wrong post-state root. Known StateDB gap (cf. #193).
+# --- EIP-7610 create-collision divergence (Cancun+), inherited from go-ethereum (#276):
+#     CREATE/CREATE2 onto an address that already holds storage should fail per EIP-7610,
+#     but go-ethereum v1.17.3 implements the check as a hardcoded 28-address mainnet
+#     allowlist (guard = nonce + code + that static set, never the storage root), not a
+#     general storage check. These fixtures use synthetic addresses that hold storage but
+#     are not in geth's list, so geth's guard — and therefore ours, since we run geth's EVM
+#     create path unchanged — does not treat them as collisions. Not a fabric-x-evm bug and
+#     unrelated to the GetStorageRoot stub (#85); affects any geth-based client.
 ../testdata/execution-specs-tests/fixtures/state_tests/for_cancun/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_osaka/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json
 ../testdata/execution-specs-tests/fixtures/state_tests/for_prague/paris/eip7610_create_collision/revert_in_create/collision_with_create2_revert_in_initcode.json


### PR DESCRIPTION
### Addressed issue

Closes #276. 

### Summary

The skip-list comment and `COMPATIBILITY.md` attributed the EIP-7610
create-collision divergence to our `GetStorageRoot` stub, implying a fabric-x-evm
bug blocked by #85. That's inaccurate. We run go-ethereum v1.17.3's EVM create
path unchanged, and geth implements EIP-7610 as a hardcoded 28-address mainnet
allowlist (the collision guard checks nonce + code + that static set, never the
storage root) — not a general storage check. The quarantined fixtures use
synthetic addresses that hold storage but aren't in geth's list, so the
divergence is inherited from go-ethereum and affects any geth-based client — not
our bug, and unrelated to the `GetStorageRoot` stub (#85).

- Rewrite the `testdata/eth_tests.skip` comment with the correct explanation.
- Correct the EIP-7610 / `GetStorageRoot` section in `COMPATIBILITY.md`.

Documentation/comment only — no production code, and the skipped fixture paths
are unchanged (verified byte-identical), so no test behavior changes.

### Validation done

- The 12 skipped fixture paths are byte-identical to `main` (only comments/docs changed).
- `make checks` passes.
- `make eth-tests` is green (0 failures); the EIP-7610 fixtures remain skipped.
