### PR TITLE
ci: cache OZ Solidity artifacts between runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,6 +133,36 @@ jobs:
           path: testdata/openzeppelin-contracts/node_modules
           key: ${{ runner.os }}-oz-node-modules-${{ hashFiles('testdata/openzeppelin-contracts/package-lock.json') }}
 
+      # A cold checkout recompiles all 368 contracts inside the first Hardhat
+      # invocation — ~64s of the run. The submodule pin fixes the sources, the
+      # compiler version and its settings, so its SHA is the whole key.
+      #
+      # cache/ has to travel with artifacts/: it holds solidity-files-cache.json,
+      # which records a contentHash and solcConfig per file. That is what makes a
+      # stale restore self-correcting — Hardhat recompiles whatever no longer
+      # matches rather than trusting the artifacts blindly.
+      #
+      # build-info/ is excluded: 309MB of the 329MB, and neither compilation nor
+      # the test run needs it.
+      - name: Get OZ submodule revision
+        id: oz-rev
+        run: echo "sha=$(git -C testdata/openzeppelin-contracts rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache OZ compilation artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            testdata/openzeppelin-contracts/artifacts
+            !testdata/openzeppelin-contracts/artifacts/build-info
+            testdata/openzeppelin-contracts/cache
+          key: ${{ runner.os }}-oz-artifacts-${{ steps.oz-rev.outputs.sha }}
+          # On a submodule bump the exact key misses, but restoring the previous
+          # revision's artifacts still helps: Hardhat recompiles only the files
+          # whose contentHash changed. Safe for the same reason — the cache
+          # validates itself rather than being trusted.
+          restore-keys: |
+            ${{ runner.os }}-oz-artifacts-
+
       - name: Hardhat OZ compatibility suite (full)
         run: make hardhat-tests-full
 


### PR DESCRIPTION
A cold checkout recompiles all 368 contracts inside the first Hardhat invocation. In the last green run that was ~64s of a 640s job: test/access took 86s against 11s locally (7.8x) where every other directory sat at the ~2.4x the runner is generally slower — the gap is the compile.

Keyed on the OpenZeppelin submodule SHA, which pins the sources, the compiler version and its settings, so nothing else feeds the output. restore-keys lets a submodule bump reuse the previous revision's artifacts and recompile only what changed.

cache/ travels with artifacts/ deliberately: it holds solidity-files-cache.json, which records a contentHash and solcConfig per file. That makes a stale restore self-correcting rather than dangerous — Hardhat recompiles whatever no longer matches instead of trusting the artifacts. Caching artifacts without it would be the version of this change that fails silently.

build-info/ is excluded: 309MB of the 329MB, and needed by neither compilation ("Nothing to compile" with it absent) nor the test run (verified: MerkleTree 141 passing without it). That keeps the cache around 21MB.