### PR TITLE
fix revert funding

### DIFF
--- a/endorser/storage/revertible_lightkvs.go
+++ b/endorser/storage/revertible_lightkvs.go
@@ -78,23 +78,28 @@ func (kvs *RevertibleLightKVS) NewSnapshot(blockNumber *uint64) (execution.ReadS
 	}
 
 	// Exact match on a preserved snapshot, else the nearest older one (state is
-	// unchanged across empty blocks that never called Update).
-	var best *Snapshot
-	for i := 0; i < count; i++ {
+	// unchanged across empty blocks that never called Update). Keep the LAST exact
+	// match in a block.
+	var exact, best *Snapshot
+	for i := range count {
 		snap := kvs.History[i].Load()
 		if snap == nil {
 			continue
 		}
 		if snap.BlockNumber == bn {
-			revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() exact history hit: requested=%d", bn)
-			return &Reader{
-				Snapshot: snap,
-				Kvs:      kvs.LightKVS,
-			}, nil
+			exact = snap
+			continue
 		}
 		if snap.BlockNumber < bn && (best == nil || snap.BlockNumber > best.BlockNumber) {
 			best = snap
 		}
+	}
+	if exact != nil {
+		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() exact history hit: requested=%d", bn)
+		return &Reader{
+			Snapshot: exact,
+			Kvs:      kvs.LightKVS,
+		}, nil
 	}
 	if best != nil {
 		revertLogger.Debugf("RevertibleLightKVS.NewSnapshot() nearest history hit: requested=%d returned=%d",
@@ -208,7 +213,9 @@ func (kvs *RevertibleLightKVS) RevertToBlock(blockNumber uint64) error {
 	}
 	revertLogger.Debugf("RevertibleLightKVS.RevertToBlock() searching history snapshots: %v", availableBlocks)
 
-	// Search through history snapshots for the requested block number
+	// Search history for the requested block number, keeping the LAST match
+	// rather than the first. Startup funding writes its state at the current
+	// height without advancing it, so block 0 exists twice: empty, then funded.
 	var targetSnapshot *Snapshot
 	targetIndex := -1
 	for i := range kvs.History {
@@ -216,7 +223,6 @@ func (kvs *RevertibleLightKVS) RevertToBlock(blockNumber uint64) error {
 		if snapshot != nil && snapshot.BlockNumber == blockNumber {
 			targetSnapshot = snapshot
 			targetIndex = i
-			break
 		}
 	}
 

--- a/endorser/storage/revertible_lightkvs.go
+++ b/endorser/storage/revertible_lightkvs.go
@@ -189,7 +189,10 @@ func (kvs *RevertibleLightKVS) Update(updates []KeyValueVersion) error {
 // will match the actual versions in the peer's ledger, avoiding MVCC conflicts.
 //
 // If the requested block number matches the current snapshot, it's a no-op and returns success.
-// Returns an error if the requested block number is not found in history or current.
+// Like NewSnapshot, falls back to the nearest older snapshot when there's no exact
+// match: an empty block never calls Update, so it never gets a history entry, but
+// state is unchanged since the last one that did. Returns an error only when no
+// snapshot at or before the requested block number exists in history or current.
 func (kvs *RevertibleLightKVS) RevertToBlock(blockNumber uint64) error {
 	revertLogger.Debugf("RevertibleLightKVS.RevertToBlock() called with blockNumber=%d", blockNumber)
 
@@ -216,23 +219,38 @@ func (kvs *RevertibleLightKVS) RevertToBlock(blockNumber uint64) error {
 	// Search history for the requested block number, keeping the LAST match
 	// rather than the first. Startup funding writes its state at the current
 	// height without advancing it, so block 0 exists twice: empty, then funded.
-	var targetSnapshot *Snapshot
-	targetIndex := -1
+	// Also track the nearest older snapshot as a fallback (see NewSnapshot):
+	// an empty block leaves no exact entry to find.
+	var targetSnapshot, bestSnapshot *Snapshot
+	targetIndex, bestIndex := -1, -1
 	for i := range kvs.History {
 		snapshot := kvs.History[i].Load()
-		if snapshot != nil && snapshot.BlockNumber == blockNumber {
+		if snapshot == nil {
+			continue
+		}
+		if snapshot.BlockNumber == blockNumber {
 			targetSnapshot = snapshot
 			targetIndex = i
+			continue
+		}
+		if snapshot.BlockNumber < blockNumber && (bestSnapshot == nil || snapshot.BlockNumber > bestSnapshot.BlockNumber) {
+			bestSnapshot = snapshot
+			bestIndex = i
 		}
 	}
 
+	// Only fall back for a target in the past.
+	if targetSnapshot == nil && blockNumber < currentSnapshot.BlockNumber {
+		targetSnapshot, targetIndex = bestSnapshot, bestIndex
+	}
+
 	if targetSnapshot == nil {
-		// No matching snapshot found
+		// No matching or older snapshot found
 		revertLogger.Debugf("RevertibleLightKVS.RevertToBlock() snapshot not found for block %d", blockNumber)
 		return fmt.Errorf("cannot revert: snapshot not found for block number %d", blockNumber)
 	}
 
-	revertLogger.Debugf("RevertibleLightKVS.RevertToBlock() found target snapshot at block %d, performing merge", blockNumber)
+	revertLogger.Debugf("RevertibleLightKVS.RevertToBlock() found target snapshot at block %d (requested %d), performing merge", targetSnapshot.BlockNumber, blockNumber)
 
 	// Create a new merged snapshot
 	// Start with a clone of the target snapshot's data

--- a/endorser/storage/revertible_lightkvs_test.go
+++ b/endorser/storage/revertible_lightkvs_test.go
@@ -116,6 +116,53 @@ func TestRevertibleLightKVS_RevertToBlock_NotFound(t *testing.T) {
 	}
 }
 
+// TestRevertibleLightKVS_RevertToBlock_SkipsEmptyBlocks is the revert-path twin of
+// TestRevertibleLightKVS_NewSnapshot_SkipsEmptyBlocks: an empty block never calls
+// Update, so it never gets a history entry, but evm_revert to that exact block
+// number must still succeed by falling back to the nearest older snapshot.
+func TestRevertibleLightKVS_RevertToBlock_SkipsEmptyBlocks(t *testing.T) {
+	kvs := NewRevertibleLightKVS(NewLightKVS(8))
+
+	// Blocks 1 and 5 wrote; 2-4 were empty (no Update, so no history entry).
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:key1", Value: []byte("v1"), BlockNum: 1, TxNum: 0, TxID: "tx1"},
+	}); err != nil {
+		t.Fatalf("Update block 1: %v", err)
+	}
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:key1", Value: []byte("v5"), BlockNum: 5, TxNum: 0, TxID: "tx5"},
+	}); err != nil {
+		t.Fatalf("Update block 5: %v", err)
+	}
+
+	// Revert to block 3: no exact entry, but state hasn't changed since block 1.
+	if err := kvs.RevertToBlock(3); err != nil {
+		t.Fatalf("RevertToBlock(3) should fall back to the nearest older snapshot, got error: %v", err)
+	}
+
+	blockNum, err := kvs.BlockNumber(t.Context())
+	if err != nil {
+		t.Fatalf("BlockNumber failed: %v", err)
+	}
+	if blockNum != 3 {
+		t.Errorf("expected reported block number 3 after revert, got %d", blockNum)
+	}
+
+	reader, err := kvs.NewSnapshot(nil)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
+	defer reader.Close()
+
+	rec, err := reader.Get("ns1", "key1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "v1" {
+		t.Errorf("expected key1='v1' after revert to empty block 3, got %+v", rec)
+	}
+}
+
 // TestRevertibleLightKVS_RevertThenContinue verifies that after a revert the store
 // can keep accepting new blocks — the core interactive-testnode usage pattern.
 func TestRevertibleLightKVS_RevertThenContinue(t *testing.T) {

--- a/endorser/storage/revertible_lightkvs_test.go
+++ b/endorser/storage/revertible_lightkvs_test.go
@@ -262,3 +262,89 @@ func TestRevertibleLightKVS_HistoryExhaustedPanics(t *testing.T) {
 		{Key: "ns1:key1", Value: []byte("v2"), BlockNum: 2, TxNum: 0, TxID: "tx2"},
 	})
 }
+
+// TestRevertibleLightKVS_RevertToBlock_DuplicateBlockNumber pins which snapshot
+// wins when several carry the same block number.
+//
+// The testnode reaches this on every startup: FundTestAccounts seeds balances
+// through the normal Handle path but numbers the write with the *current*
+// height rather than advancing it, so block 0 ends up in history twice — empty,
+// then funded. History is oldest-first, so resolving a revert by first match
+// returns the state from before the funding and every test account reads back
+// at zero.
+func TestRevertibleLightKVS_RevertToBlock_DuplicateBlockNumber(t *testing.T) {
+	kvs := NewRevertibleLightKVS(NewLightKVS(4))
+
+	// Two writes both labelled block 0, the way startup funding lands on top of
+	// the initial state.
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:balance", Value: []byte("empty"), BlockNum: 0, TxNum: 0, TxID: "genesis"},
+	}); err != nil {
+		t.Fatalf("Update genesis failed: %v", err)
+	}
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:balance", Value: []byte("funded"), BlockNum: 0, TxNum: 0, TxID: "funding"},
+	}); err != nil {
+		t.Fatalf("Update funding failed: %v", err)
+	}
+
+	// Then a real block, so the revert has to come out of history rather than
+	// being a no-op against current.
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:balance", Value: []byte("spent"), BlockNum: 1, TxNum: 0, TxID: "tx1"},
+	}); err != nil {
+		t.Fatalf("Update block 1 failed: %v", err)
+	}
+
+	if err := kvs.RevertToBlock(0); err != nil {
+		t.Fatalf("RevertToBlock(0) failed: %v", err)
+	}
+
+	reader, err := kvs.NewSnapshot(nil)
+	if err != nil {
+		t.Fatalf("NewSnapshot failed: %v", err)
+	}
+	defer reader.Close()
+
+	rec, err := reader.Get("ns1", "balance")
+	if err != nil {
+		t.Fatalf("Get balance failed: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "funded" {
+		t.Errorf("revert to block 0 should restore the last state written at block 0 (%q), got %+v", "funded", rec)
+	}
+}
+
+// TestRevertibleLightKVS_NewSnapshot_DuplicateBlockNumber is the read-path twin
+// of the above: an as-of-block-0 read must see the same state a revert to block
+// 0 restores, not the earlier snapshot that shares the number.
+func TestRevertibleLightKVS_NewSnapshot_DuplicateBlockNumber(t *testing.T) {
+	kvs := NewRevertibleLightKVS(NewLightKVS(4))
+
+	for _, w := range []struct{ value, txID string }{{"empty", "genesis"}, {"funded", "funding"}} {
+		if err := kvs.Update([]KeyValueVersion{
+			{Key: "ns1:balance", Value: []byte(w.value), BlockNum: 0, TxNum: 0, TxID: w.txID},
+		}); err != nil {
+			t.Fatalf("Update %s failed: %v", w.txID, err)
+		}
+	}
+	if err := kvs.Update([]KeyValueVersion{
+		{Key: "ns1:balance", Value: []byte("spent"), BlockNum: 1, TxNum: 0, TxID: "tx1"},
+	}); err != nil {
+		t.Fatalf("Update block 1 failed: %v", err)
+	}
+
+	reader, err := kvs.NewSnapshot(BlockAt(0))
+	if err != nil {
+		t.Fatalf("NewSnapshot(BlockAt(0)) failed: %v", err)
+	}
+	defer reader.Close()
+
+	rec, err := reader.Get("ns1", "balance")
+	if err != nil {
+		t.Fatalf("Get balance failed: %v", err)
+	}
+	if rec == nil || string(rec.Value) != "funded" {
+		t.Errorf("reading at block 0 should see the last state written at block 0 (%q), got %+v", "funded", rec)
+	}
+}


### PR DESCRIPTION
the testnode writes balances to a block 0. The hardhat tests revert to block 0 several times. The revertible LightKVS reverted to the genesis block, pre funding. That is now changed to the last written block 0.

This change is necessary to enable parallelization of the hardhat tests.