### PR TITLE
start estimating gas with maxUsedGas + sentry buffer

### DIFF
--- a/api/endorsementpb/endorsement.pb.go
+++ b/api/endorsementpb/endorsement.pb.go
@@ -369,9 +369,10 @@ type CallResponse struct {
 	// Set when the call did not succeed; carries the revert reason and payload.
 	Status  int32  `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
 	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	// EVM gas consumed by the simulation (eth_estimateGas).
-	// Zero when the call is rejected before ApplyMessage runs.
-	UsedGas       uint64 `protobuf:"varint,4,opt,name=used_gas,json=usedGas,proto3" json:"used_gas,omitempty"`
+	// Maximum EVM gas the simulation needed, before EIP-3529 refunds are
+	// credited (eth_estimateGas needs this pre-refund figure as its search
+	// baseline). Zero when the call is rejected before ApplyMessage runs.
+	MaxUsedGas    uint64 `protobuf:"varint,4,opt,name=max_used_gas,json=maxUsedGas,proto3" json:"max_used_gas,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -427,9 +428,9 @@ func (x *CallResponse) GetMessage() string {
 	return ""
 }
 
-func (x *CallResponse) GetUsedGas() uint64 {
+func (x *CallResponse) GetMaxUsedGas() uint64 {
 	if x != nil {
-		return x.UsedGas
+		return x.MaxUsedGas
 	}
 	return 0
 }
@@ -865,13 +866,14 @@ const file_api_endorsementpb_endorsement_proto_rawDesc = "" +
 	"\x05value\x18\x05 \x01(\fR\x05value\x12\x12\n" +
 	"\x04data\x18\x06 \x01(\fR\x04data\x12&\n" +
 	"\fblock_number\x18\a \x01(\x04H\x00R\vblockNumber\x88\x01\x01B\x0f\n" +
-	"\r_block_number\"|\n" +
+	"\r_block_number\"\x83\x01\n" +
 	"\fCallResponse\x12\x1f\n" +
 	"\vreturn_data\x18\x01 \x01(\fR\n" +
 	"returnData\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\x05R\x06status\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\x12\x19\n" +
-	"\bused_gas\x18\x04 \x01(\x04R\ausedGas\"c\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12 \n" +
+	"\fmax_used_gas\x18\x04 \x01(\x04R\n" +
+	"maxUsedGas\"c\n" +
 	"\x0eBalanceRequest\x12\x18\n" +
 	"\aaccount\x18\x01 \x01(\fR\aaccount\x12&\n" +
 	"\fblock_number\x18\x02 \x01(\x04H\x00R\vblockNumber\x88\x01\x01B\x0f\n" +

--- a/api/endorsementpb/endorsement.proto
+++ b/api/endorsementpb/endorsement.proto
@@ -88,9 +88,10 @@ message CallResponse {
     int32 status = 2;
     string message = 3;
 
-    // EVM gas consumed by the simulation (eth_estimateGas).
-    // Zero when the call is rejected before ApplyMessage runs.
-    uint64 used_gas = 4;
+    // Maximum EVM gas the simulation needed, before EIP-3529 refunds are
+    // credited (eth_estimateGas needs this pre-refund figure as its search
+    // baseline). Zero when the call is rejected before ApplyMessage runs.
+    uint64 max_used_gas = 4;
 }
 
 message BalanceRequest {

--- a/endorser/api/service.go
+++ b/endorser/api/service.go
@@ -46,9 +46,9 @@ type Service interface {
 
 	// Call runs a read-only eth_call. On an EVM revert or a failed execution it
 	// returns a *common.CallError; the revert payload is returned alongside it.
-	// usedGas is the EVM gas consumed by the simulation; callers that
-	// only need return data (eth_call) may ignore it.
-	Call(ctx context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) (ret []byte, usedGas uint64, err error)
+	// maxUsedGas is the EVM gas the simulation needed before EIP-3529 refunds
+	// are credited; callers that only need return data (eth_call) may ignore it.
+	Call(ctx context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) (ret []byte, maxUsedGas uint64, err error)
 
 	BalanceAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) (*big.Int, error)
 	StorageAt(ctx context.Context, account ethcommon.Address, key ethcommon.Hash, blockNumber *big.Int) ([]byte, error)

--- a/endorser/client/client.go
+++ b/endorser/client/client.go
@@ -64,16 +64,16 @@ func (c *Client) Execute(ctx context.Context, inv endorsement.Invocation, ethTx 
 
 // Call runs a read-only eth_call. A non-OK status is returned as a
 // *common.CallError; only transport faults surface as a gRPC error.
-// usedGas is the EVM gas consumed by the simulation.
+// maxUsedGas is the EVM gas the simulation needed before EIP-3529 refunds are credited.
 func (c *Client) Call(ctx context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) ([]byte, uint64, error) {
 	resp, err := c.rpc.Call(ctx, callRequest(msg, blockNumber))
 	if err != nil {
 		return nil, 0, err
 	}
 	if resp.GetStatus() != common.StatusOK {
-		return resp.GetReturnData(), resp.GetUsedGas(), &common.CallError{Status: resp.GetStatus(), Message: resp.GetMessage(), Data: resp.GetReturnData()}
+		return resp.GetReturnData(), resp.GetMaxUsedGas(), &common.CallError{Status: resp.GetStatus(), Message: resp.GetMessage(), Data: resp.GetReturnData()}
 	}
-	return resp.GetReturnData(), resp.GetUsedGas(), nil
+	return resp.GetReturnData(), resp.GetMaxUsedGas(), nil
 }
 
 func (c *Client) BalanceAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) (*big.Int, error) {

--- a/endorser/client/client_test.go
+++ b/endorser/client/client_test.go
@@ -135,7 +135,7 @@ func TestExecute_TransportErrorIsReturned(t *testing.T) {
 }
 
 func TestCall_Success(t *testing.T) {
-	c := newClient(t, &mockServer{callResp: &endorsementpb.CallResponse{ReturnData: []byte{0xde, 0xad}, Status: common.StatusOK, UsedGas: 21000}})
+	c := newClient(t, &mockServer{callResp: &endorsementpb.CallResponse{ReturnData: []byte{0xde, 0xad}, Status: common.StatusOK, MaxUsedGas: 21000}})
 
 	out, gas, err := c.Call(context.Background(), &ethereum.CallMsg{}, nil)
 	if err != nil {
@@ -152,7 +152,7 @@ func TestCall_Success(t *testing.T) {
 // A non-OK Call status comes back as a *common.CallError, not a gRPC error.
 func TestCall_RevertBecomesCallError(t *testing.T) {
 	data := []byte{0x08, 0xc3, 0x79, 0xa0}
-	c := newClient(t, &mockServer{callResp: &endorsementpb.CallResponse{ReturnData: data, Status: common.StatusEVMRevert, Message: "reverted", UsedGas: 15000}})
+	c := newClient(t, &mockServer{callResp: &endorsementpb.CallResponse{ReturnData: data, Status: common.StatusEVMRevert, Message: "reverted", MaxUsedGas: 15000}})
 
 	out, gas, err := c.Call(context.Background(), &ethereum.CallMsg{}, nil)
 	ce, ok := err.(*common.CallError)

--- a/endorser/core/endorser.go
+++ b/endorser/core/endorser.go
@@ -43,8 +43,9 @@ type EVMEngineInterface interface {
 	// Execute runs a state-changing tx. blockTime is the Unix second used as
 	// EVM block.timestamp and must be non-zero (gateway always supplies it).
 	Execute(ctx context.Context, tx *types.Transaction, blockTime uint64) (endorsement.ExecutionResult, error)
-	// Call returns return data and EVM usedGas from the simulation.
-	Call(msg ethereum.CallMsg, blockNumber *big.Int) (ret []byte, usedGas uint64, err error)
+	// Call returns return data and the EVM gas the simulation needed before
+	// EIP-3529 refunds are credited.
+	Call(msg ethereum.CallMsg, blockNumber *big.Int) (ret []byte, maxUsedGas uint64, err error)
 	BalanceAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) (*big.Int, error)
 	StorageAt(ctx context.Context, account ethcommon.Address, key ethcommon.Hash, blockNumber *big.Int) ([]byte, error)
 	CodeAt(ctx context.Context, account ethcommon.Address, blockNumber *big.Int) ([]byte, error)
@@ -126,8 +127,9 @@ func validateRequestTimestamp(ts, now time.Time, maxFuture, maxPast time.Duratio
 
 // Call runs a read-only eth_call. A revert or failed execution comes back as a
 // *common.CallError; on a revert the payload is returned alongside it.
-// usedGas is the EVM gas consumed by the simulation.
-func (f *Endorser) Call(ctx context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) (ret []byte, usedGas uint64, err error) {
+// maxUsedGas is the EVM gas the simulation needed before EIP-3529 refunds are
+// credited.
+func (f *Endorser) Call(ctx context.Context, msg *ethereum.CallMsg, blockNumber *big.Int) (ret []byte, maxUsedGas uint64, err error) {
 	res, gas, err := f.Engine.Call(*msg, blockNumber)
 	if err != nil {
 		return res, gas, &common.CallError{Status: classify(err), Message: err.Error(), Data: res}

--- a/endorser/execution/executor.go
+++ b/endorser/execution/executor.go
@@ -120,9 +120,9 @@ func (e *EVMEngine) Execute(ctx context.Context, tx *types.Transaction, blockTim
 // TIMESTAMP uses the endorser's wall clock (Unix seconds) so view functions see a time
 // consistent with gateway-stamped Execute. Historical block times are not reconstructed;
 // every call gets "now".
-// usedGas is the EVM gas consumed by the simulation; 0 when the call is rejected
-// before ApplyMessage runs.
-func (e *EVMEngine) Call(msg ethereum.CallMsg, blockNumber *big.Int) (ret []byte, usedGas uint64, err error) {
+// maxUsedGas is the EVM gas the simulation needed before EIP-3529 refunds are
+// credited; 0 when the call is rejected before ApplyMessage runs.
+func (e *EVMEngine) Call(msg ethereum.CallMsg, blockNumber *big.Int) (ret []byte, maxUsedGas uint64, err error) {
 	blockTime := uint64(time.Now().Unix())
 	ex, err := e.newExecutor(blockNumber, blockTime)
 	if err != nil {
@@ -389,18 +389,14 @@ func callMsgToMessage(msg ethereum.CallMsg, baseFee *big.Int, skipNonceCheck, sk
 }
 
 // Call executes a read-only call (eth_call semantics).
-// usedGas is the gas consumed by the EVM (for eth_estimateGas).
+// maxUsedGas is the gas the EVM would need in total to complete the call,
+// before EIP-3529 refunds are credited.
 //
-// An empty revert is returned as-is, not specially masked here: gas estimation
-// re-simulates a call at a candidate gas limit to verify it (see
-// gateway/core/endorse.go's EstimateGas), and a delegatecall (e.g. through an
-// EIP-1167 minimal proxy) that runs out of the gas forwarded to it also bubbles
-// up as an empty revert -- indistinguishable, at this layer, from a genuine
-// zero-data revert. Masking it here would make that verification trust a false
-// "succeeded" for an out-of-gas candidate. Callers that want eth_call's classic
-// "empty revert probing a contract is not an error" behavior apply it
-// themselves (see EndorsementClient.call in gateway/core/endorse.go).
-func (h *Executor) Call(msg ethereum.CallMsg) (ret []byte, usedGas uint64, err error) {
+// An empty revert is returned as-is, not masked: it's indistinguishable here
+// from a delegatecall (e.g. an EIP-1167 minimal proxy) running out of its
+// forwarded gas, and masking it would let gas-estimation's verification
+// trust a false success for an out-of-gas candidate.
+func (h *Executor) Call(msg ethereum.CallMsg) (ret []byte, maxUsedGas uint64, err error) {
 	return h.execute(callMsgToMessage(msg, h.BlockCtx.BaseFee, true, true))
 }
 
@@ -445,7 +441,7 @@ func (h *Executor) Send(tx *types.Transaction) ([]byte, error) {
 // execute applies production defaults then runs the EVM via ApplyMessage.
 // Gas prices are always zeroed (free gas) so buyGas never requires ETH balance.
 // If MaxTxGas is set, msg.GasLimit is capped before execution.
-func (h *Executor) execute(msg *core.Message) (ret []byte, usedGas uint64, err error) {
+func (h *Executor) execute(msg *core.Message) (ret []byte, maxUsedGas uint64, err error) {
 	if msg.GasLimit == 0 {
 		msg.GasLimit = 5_000_000
 	}
@@ -465,8 +461,10 @@ func (h *Executor) execute(msg *core.Message) (ret []byte, usedGas uint64, err e
 
 // ApplyMessage runs msg on the EVM exactly as provided, without production defaults.
 // Use this in test infrastructure (testimpl) when real gas pricing is needed.
-// usedGas is the gas consumed by the EVM (0 if rejected before ApplyMessage).
-func (h *Executor) ApplyMessage(msg *core.Message) (ret []byte, usedGas uint64, err error) {
+// maxUsedGas is go-ethereum's ExecutionResult.MaxUsedGas: gas needed before
+// EIP-3529 refunds are credited (0 if rejected before ApplyMessage). See
+// Call's doc comment for why.
+func (h *Executor) ApplyMessage(msg *core.Message) (ret []byte, maxUsedGas uint64, err error) {
 	evm := vm.NewEVM(h.BlockCtx, h.state, h.ChainCfg, vm.Config{})
 
 	// Snapshot before execution mirrors geth's approach and allows reverting on error.
@@ -494,13 +492,13 @@ func (h *Executor) ApplyMessage(msg *core.Message) (ret []byte, usedGas uint64, 
 		// rejection.
 		if errors.Is(result.Err, vm.ErrExecutionReverted) {
 			if reason, uErr := abi.UnpackRevert(result.ReturnData); uErr == nil {
-				return result.ReturnData, result.UsedGas, fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
+				return result.ReturnData, result.MaxUsedGas, fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
 			}
-			return result.ReturnData, result.UsedGas, result.Err
+			return result.ReturnData, result.MaxUsedGas, result.Err
 		}
-		return result.ReturnData, result.UsedGas, &ExecFailure{err: result.Err}
+		return result.ReturnData, result.MaxUsedGas, &ExecFailure{err: result.Err}
 	}
-	return result.ReturnData, result.UsedGas, nil
+	return result.ReturnData, result.MaxUsedGas, nil
 }
 
 // TxRejected tags an invalid transaction rejected before execution (nonce, funds,

--- a/endorser/execution/executor_test.go
+++ b/endorser/execution/executor_test.go
@@ -11,10 +11,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	gethcore "github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
 	"github.com/hyperledger/fabric-x-evm/common"
+	"github.com/hyperledger/fabric-x-sdk/blocks"
 	"github.com/hyperledger/fabric-x-sdk/state"
 	_ "modernc.org/sqlite"
 )
@@ -229,5 +232,66 @@ func TestNewExecutor_NegativeBlockNumberResolvesToLatest(t *testing.T) {
 	got := ex.reader.(*testVersionedDBReader).blockNumber
 	if got != wantLatest {
 		t.Errorf("newExecutor(-5) resolved to block %d, want latest (%d)", got, wantLatest)
+	}
+}
+
+// TestCall_ReportsPreRefundGasNotPostRefund verifies that Call/ApplyMessage
+// return go-ethereum's pre-refund MaxUsedGas, not the post-refund UsedGas.
+// EstimateGas seeds its search from this value; if it silently became the
+// net figure again, every call that clears storage to zero would report less
+// gas than it actually needs on resubmission, since EIP-3529's refund is
+// only credited to the final bill and is never spendable mid-execution.
+func TestCall_ReportsPreRefundGasNotPostRefund(t *testing.T) {
+	backend, err := state.NewWriteDB(Channel, "file:exec_refund?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contract := newAddress()
+	slot := ethcommon.HexToHash("0x00")
+	// PUSH1 0x00; PUSH1 0x00; SSTORE; STOP -- clears slot 0 to zero.
+	code := []byte{0x60, 0x00, 0x60, 0x00, 0x55, 0x00}
+
+	// Prime the slot with a nonzero original value and commit it, so the
+	// SSTORE-to-zero below actually earns an EIP-3529 clear refund: the
+	// refund only applies when the slot's value *before this transaction*
+	// was nonzero.
+	setup := snapshotDB(t, backend, 0)
+	setup.CreateAccount(contract)
+	setup.SetCode(contract, code, tracing.CodeChangeContractCreation)
+	setup.SetState(contract, slot, ethcommon.HexToHash("0x01"))
+	err = backend.UpdateWorldState(t.Context(), blocks.Block{
+		Number: 0,
+		Transactions: []blocks.Transaction{{
+			ID: "setup", Number: 0, Valid: true,
+			NsRWS: []blocks.NsReadWriteSet{{Namespace: Namespace, RWS: setup.Result()}},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kvs := &testVersionedDBSnapshotter{db: backend}
+	cfg := EVMConfig{ChainConfig: common.BuildChainConfig(4011)}
+	eng := NewEVMEngine(Namespace, kvs, cfg, false)
+
+	ex, err := eng.newExecutor(nil, uint64(1_700_000_000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ex.Close()
+
+	_, gotGas, err := ex.Call(ethereum.CallMsg{To: &contract})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 21,000 intrinsic + 6 (two PUSH1s) + 5,000 (cold-access SSTORE clear:
+	// 2,100 cold surcharge + 2,900 warm reset). If the post-refund figure
+	// leaked back in, this would read 21,206 (26,006 minus the uncapped
+	// 4,800 clear refund) instead.
+	const want = 26_006
+	if gotGas != want {
+		t.Errorf("gas = %d, want %d (the pre-refund figure)", gotGas, want)
 	}
 }

--- a/endorser/server/handlers.go
+++ b/endorser/server/handlers.go
@@ -58,16 +58,16 @@ func invocation(req *endorsementpb.ExecuteRequest) endorsement.Invocation {
 
 // Call runs a read-only eth_call. A revert or failed execution is carried in
 // the response; only transport faults are a gRPC error.
-// used_gas is always set from the simulation.
+// max_used_gas is always set from the simulation.
 func (s *Server) Call(ctx context.Context, req *endorsementpb.CallRequest) (*endorsementpb.CallResponse, error) {
-	out, usedGas, err := s.svc.Call(ctx, callMsg(req), blockNumber(req.BlockNumber))
+	out, maxUsedGas, err := s.svc.Call(ctx, callMsg(req), blockNumber(req.BlockNumber))
 	if err != nil {
 		if ce, ok := errors.AsType[*common.CallError](err); ok {
-			return &endorsementpb.CallResponse{ReturnData: ce.Data, Status: ce.Status, Message: ce.Message, UsedGas: usedGas}, nil
+			return &endorsementpb.CallResponse{ReturnData: ce.Data, Status: ce.Status, Message: ce.Message, MaxUsedGas: maxUsedGas}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "call: %v", err)
 	}
-	return &endorsementpb.CallResponse{ReturnData: out, Status: common.StatusOK, UsedGas: usedGas}, nil
+	return &endorsementpb.CallResponse{ReturnData: out, Status: common.StatusOK, MaxUsedGas: maxUsedGas}, nil
 }
 
 func (s *Server) BalanceAt(ctx context.Context, req *endorsementpb.BalanceRequest) (*endorsementpb.BalanceResponse, error) {

--- a/endorser/server/server_test.go
+++ b/endorser/server/server_test.go
@@ -194,8 +194,8 @@ func TestCall_Success(t *testing.T) {
 	if resp.GetStatus() != common.StatusOK {
 		t.Errorf("status = %d, want %d", resp.GetStatus(), common.StatusOK)
 	}
-	if resp.GetUsedGas() != 21000 {
-		t.Errorf("usedGas = %d, want 21000", resp.GetUsedGas())
+	if resp.GetMaxUsedGas() != 21000 {
+		t.Errorf("maxUsedGas = %d, want 21000", resp.GetMaxUsedGas())
 	}
 }
 

--- a/endorser/testimpl/evm_engine_wrapper.go
+++ b/endorser/testimpl/evm_engine_wrapper.go
@@ -132,7 +132,8 @@ func (w *EVMEngineWrapper) Execute(ctx context.Context, tx *types.Transaction, b
 
 // Call executes a read-only call against the state.
 // The behavior depends on the configured mode.
-// usedGas is the EVM gas consumed .
+// maxUsedGas is the EVM gas the simulation needed before EIP-3529 refunds are
+// credited.
 func (w *EVMEngineWrapper) Call(msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, uint64, error) {
 	// Create the appropriate executor based on mode
 	type caller interface {

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -142,20 +142,26 @@ func (e *EndorsementClient) CallContract(ctx context.Context, args ethereum.Call
 // so there's no cost to simulating generously.
 const estimateGasCeiling = uint64(10_000_000)
 
+// sstoreSentryBuffer covers EIP-2200's SSTORE sentry: at every SSTORE the EVM
+// requires strictly more than 2300 gas in reserve, regardless of the opcode's
+// own cost. Almost any state-changing call needs at least this much above its
+// own maxUsedGas.
+const sstoreSentryBuffer = uint64(2301)
+
 // EstimateGas returns a gas limit verified to work if resubmitted, not a raw
-// usedGas value: EVM rules like EIP-2200's SSTORE sentry and EIP-150's
+// maxUsedGas value: EVM rules like EIP-2200's SSTORE sentry and EIP-150's
 // 63/64 call-forwarding need gas in reserve during execution, not just
-// enough in total, so exact usedGas can sometimes still run out (view calls
-// and other simple cases usually don't hit this). Since gas isn't charged,
-// we generously double on each failure, until we hit the ceiling or succeed.
+// enough in total, so exact maxUsedGas can sometimes still run out. EIP-150's
+// forwarding loss compounds with call depth, so we generously double on each
+// failure, until we hit the ceiling or succeed.
 func (e *EndorsementClient) EstimateGas(ctx context.Context, args ethereum.CallMsg, blockNumber *big.Int) (uint64, error) {
 	call := args
 
-	probeGas := func(gas uint64) (usedGas uint64, ok bool, err error) {
+	probeGas := func(gas uint64) (maxUsedGas uint64, ok bool, err error) {
 		call.Gas = gas
-		_, usedGas, err = e.endorsers[0].Call(ctx, &call, blockNumber)
+		_, maxUsedGas, err = e.endorsers[0].Call(ctx, &call, blockNumber)
 		if err == nil {
-			return usedGas, true, nil
+			return maxUsedGas, true, nil
 		}
 		callErr, isCallErr := errors.AsType[*common.CallError](err)
 		if !isCallErr {
@@ -169,10 +175,10 @@ func (e *EndorsementClient) EstimateGas(ctx context.Context, args ethereum.CallM
 		// Out of gas, or an empty-data revert -- indistinguishable here from a
 		// delegatecall (e.g. through an EIP-1167 minimal proxy) that ran out of
 		// the gas forwarded to it. Either way, treat it as "not enough gas yet".
-		return usedGas, false, nil
+		return maxUsedGas, false, nil
 	}
 
-	usedGas, ok, err := probeGas(estimateGasCeiling)
+	maxUsedGas, ok, err := probeGas(estimateGasCeiling)
 	if err != nil {
 		return 0, err
 	}
@@ -180,7 +186,7 @@ func (e *EndorsementClient) EstimateGas(ctx context.Context, args ethereum.CallM
 		return 0, fmt.Errorf("gas required exceeds allowance (%d)", estimateGasCeiling)
 	}
 
-	for guess := usedGas; guess < estimateGasCeiling; guess *= 2 {
+	for guess := maxUsedGas + sstoreSentryBuffer; guess < estimateGasCeiling; guess *= 2 {
 		if _, ok, err := probeGas(guess); err != nil {
 			return 0, err
 		} else if ok {

--- a/gateway/core/endorse_test.go
+++ b/gateway/core/endorse_test.go
@@ -182,16 +182,18 @@ func TestCallContract_EmptyRevertIsNotAnError(t *testing.T) {
 	}
 }
 
-// When the raw usedGas already verifies (e.g. a view call with no SSTORE),
-// that's what comes back untouched -- no unnecessary padding.
-func TestEstimateGas_ReturnsRawUsedGasWhenThatVerifies(t *testing.T) {
+// The loop's first try is always padded by the sentry buffer, even when the
+// raw maxUsedGas alone would already have verified: we can't tell in advance
+// whether a call touches storage, and paying that fixed, tiny padding
+// unconditionally is cheaper than risking a wasted probe on every write.
+func TestEstimateGas_PadsFirstGuessWithSentryBuffer(t *testing.T) {
 	c := newClient(&stubEndorser{callPayload: []byte{0x01}, callGas: 42123})
 
 	got, err := c.EstimateGas(context.Background(), ethereum.CallMsg{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if want := uint64(42123); got != want {
+	if want := uint64(42123) + sstoreSentryBuffer; got != want {
 		t.Errorf("gas = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
As we discovered while discussing https://github.com/hyperledger/fabric-x-evm/pull/337, our first estimateGas guess would succeed much more often if we use maxUsedGas (gas used before refunds), and already add the EIP-2200's SSTORE sentry.