### PR TITLE
feat: serve JSON-RPC over WebSocket on the HTTP listener

### DIFF
--- a/gateway/api/server.go
+++ b/gateway/api/server.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -41,12 +42,42 @@ func NewServer(b Backend) (*rpc.Server, error) {
 }
 
 // NewHTTPServer creates and configures an HTTP server without starting it.
+// The same listener serves JSON-RPC over HTTP and WebSocket: Upgrade requests
+// go to srv.WebsocketHandler (nil origins = geth default handshake checks);
+// everything else uses the HTTP stack. Logging wraps the HTTP path only so WS
+// upgrades can Hijack the connection.
 func NewHTTPServer(srv *rpc.Server, addr string) *http.Server {
-	handler := node.NewHTTPHandlerStack(srv, []string{"*"}, []string{"*"}, nil)
+	// nil cors disables the CORS middleware; nil vhosts still allows IP Hosts
+	// (127.0.0.1 etc.) via geth's virtualHostHandler.
+	httpHandler := node.NewHTTPHandlerStack(srv, nil, nil, nil)
 	return &http.Server{
-		Addr:    addr,
-		Handler: &loggingHandler{next: handler},
+		Addr: addr,
+		Handler: &rpcTransportHandler{
+			ws:   srv.WebsocketHandler(nil),
+			http: &loggingHandler{next: httpHandler},
+		},
 	}
+}
+
+// rpcTransportHandler dispatches WebSocket upgrades before HTTP, matching
+// go-ethereum's httpServer.ServeHTTP check order (node/rpcstack.go).
+type rpcTransportHandler struct {
+	ws   http.Handler
+	http http.Handler
+}
+
+func (h *rpcTransportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isWebsocket(r) {
+		h.ws.ServeHTTP(w, r)
+		return
+	}
+	h.http.ServeHTTP(w, r)
+}
+
+// isWebsocket mirrors go-ethereum's unexported helper in node/rpcstack.go.
+func isWebsocket(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 
 type loggingHandler struct {

--- a/gateway/api/server_ws_test.go
+++ b/gateway/api/server_ws_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package api
+
+import (
+	"context"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/gorilla/websocket"
+)
+
+func newTestHTTPServer(t *testing.T) string {
+	t.Helper()
+	rpcSrv, err := NewServer(&stubBackend{chainID: big.NewInt(4011)})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	httpSrv := NewHTTPServer(rpcSrv, ln.Addr().String())
+	go func() { _ = httpSrv.Serve(ln) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(ctx)
+	})
+	return ln.Addr().String()
+}
+
+func TestWebSocket_ChainID(t *testing.T) {
+	addr := newTestHTTPServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := rpc.DialContext(ctx, "ws://"+addr)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer client.Close()
+
+	var chainID hexutil.Big
+	if err := client.CallContext(ctx, &chainID, "eth_chainId"); err != nil {
+		t.Fatalf("eth_chainId over ws: %v", err)
+	}
+	if (*big.Int)(&chainID).Cmp(big.NewInt(4011)) != 0 {
+		t.Fatalf("chainId = %s, want 4011", (*big.Int)(&chainID).String())
+	}
+}
+
+func TestHTTPAndWebSocket_Concurrent(t *testing.T) {
+	addr := newTestHTTPServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	httpClient, err := rpc.DialContext(ctx, "http://"+addr)
+	if err != nil {
+		t.Fatalf("http dial: %v", err)
+	}
+	defer httpClient.Close()
+
+	wsClient, err := rpc.DialContext(ctx, "ws://"+addr)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer wsClient.Close()
+
+	var httpID, wsID hexutil.Big
+	if err := httpClient.CallContext(ctx, &httpID, "eth_chainId"); err != nil {
+		t.Fatalf("http eth_chainId: %v", err)
+	}
+	if err := wsClient.CallContext(ctx, &wsID, "eth_chainId"); err != nil {
+		t.Fatalf("ws eth_chainId: %v", err)
+	}
+	want := big.NewInt(4011)
+	if (*big.Int)(&httpID).Cmp(want) != 0 || (*big.Int)(&wsID).Cmp(want) != 0 {
+		t.Fatalf("http=%s ws=%s, want both 4011", (*big.Int)(&httpID), (*big.Int)(&wsID))
+	}
+}
+
+func TestHTTP_WithoutUpgradeStillWorks(t *testing.T) {
+	addr := newTestHTTPServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := rpc.DialContext(ctx, "http://"+addr)
+	if err != nil {
+		t.Fatalf("http dial: %v", err)
+	}
+	defer client.Close()
+
+	var listening bool
+	if err := client.CallContext(ctx, &listening, "net_listening"); err != nil {
+		t.Fatalf("net_listening: %v", err)
+	}
+	if !listening {
+		t.Fatal("net_listening = false")
+	}
+}
+
+func TestWebSocket_OriginChecks(t *testing.T) {
+	addr := newTestHTTPServer(t)
+	url := "ws://" + addr
+
+	t.Run("evil origin rejected", func(t *testing.T) {
+		hdr := http.Header{}
+		hdr.Set("Origin", "https://evil.example")
+		_, resp, err := websocket.DefaultDialer.Dial(url, hdr)
+		if err == nil {
+			t.Fatal("expected dial failure for evil Origin")
+		}
+		if resp == nil {
+			t.Fatalf("expected HTTP response on rejected handshake, err=%v", err)
+		}
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("no origin accepted", func(t *testing.T) {
+		conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+		if err != nil {
+			status := 0
+			if resp != nil {
+				status = resp.StatusCode
+			}
+			t.Fatalf("dial without Origin: %v (status=%d)", err, status)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("localhost origin accepted", func(t *testing.T) {
+		hdr := http.Header{}
+		hdr.Set("Origin", "http://localhost")
+		conn, resp, err := websocket.DefaultDialer.Dial(url, hdr)
+		if err != nil {
+			status := 0
+			if resp != nil {
+				status = resp.StatusCode
+			}
+			t.Fatalf("dial with localhost Origin: %v (status=%d)", err, status)
+		}
+		_ = conn.Close()
+	})
+}
+
+func TestIsWebsocket(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if isWebsocket(req) {
+		t.Fatal("plain GET should not be websocket")
+	}
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	if !isWebsocket(req) {
+		t.Fatal("expected websocket upgrade")
+	}
+}


### PR DESCRIPTION
## Description

Closes #330

Adds WebSocket JSON-RPC on the same listener as HTTP. Upgrade requests go to `rpc.Server.WebsocketHandler` with nil origins (geth default handshake checks, not `*`). Everything else keeps the existing HTTP stack. Logging wraps the HTTP path only so WS can Hijack. Also drops wildcard CORS and vhosts on HTTP as discussed.

Transport only. No EthAPI or Backend changes. Filters and subscriptions stay for later issues under #329.

## Type of Change
- [x] New feature

## Related Issue
#330

## Testing
- [x] WS dial via `rpc.DialContext` and `eth_chainId`
- [x] HTTP and WS concurrent on one server
- [x] HTTP without Upgrade still works
- [x] Origin: evil rejected, no Origin ok, localhost ok
- [x] `go test ./... -short` locally

## Checklist
- [x] Code builds
- [x] Unit tests pass
- [x] No COMPATIBILITY.md change (subscribe/filters not in yet)