### PR TITLE
feat(gateway): surface tx.Valid as FabricValid in the domain model

### DIFF
--- a/gateway/core/chain.go
+++ b/gateway/core/chain.go
@@ -159,7 +159,7 @@ func ConvertToDomain(b blocks.Block) domain.Block {
 			status = 1
 		}
 
-		etx, err := convertTransaction(tx.InputArgs[1], b.Hash, b.Number, tx.Number, tx.ID, status, tx.Status, tx.Events, &logIndex)
+		etx, err := convertTransaction(tx.InputArgs[1], b.Hash, b.Number, tx.Number, tx.ID, status, tx.Status, tx.Valid, tx.Events, &logIndex)
 		if err != nil {
 			panic(err) // we surface this for now instead of swallowing it
 		}
@@ -171,7 +171,7 @@ func ConvertToDomain(b blocks.Block) domain.Block {
 }
 
 // convertTransaction converts an Ethereum transaction to a domain.Transaction.
-func convertTransaction(ethTxBytes []byte, blockHash []byte, blockNumber uint64, txIndex int64, txID string, ethStatus uint8, validationCode int, events []byte, logIndex *int64) (domain.Transaction, error) {
+func convertTransaction(ethTxBytes []byte, blockHash []byte, blockNumber uint64, txIndex int64, txID string, ethStatus uint8, validationCode int, fabricValid bool, events []byte, logIndex *int64) (domain.Transaction, error) {
 	ethTx := &types.Transaction{}
 	if err := ethTx.UnmarshalBinary(ethTxBytes); err != nil {
 		return domain.Transaction{}, fmt.Errorf("invalid tx: %w", err)
@@ -234,6 +234,7 @@ func convertTransaction(ethTxBytes []byte, blockHash []byte, blockNumber uint64,
 		Status:          ethStatus,
 		FabricTxID:      txID,
 		FabricTxStatus:  validationCode,
+		FabricValid:     fabricValid,
 		Logs:            logs,
 	}, nil
 }

--- a/gateway/core/chain_test.go
+++ b/gateway/core/chain_test.go
@@ -69,6 +69,7 @@ func TestConvertToDomain_ValidTx(t *testing.T) {
 	require.Len(t, got.Transactions, 1)
 	assert.Equal(t, uint8(1), got.Transactions[0].Status)
 	assert.Equal(t, "tx-1", got.Transactions[0].FabricTxID)
+	assert.True(t, got.Transactions[0].FabricValid)
 }
 
 func TestConvertToDomain_InvalidTxStatus(t *testing.T) {
@@ -90,6 +91,7 @@ func TestConvertToDomain_InvalidTxStatus(t *testing.T) {
 
 	require.Len(t, got.Transactions, 1)
 	assert.Equal(t, uint8(0), got.Transactions[0].Status)
+	assert.False(t, got.Transactions[0].FabricValid)
 }
 
 func TestConvertToDomain_SkipsInsufficientInputArgs(t *testing.T) {
@@ -140,7 +142,7 @@ func TestConvertTransaction_RegularTransfer(t *testing.T) {
 	ethb, _ := ethTx.MarshalBinary()
 
 	logIndex := int64(0)
-	domainTx, err := convertTransaction(ethb, []byte("block-hash"), 42, 5, "fabric-tx-123", 1, 0, nil, &logIndex)
+	domainTx, err := convertTransaction(ethb, []byte("block-hash"), 42, 5, "fabric-tx-123", 1, 0, true, nil, &logIndex)
 
 	require.NoError(t, err)
 	assert.Equal(t, ethTx.Hash().Bytes(), domainTx.TxHash)
@@ -152,6 +154,7 @@ func TestConvertTransaction_RegularTransfer(t *testing.T) {
 	assert.Equal(t, "fabric-tx-123", domainTx.FabricTxID)
 	assert.Equal(t, uint8(1), domainTx.Status)
 	assert.Equal(t, 0, domainTx.FabricTxStatus)
+	assert.True(t, domainTx.FabricValid)
 	assert.NotNil(t, domainTx.FromAddress)
 	assert.NotNil(t, domainTx.RawTx)
 }
@@ -167,7 +170,7 @@ func TestConvertTransaction_ContractCreation(t *testing.T) {
 	ethb, _ := signed.MarshalBinary()
 
 	logIndex := int64(0)
-	domainTx, err := convertTransaction(ethb, []byte("block-hash"), 42, 3, "fabric-tx-456", 1, 0, nil, &logIndex)
+	domainTx, err := convertTransaction(ethb, []byte("block-hash"), 42, 3, "fabric-tx-456", 1, 0, true, nil, &logIndex)
 
 	require.NoError(t, err)
 	assert.Nil(t, domainTx.ToAddress)
@@ -184,7 +187,7 @@ func TestConvertTransaction_InvalidSignature(t *testing.T) {
 	ethb, _ := ethTx.MarshalBinary()
 
 	logIndex := int64(0)
-	_, err := convertTransaction(ethb, []byte("block-hash"), 42, 1, "fabric-tx-789", 1, 0, nil, &logIndex)
+	_, err := convertTransaction(ethb, []byte("block-hash"), 42, 1, "fabric-tx-789", 1, 0, true, nil, &logIndex)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid sender")
@@ -200,19 +203,21 @@ func TestConvertTransaction_ValidationCodes(t *testing.T) {
 		name           string
 		ethStatus      uint8
 		validationCode int
+		fabricValid    bool
 	}{
-		{"valid", 1, 0},
-		{"mvcc_conflict", 0, 11},
-		{"endorsement_failure", 0, 8},
+		{"valid", 1, 0, true},
+		{"mvcc_conflict", 0, 11, false},
+		{"endorsement_failure", 0, 8, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logIndex := int64(0)
-			domainTx, err := convertTransaction(ethb, []byte("bh"), 42, 1, "tx", tt.ethStatus, tt.validationCode, nil, &logIndex)
+			domainTx, err := convertTransaction(ethb, []byte("bh"), 42, 1, "tx", tt.ethStatus, tt.validationCode, tt.fabricValid, nil, &logIndex)
 			require.NoError(t, err)
 			assert.Equal(t, tt.ethStatus, domainTx.Status)
 			assert.Equal(t, tt.validationCode, domainTx.FabricTxStatus)
+			assert.Equal(t, tt.fabricValid, domainTx.FabricValid)
 		})
 	}
 }

--- a/gateway/domain/models.go
+++ b/gateway/domain/models.go
@@ -31,6 +31,7 @@ type Transaction struct {
 	Status          uint8
 	FabricTxID      string
 	FabricTxStatus  int
+	FabricValid     bool  // Fabric-valid commit: the nonce was consumed, reverts included
 	Logs            []Log // populated for receipt queries
 }
 


### PR DESCRIPTION
## Summary

Part of #356.

Surface the reliable Fabric-validity signal into the domain model: `ConvertToDomain` now carries the SDK block transaction's `tx.Valid` as a new `domain.Transaction.FabricValid`. This is the signal the nonce gate needs to tell a Fabric-valid commit (nonce consumed, reverts included) from an MVCC-invalidated one - unlike `FabricTxStatus`, which is derived from the never-set `tx.Status` and is always 0.

## Changes

- `gateway/domain/models.go` - add `FabricValid bool`.
- `gateway/core/chain.go` - set `FabricValid` from `tx.Valid` in `convertTransaction`.
- `gateway/core/chain_test.go` - cover the new field.

## Scope / follow-ups

Producer side only. Two steps land separately:
- switching the nonce gate's `Observe` from `FabricTxStatus` to `FabricValid` - lives in #227 (nonce parking), and lands once the gate and this field are on the same branch.
- removing the dead `FabricTxStatus` plumbing (a DB column + sqlc regen) - a small separate follow-up.

## Tests

- [x] `go test ./gateway/core/...`
- [x] `make checks`
