### PR TITLE
fix: off-by-one in delivery to notifier switch

### DIFF
--- a/common/notification.go
+++ b/common/notification.go
@@ -9,6 +9,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -86,8 +87,17 @@ func (d *AllTxBatchDispatcher) HandleBatch(ctx context.Context, batch notificati
 
 	notifLogger.Debugf("[NOTIFY] block=%d dispatching=%d/%d txs", batch.BlockNumber, len(txs), len(batch.Events))
 
+	// TODO: StreamAllTransactions carries no block header, so there's no real hash to
+	// use here. Replace with the real hash once
+	// https://github.com/hyperledger/fabric-x-committer/issues/773 is implemented.
+	var parentNum uint64
+	if batch.BlockNumber > 0 {
+		parentNum = batch.BlockNumber - 1
+	}
 	b := blocks.Block{
 		Number:       batch.BlockNumber,
+		Hash:         blockNumberHash(batch.BlockNumber),
+		ParentHash:   blockNumberHash(parentNum),
 		Transactions: txs,
 	}
 
@@ -98,6 +108,13 @@ func (d *AllTxBatchDispatcher) HandleBatch(ctx context.Context, batch notificati
 	}
 
 	return nil
+}
+
+// blockNumberHash encodes n as a 32-byte big-endian hash-shaped placeholder.
+func blockNumberHash(n uint64) []byte {
+	h := make([]byte, 32)
+	binary.BigEndian.PutUint64(h[24:], n)
+	return h
 }
 
 // namespacesToNsRWS converts applicationpb.TxNamespace slices (as delivered by

--- a/common/notification_test.go
+++ b/common/notification_test.go
@@ -145,6 +145,8 @@ func TestHandleBatch_DispatchesOnlyEVMTxsFromMixedBatch(t *testing.T) {
 	require.Len(t, h.seen, 1, "one dispatched Block")
 	b := h.seen[0]
 	assert.Equal(t, uint64(42), b.Number)
+	assert.Equal(t, blockNumberHash(42), b.Hash)
+	assert.Equal(t, blockNumberHash(41), b.ParentHash)
 	require.Len(t, b.Transactions, 2, "only the two EVM txs make it through")
 
 	assert.Equal(t, "evm-1", b.Transactions[0].ID)
@@ -158,6 +160,25 @@ func TestHandleBatch_DispatchesOnlyEVMTxsFromMixedBatch(t *testing.T) {
 	assert.Equal(t, int64(2), b.Transactions[1].Number)
 	assert.False(t, b.Transactions[1].Valid, "non-COMMITTED tx has Valid=false")
 	assert.Equal(t, int(committerpb.Status_ABORTED_MVCC_CONFLICT), b.Transactions[1].Status)
+}
+
+func TestHandleBatch_BlockZeroParentHashDoesNotUnderflow(t *testing.T) {
+	// Block 0 realistically never reaches here (genesis has no EVM txs, so the
+	// len(txs)==0 guard returns early) but the parentNum computation must not
+	// wrap a uint64 to MaxUint64 if it ever does.
+	h := &stubHandler{}
+	d := NewAllTxBatchDispatcher(h)
+	err := d.HandleBatch(context.Background(), notification.AllTxBatch{
+		BlockNumber: 0,
+		Events: []notification.CommittedTxEvent{
+			{TxID: "evm-1", Status: committerpb.Status_COMMITTED,
+				Metadata: makeMetadata(t, ProposalTypeEVMTx, []byte{0xaa})},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, h.seen, 1)
+	assert.Equal(t, blockNumberHash(0), h.seen[0].Hash)
+	assert.Equal(t, blockNumberHash(0), h.seen[0].ParentHash, "parent of block 0 must not underflow")
 }
 
 func TestHandleBatch_MultipleHandlersAllReceive(t *testing.T) {

--- a/gateway/app/hybridx/hybrid.go
+++ b/gateway/app/hybridx/hybrid.go
@@ -14,8 +14,9 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 // any gap between the two phases:
 //
 //  1. The gate receives a batch for block B and updates nNot = B.
-//  2. If nDel >= nNot it atomically flips switched and forwards the batch.
-//  3. If nDel < nNot it discards the batch content (delivery is still behind).
+//  2. If nDel+1 >= nNot (delivery covers everything before B) it atomically
+//     flips switched and forwards the batch.
+//  3. Otherwise it discards the batch content (delivery is still behind).
 //
 // Because the decision and the first forward happen in the same HandleBatch call
 // there is no window in which a batch could be lost.
@@ -27,6 +28,7 @@ package hybridx
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -57,6 +59,15 @@ type HybridSynchronizer struct {
 	delivery  deliverySyncer
 	notifPeer notification.AllTxPeer
 	notifReq  *notification.StreamAllRequest
+
+	// dispatchMu serializes dispatch calls from the delivery and notification
+	// paths (both can be live during the ~100ms teardown window after a switch)
+	// and guards lastDispatched, the highest block number fully handled so far
+	// (-1 means none yet). A block is recorded here only after every handler
+	// succeeds, so a failed attempt from either path can still be retried
+	// instead of being silently skipped as "already dispatched".
+	dispatchMu     sync.Mutex
+	lastDispatched int64
 }
 
 // New constructs a HybridSynchronizer.
@@ -74,6 +85,7 @@ func New(
 		logger:    logger,
 		handlers:  append([]blocks.BlockHandler(nil), handlers...),
 	}
+	h.lastDispatched = -1
 
 	delivery, err := nfabx.NewSynchronizer(db, channel, conf, signer, logger, &deliveryShim{h: h})
 	if err != nil {
@@ -105,22 +117,34 @@ func newWithDeps(
 	handlers ...blocks.BlockHandler,
 ) *HybridSynchronizer {
 	return &HybridSynchronizer{
-		logger:    logger,
-		handlers:  append([]blocks.BlockHandler(nil), handlers...),
-		delivery:  delivery,
-		notifPeer: notifPeer,
-		notifReq:  notifReq,
+		logger:         logger,
+		handlers:       append([]blocks.BlockHandler(nil), handlers...),
+		delivery:       delivery,
+		notifPeer:      notifPeer,
+		notifReq:       notifReq,
+		lastDispatched: -1,
 	}
 }
 
 // dispatch calls Handle on every handler in the chain.
-// Called by both the deliveryShim and the notifGate.
+// Called by both the deliveryShim and the notifGate — concurrently, near a
+// switch, from separate goroutines — so dispatchMu serializes attempts and a
+// block is recorded as dispatched only once every handler has returned nil.
 func (h *HybridSynchronizer) dispatch(ctx context.Context, b blocks.Block) error {
+	h.dispatchMu.Lock()
+	defer h.dispatchMu.Unlock()
+
+	if int64(b.Number) <= h.lastDispatched {
+		h.logger.Debugf("hybridx: skipping already-dispatched block %d", b.Number)
+		return nil
+	}
+
 	for _, bh := range h.handlers {
 		if err := bh.Handle(ctx, b); err != nil {
 			return err
 		}
 	}
+	h.lastDispatched = int64(b.Number)
 	return nil
 }
 
@@ -255,8 +279,8 @@ func (s *deliveryShim) Handle(ctx context.Context, b blocks.Block) error {
 //
 // For each incoming batch it:
 //  1. If switched: converts the batch to a blocks.Block and dispatches it.
-//  2. If not switched but nDel >= batch.BlockNumber: flips switched and dispatches
-//     — this is the gap-free handoff point.
+//  2. If not switched but nDel+1 >= batch.BlockNumber: flips switched and
+//     dispatches — this is the gap-free handoff point.
 //  3. Otherwise: discards the batch (delivery is still behind).
 type notifGate struct {
 	nDel       *atomic.Uint64
@@ -278,8 +302,9 @@ func (g *notifGate) HandleBatch(ctx context.Context, batch notification.AllTxBat
 		return g.dispatchBatch(ctx, batch)
 	}
 
-	// Check whether delivery has caught up with this batch's block number.
-	if g.nDel.Load() >= batch.BlockNumber {
+	// Delivery must cover everything strictly before this batch; this batch itself
+	// is about to be dispatched via notification, so nDel need only reach batch-1.
+	if g.nDel.Load()+1 >= batch.BlockNumber {
 		g.switched.Store(1)
 		g.logger.Infof("hybridx: switching to notification at block %d", batch.BlockNumber)
 		return g.dispatchBatch(ctx, batch)

--- a/gateway/app/hybridx/hybrid_test.go
+++ b/gateway/app/hybridx/hybrid_test.go
@@ -168,8 +168,7 @@ func TestReady_BeforeAndAfterSwitch(t *testing.T) {
 		recorder := &recordingHandler{}
 		h := newHybrid(t, delivery, peer, recorder)
 
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx := t.Context()
 		go func() { _ = h.Start(ctx) }()
 
 		synctest.Wait()
@@ -205,8 +204,7 @@ func TestGate_DiscardsBatchWhileDeliveryBehind(t *testing.T) {
 		recorder := &recordingHandler{}
 		h := newHybrid(t, delivery, peer, recorder)
 
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx := t.Context()
 		go func() { _ = h.Start(ctx) }()
 
 		synctest.Wait()
@@ -233,8 +231,7 @@ func TestGate_SwitchesAndForwardsWhenCaughtUp(t *testing.T) {
 		recorder := &recordingHandler{}
 		h := newHybrid(t, delivery, peer, recorder)
 
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+		ctx := t.Context()
 		go func() { _ = h.Start(ctx) }()
 
 		synctest.Wait()
@@ -262,6 +259,153 @@ func TestGate_SwitchesAndForwardsWhenCaughtUp(t *testing.T) {
 			t.Fatal("delivery was not cancelled after switch")
 		}
 	})
+}
+
+// TestGate_SwitchesOnFreshBlockRace reproduces the continuous-traffic race: a
+// notification for block N arrives while delivery has only just reached N-1, not
+// yet N — the state that occurs on essentially every block under live traffic.
+// Before the fix (nDel >= batch.BlockNumber) this case never switched.
+func TestGate_SwitchesOnFreshBlockRace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		delivery := newFakeDelivery()
+		peer := newFakeNotifPeer()
+		recorder := &recordingHandler{}
+		h := newHybrid(t, delivery, peer, recorder)
+
+		ctx := t.Context()
+		go func() { _ = h.Start(ctx) }()
+
+		synctest.Wait()
+		<-delivery.started
+
+		// Delivery has only reached block 8 (height=9); notif sends block 10.
+		// nDel(8)+1=9 < 10, so this must still be discarded.
+		delivery.setReady(9)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		peer.push(10, "tx-race-1")
+		synctest.Wait()
+
+		assert.Empty(t, recorder.received(), "batch still ahead of delivery must be discarded")
+		select {
+		case <-delivery.stopped:
+			t.Fatal("delivery must not be cancelled yet")
+		default:
+		}
+
+		// Delivery now reaches block 9 (height=10) — exactly one behind block 10,
+		// the state live traffic produces continuously. The old nDel >=
+		// batch.BlockNumber condition would discard this forever; the fixed
+		// nDel+1 >= batch.BlockNumber condition must switch here.
+		delivery.setReady(10)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		peer.push(10, "tx-race-2")
+		synctest.Wait()
+
+		select {
+		case <-delivery.stopped:
+			// switch happened
+		case <-time.After(time.Second):
+			t.Fatal("delivery was not cancelled — switch did not fire on the N-1 race case")
+		}
+	})
+}
+
+// TestDispatch_OverlappingBlocksDispatchedOnce verifies that once switching
+// happens (now common after the notifGate fix), blocks landing in the
+// delivery/notification overlap window during teardown are each handled exactly
+// once, never twice, thanks to the dispatchMu-guarded lastDispatched in dispatch.
+func TestDispatch_OverlappingBlocksDispatchedOnce(t *testing.T) {
+	delivery := newFakeDelivery()
+	peer := newFakeNotifPeer()
+	recorder := &recordingHandler{}
+	h := newHybrid(t, delivery, peer, recorder)
+
+	shim := &deliveryShim{h: h}
+	adapter := &hybridAdapter{h: h}
+	ctx := context.Background()
+
+	// Blocks 1-2 arrive via delivery only, before any switch.
+	require.NoError(t, shim.Handle(ctx, blocks.Block{Number: 1}))
+	require.NoError(t, shim.Handle(ctx, blocks.Block{Number: 2}))
+
+	// Blocks 3-5 land in the post-switch race window: delivery (still finishing
+	// up) and notification (now live) dispatch them concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for n := uint64(3); n <= 5; n++ {
+			_ = shim.Handle(ctx, blocks.Block{Number: n})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for n := uint64(3); n <= 5; n++ {
+			_ = adapter.Handle(ctx, blocks.Block{Number: n})
+		}
+	}()
+	wg.Wait()
+
+	// Blocks 6-7 arrive via notification only, once delivery has been cancelled.
+	require.NoError(t, adapter.Handle(ctx, blocks.Block{Number: 6}))
+	require.NoError(t, adapter.Handle(ctx, blocks.Block{Number: 7}))
+
+	counts := make(map[uint64]int)
+	for _, b := range recorder.received() {
+		counts[b.Number]++
+	}
+	for n := uint64(1); n <= 7; n++ {
+		assert.Equal(t, 1, counts[n], "block %d must be dispatched exactly once", n)
+	}
+}
+
+// failNTimesHandler fails the first n calls to Handle, then succeeds on every
+// call after that. Records the block number of every call, including failures.
+type failNTimesHandler struct {
+	mu        sync.Mutex
+	remaining int
+	calls     []uint64
+}
+
+func (f *failNTimesHandler) Handle(_ context.Context, b blocks.Block) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, b.Number)
+	if f.remaining > 0 {
+		f.remaining--
+		return errors.New("transient failure")
+	}
+	return nil
+}
+
+// TestDispatch_FailedAttemptCanBeRetried verifies that a block whose handler
+// chain fails is NOT marked as dispatched, so a caller that retries the exact
+// same block (as the real delivery synchronizer does after a handler error —
+// it re-subscribes from the last persisted height and redelivers the block)
+// reaches the downstream handlers instead of being silently skipped as
+// "already dispatched". This is the case that would cause a permanently
+// missed block if lastDispatched were updated before handlers ran.
+func TestDispatch_FailedAttemptCanBeRetried(t *testing.T) {
+	delivery := newFakeDelivery()
+	peer := newFakeNotifPeer()
+	failing := &failNTimesHandler{remaining: 1}
+	recorder := &recordingHandler{}
+	h := newHybrid(t, delivery, peer, failing, recorder)
+
+	shim := &deliveryShim{h: h}
+	ctx := context.Background()
+
+	err := shim.Handle(ctx, blocks.Block{Number: 3})
+	require.Error(t, err)
+	assert.Empty(t, recorder.received(), "recorder must not see a block whose handler chain failed")
+
+	// Retry of the same block number, exactly as the real synchronizer would do.
+	require.NoError(t, shim.Handle(ctx, blocks.Block{Number: 3}))
+	assert.Len(t, recorder.received(), 1, "retried block must reach downstream handlers, not be skipped")
 }
 
 // TestStart_DeliveryErrorIsLogged verifies that a delivery error does not cause

--- a/integration/hybridx_test.go
+++ b/integration/hybridx_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package integration
+
+import (
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-evm/integration/contracts"
+)
+
+// switchWatchingLogger wraps TestLogger and additionally closes switched the
+// first time it observes hybridx's "switching to notification" log line, so
+// tests can wait on the switch without reaching into HybridSynchronizer's
+// unexported state.
+type switchWatchingLogger struct {
+	TestLogger
+	once     sync.Once
+	switched chan struct{}
+}
+
+func newSwitchWatchingLogger(t *testing.T) *switchWatchingLogger {
+	return &switchWatchingLogger{
+		TestLogger: TestLogger{T: t},
+		switched:   make(chan struct{}),
+	}
+}
+
+func (l *switchWatchingLogger) Infof(format string, v ...any) {
+	l.TestLogger.Infof(format, v...)
+	if strings.HasPrefix(format, "hybridx: switching to notification") {
+		l.once.Do(func() { close(l.switched) })
+	}
+}
+
+// testHybridSwitchesToNotification verifies, against a real fabric-x committer,
+// that the hybrid synchronizer actually switches from delivery to notification
+// mode under continuous traffic — the scenario that was silently broken before
+// the nDel+1 >= batch.BlockNumber fix in gateway/app/hybridx/hybrid.go
+// (previously nDel could at best reach batch.BlockNumber-1 under continuous
+// traffic, so the switch never fired: no error, no log, permanent delivery-only
+// fallback). It also submits a transaction after the switch and confirms it is
+// correctly reflected on-chain, exercising the notification path's
+// double-dispatch guard and block-hash placeholder end-to-end against the real
+// committer rather than the fabrictest fake the unit tests use.
+func testHybridSwitchesToNotification(t *testing.T) {
+	logs := newSwitchWatchingLogger(t)
+	th, err := newFileConfigHarness(t, logs, evmConfig(""), "", "fabx.yaml", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { th.Stop() })
+
+	node := th.Gateways[0]
+	ethClient, err := NewEthClient(contracts.CounterMetaData, th.ethChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Continuous traffic: fire a deploy and several calls back-to-back with no
+	// delay, so each new block's notification batch races the delivery
+	// synchronizer's processing of that same block — the exact condition that
+	// never switched before the fix.
+	addr := deploySmartContract(t, node, ethClient)
+	const calls = 20
+	for range calls {
+		callSmartContract(t, ethClient, addr, node, "increment")
+	}
+
+	select {
+	case <-logs.switched:
+		t.Log("hybridx switched to notification mode")
+	case <-time.After(10 * time.Second):
+		t.Fatal("hybridx never switched to notification mode under continuous traffic")
+	}
+
+	// The synchronizer must keep working correctly after the switch.
+	callSmartContract(t, ethClient, addr, node, "increment")
+	querySmartContractExpect(t, ethClient, addr, th, big.NewInt(calls+1), "getCount")
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -191,6 +191,10 @@ func TestFabricX(t *testing.T) {
 	t.Run("two_of_two_endorsement_policy", func(t *testing.T) {
 		testTwoOfTwoEndorsementGRPC(t)
 	})
+
+	t.Run("hybrid_switches_to_notification", func(t *testing.T) {
+		testHybridSwitchesToNotification(t)
+	})
 }
 
 // testTwoOfTwoEndorsementGRPC runs org1's and org2's endorsers as separate,


### PR DESCRIPTION
- the hybridx synchronizer required delivery to reach the batch's own block number after the handlers had all processed the block. In practice this meant that the switch to notifier never happened.

- At the switch moment, there was some overlap between the two inputs, which causes some blocks to be processed twice. This commit changes the switch condition to only have covered everything _before_ it, and ensures only one identical block passes at the switch.

- AllTxStreamer does not support block hashes yet. Keeping them nil caused insert conflicts in the database (which we didn't notice because the switch never happened before). This commit temporarily uses block numbers as fake hashes, until https://github.com/hyperledger/fabric-x-committer/issues/773 is implemented.