### PR TITLE
unify synchronizer, update config structure

### DIFF
--- a/docs/ENDORSEMENT_API.md
+++ b/docs/ENDORSEMENT_API.md
@@ -9,15 +9,19 @@ Schema: [`api/endorsementpb/endorsement.proto`](../api/endorsementpb/endorsement
 
 ## Table of Contents
 
-- [Architecture](#architecture)
-- [Service](#service)
-- [Messages](#messages)
-- [Endorsement](#endorsement)
-- [Errors](#errors)
-- [Security](#security)
-- [Resilience](#resilience)
-- [Configuration](#configuration)
-- [Testing](#testing)
+- [Endorsement API](#endorsement-api)
+  - [Table of Contents](#table-of-contents)
+  - [Architecture](#architecture)
+  - [Service](#service)
+  - [Messages](#messages)
+  - [Endorsement](#endorsement)
+  - [Errors](#errors)
+  - [Security](#security)
+  - [Resilience](#resilience)
+  - [Configuration](#configuration)
+    - [Endorser](#endorser)
+    - [Gateway](#gateway)
+  - [Testing](#testing)
 
 ## Architecture
 
@@ -49,14 +53,14 @@ as separate processes. See [Configuration](#configuration).
 One RPC per engine function. Only `Execute` produces an endorsement; the reads
 return plain values.
 
-| RPC | Purpose |
-|---|---|
-| `Execute` | Execute and endorse an Ethereum transaction |
-| `Call` | Read-only `eth_call` |
-| `BalanceAt` | Account balance |
-| `StorageAt` | Storage word at a key |
-| `CodeAt` | Contract code |
-| `NonceAt` | Account nonce |
+| RPC         | Purpose                                     |
+| ----------- | ------------------------------------------- |
+| `Execute`   | Execute and endorse an Ethereum transaction |
+| `Call`      | Read-only `eth_call`                        |
+| `BalanceAt` | Account balance                             |
+| `StorageAt` | Storage word at a key                       |
+| `CodeAt`    | Contract code                               |
+| `NonceAt`   | Account nonce                               |
 
 Separate reads, rather than one query RPC with a type enum, keep every request
 and response fully typed: a storage key cannot be sent on a balance query, and
@@ -77,12 +81,12 @@ the full proposal never crosses the wire.
 **`ExecuteResponse`** carries the execution result and the endorser's signature
 over it:
 
-| Field | Meaning |
-|---|---|
-| `read_write_set` | Serialized read-write set of the execution, kept byte-exact for signing |
-| `event` | Optional event |
-| `status`, `message`, `payload` | Execution outcome and EVM return data |
-| `endorser_id`, `signature` | Serialized identity of the signer, and its signature |
+| Field                          | Meaning                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `read_write_set`               | Serialized read-write set of the execution, kept byte-exact for signing |
+| `event`                        | Optional event                                                          |
+| `status`, `message`, `payload` | Execution outcome and EVM return data                                   |
+| `endorser_id`, `signature`     | Serialized identity of the signer, and its signature                    |
 
 **`CallRequest`/`CallResponse`** carry the `ethereum.CallMsg` fields (from, to,
 gas, gas price, value, data) and a block selector; the response is the return
@@ -116,24 +120,24 @@ Application outcomes and transport faults travel on separate channels.
 the result carries the outcome. Status codes are defined in
 [`common/proposal.go`](../common/proposal.go):
 
-| Status | Meaning |
-|---|---|
-| `200` | Success |
-| `201` | EVM reverted; still endorsed and committed, receipt records `status=0` |
-| `400` | Invalid transaction, rejected before execution (nonce, funds, intrinsic gas, signature) |
-| `460` | Valid transaction whose EVM execution failed (out of gas, invalid opcode) |
-| `500` | Server-side fault, such as a signing failure |
+| Status | Meaning                                                                                 |
+| ------ | --------------------------------------------------------------------------------------- |
+| `200`  | Success                                                                                 |
+| `201`  | EVM reverted; still endorsed and committed, receipt records `status=0`                  |
+| `400`  | Invalid transaction, rejected before execution (nonce, funds, intrinsic gas, signature) |
+| `460`  | Valid transaction whose EVM execution failed (out of gas, invalid opcode)               |
+| `500`  | Server-side fault, such as a signing failure                                            |
 
 **Everything else** travels as a gRPC status error, and only these ever surface
 as a Go error:
 
-| gRPC code | Meaning | Retryable |
-|---|---|---|
-| `INVALID_ARGUMENT` | Malformed request, such as a transaction that fails to decode | no |
-| `UNAVAILABLE` | Endorser unreachable | yes |
-| `DEADLINE_EXCEEDED` | Call timed out | yes |
-| `INTERNAL` | Transport fault | no |
-| `RESOURCE_EXHAUSTED` | Server overloaded (rate limit or concurrent-stream limit) | yes |
+| gRPC code            | Meaning                                                       | Retryable |
+| -------------------- | ------------------------------------------------------------- | --------- |
+| `INVALID_ARGUMENT`   | Malformed request, such as a transaction that fails to decode | no        |
+| `UNAVAILABLE`        | Endorser unreachable                                          | yes       |
+| `DEADLINE_EXCEEDED`  | Call timed out                                                | yes       |
+| `INTERNAL`           | Transport fault                                               | no        |
+| `RESOURCE_EXHAUSTED` | Server overloaded (rate limit or concurrent-stream limit)     | yes       |
 
 The separation matters because a revert is a successful RPC carrying a
 committed outcome, while an unreachable endorser is not an endorsement outcome
@@ -181,24 +185,28 @@ endorsement policy is evaluated against.
 ### Endorser
 
 An endorser is configured with its identity (which it signs endorsements
-with), its committer connection, and its database:
+with) and its database. The committer connection it stays in sync with is
+not endorser-specific config — it's a top-level, process-wide field (see
+below), since a combined gateway+endorser process has exactly one
+synchronizer and therefore exactly one committer connection to configure:
 
 ```yaml
+committer:
+  endpoint:
+    host: committer.org1.example.com
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: /crypto/.../client.crt
+    key-path: /crypto/.../client.key
+    ca-cert-paths:
+      - /crypto/.../tlsca.org1.example.com-cert.pem
+
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: /crypto/peerOrganizations/org1.example.com/peers/endorser.org1.example.com/msp
-  committer:
-    endpoint:
-      host: committer.org1.example.com
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: /crypto/.../client.crt
-      key-path: /crypto/.../client.key
-      ca-cert-paths:
-        - /crypto/.../tlsca.org1.example.com-cert.pem
   database:
     database: memory
 ```
@@ -208,8 +216,9 @@ max-concurrent-streams and rate limiting. Its bootstrap (listen, TLS,
 interceptors, health) comes from the `serve` package in fabric-x-committer;
 it moves to fabric-x-common once published there.
 
-The endorser's `committer` connection is how it stays in sync with committed
-blocks. It is separate from the gRPC server the gateway dials.
+The top-level `committer` connection is how this process stays in sync with
+committed blocks — shared with `gateway:` when both are present in the same
+process.
 
 ### Gateway
 

--- a/endorser/app/factory.go
+++ b/endorser/app/factory.go
@@ -49,7 +49,7 @@ func NewEndorserCore(
 
 	// An unset protocol means fabric-x, matching the documented default
 	// (common.Network.Protocol) and the gateway wiring (NewNetworkSubmitters,
-	// NewGatewaySynchronizer). Normalize once so the KVS and builder choices
+	// NewSynchronizer). Normalize once so the KVS and builder choices
 	// below cannot disagree about what "" means.
 	protocol, err := common.NormalizeProtocol(protocol)
 	if err != nil {
@@ -110,6 +110,7 @@ func NewEndorserCore(
 func NewEndorser(
 	cfg config.Endorser,
 	network common.Network,
+	committer common.ClientConfig,
 	signer sdk.Signer,
 	logger sdk.Logger,
 	testImpl bool,
@@ -128,9 +129,9 @@ func NewEndorser(
 	var sync *sdknet.Synchronizer
 	switch network.Protocol {
 	case common.ProtocolFabric:
-		sync, err = nfab.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
+		sync, err = nfab.NewSynchronizer(kvs, network.Channel, committer.ToPeerConf(), signer, logger, kvs)
 	default: // "fabric-x" or "" (the default)
-		sync, err = nfabx.NewSynchronizer(kvs, network.Channel, cfg.Committer.ToPeerConf(), signer, logger, kvs)
+		sync, err = nfabx.NewSynchronizer(kvs, network.Channel, committer.ToPeerConf(), signer, logger, kvs)
 	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create synchronizer: %w", err)

--- a/endorser/config/config.go
+++ b/endorser/config/config.go
@@ -24,12 +24,14 @@ const (
 	DefaultTimestampPastSkew = 60 * time.Second
 )
 
-// Endorser contains configuration for a single embedded endorser peer.
+// Endorser contains configuration for the embedded endorser peer.
 type Endorser struct {
-	Name      string                `mapstructure:"name"      yaml:"name"`
-	Identity  common.IdentityConfig `mapstructure:"identity"  yaml:"identity"`
-	Committer common.ClientConfig   `mapstructure:"committer" yaml:"committer"`
-	Database  DB                    `mapstructure:"database"  yaml:"database"`
+	// Name is purely used for logging.
+	Name string `mapstructure:"name"      yaml:"name"`
+	// Identity is the signing identity of the endorser.
+	Identity common.IdentityConfig `mapstructure:"identity"  yaml:"identity"`
+	// Database stores the world state.
+	Database DB `mapstructure:"database"  yaml:"database"`
 	// DebugLogs enables per-tx StateDB DEBUG logging via StateDBLogger.
 	DebugLogs bool `mapstructure:"debug-logs" yaml:"debug-logs"`
 	// MaxTimestampFuture is how far ahead of local time a request timestamp may
@@ -106,9 +108,6 @@ func (cfg Endorser) Validate() error {
 	}
 	if err := cfg.Identity.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("identity: %w", err))
-	}
-	if err := cfg.Committer.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("committer: %w", err))
 	}
 	if cfg.Database.Database == "" {
 		errs = append(errs, errors.New("database.database is required"))

--- a/endorser/config/validate_test.go
+++ b/endorser/config/validate_test.go
@@ -42,9 +42,6 @@ func validEndorser(t *testing.T) config.Endorser {
 	return config.Endorser{
 		Name:     "org1",
 		Identity: common.IdentityConfig{MspID: "Org1MSP", MSPDir: mspDir},
-		Committer: common.ClientConfig{
-			Endpoint: &common.Endpoint{Host: "127.0.0.1", Port: 4001},
-		},
 		Database: config.DB{Database: "sqlite", ConnString: "file:endorser.db"},
 	}
 }
@@ -63,8 +60,6 @@ func TestEndorserValidate(t *testing.T) {
 		{"missing msp-id", func(e *config.Endorser) { e.Identity.MspID = "" }, "msp-id"},
 		{"missing msp-dir", func(e *config.Endorser) { e.Identity.MSPDir = "" }, "msp-dir"},
 		{"msp-dir not exist", func(e *config.Endorser) { e.Identity.MSPDir = "/no/such/dir" }, "msp-dir"},
-		{"nil committer endpoint", func(e *config.Endorser) { e.Committer.Endpoint = nil }, "endpoint"},
-		{"missing committer key", func(e *config.Endorser) { e.Committer.TLS.KeyPath = "/no/key" }, "tls.key-path"},
 		{"no db at all", func(e *config.Endorser) {
 			e.Database.Database = ""
 			e.Database.ConnString = ""

--- a/gateway/app/app.go
+++ b/gateway/app/app.go
@@ -22,9 +22,11 @@ import (
 	"golang.org/x/sync/errgroup"
 	_ "modernc.org/sqlite"
 
+	"github.com/hyperledger/fabric-x-evm/common"
 	eapi "github.com/hyperledger/fabric-x-evm/endorser/api"
 	eapp "github.com/hyperledger/fabric-x-evm/endorser/app"
 	eclient "github.com/hyperledger/fabric-x-evm/endorser/client"
+	"github.com/hyperledger/fabric-x-evm/endorser/execution"
 	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
 	"github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/config"
@@ -38,9 +40,8 @@ var appLogger = flogging.MustGetLogger("gateway.app")
 // App represents the gateway application with all its components.
 type App struct {
 	cfg           config.Config
-	endorserSyncs []Synchronizer
 	endorserConns []*eclient.Client // set only in split deployment; closed on Shutdown
-	gwSync        Synchronizer
+	synchronizer  Synchronizer
 	gateway       *core.Gateway
 	chain         *core.Chain
 	rpcServer     *rpc.Server
@@ -94,7 +95,6 @@ func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableT
 	if cfg.Endorser == nil {
 		return nil, fmt.Errorf("one of endorser or gateway.endorsers is required")
 	}
-	// Create this process's own endorser and its synchronizer.
 	ecfg := *cfg.Endorser
 	// Test RPC needs a large sequential history window (see testnode); production
 	// only needs a couple of snapshots for the synchronizer.
@@ -108,12 +108,17 @@ func newApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, enableT
 		return nil, fmt.Errorf("failed to create signer: %w", err)
 	}
 
-	end, sync, kvs, err := eapp.NewEndorser(ecfg, cfg.Network, eSigner, logger, enableTestRPC)
+	evmConfig := execution.EVMConfig{
+		ChainConfig: common.BuildChainConfig(cfg.Network.ChainID),
+		MaxTxGas:    cfg.Network.MaxTxGas,
+		DebugLogs:   ecfg.DebugLogs,
+	}
+	end, kvs, _, err := eapp.NewEndorserCore(ecfg.Database, cfg.Network.Channel, cfg.Network.Namespace, cfg.Network.Protocol, eSigner, evmConfig, enableTestRPC, ecfg)
 	if err != nil {
 		return nil, fmt.Errorf("endorser (%s): %w", ecfg.Name, err)
 	}
 
-	return buildApp(ctx, cfg, gwSigner, logger, []eapi.Service{end}, []Synchronizer{sync}, kvs, enableTestRPC, testAccountsPath)
+	return buildApp(ctx, cfg, gwSigner, logger, []eapi.Service{end}, kvs, enableTestRPC, testAccountsPath, kvs)
 }
 
 // newSplitApp builds the gateway in split-deployment mode: every endorsers is
@@ -140,7 +145,7 @@ func newSplitApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, lo
 		endorsers[i] = c
 	}
 
-	app, err := buildApp(ctx, cfg, gwSigner, logger, endorsers, nil, nil, enableTestRPC, testAccountsPath)
+	app, err := buildApp(ctx, cfg, gwSigner, logger, endorsers, nil, enableTestRPC, testAccountsPath)
 	if err != nil {
 		closeAll()
 		return nil, err
@@ -151,7 +156,7 @@ func newSplitApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, lo
 
 // buildApp wires up the gateway from pre-built endorsers.
 // extraHandlers are prepended to the synchronizer handler list, ahead of chain/gateway.
-func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, endorserSyncs []Synchronizer, lightKVS estorage.KVS, enableTestRPC bool, testAccountsPath string, extraHandlers ...blocks.BlockHandler) (*App, error) {
+func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logger sdk.Logger, endorsers []eapi.Service, lightKVS estorage.KVS, enableTestRPC bool, testAccountsPath string, extraHandlers ...blocks.BlockHandler) (*App, error) {
 	orderers := make([]network.OrdererConf, len(cfg.Gateway.Orderers))
 	for i, o := range cfg.Gateway.Orderers {
 		orderers[i] = o.ToOrdererConf()
@@ -176,9 +181,9 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 
 	// Chain must be called before gateway, to persist blocks before marking transactions complete.
 	handlers := append(extraHandlers, chain, gateway)
-	gwSync, err := NewGatewaySynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+	synchronizer, err := NewSynchronizer(cfg.Network.Protocol, chain, cfg.Network.Channel, cfg.Network.Namespace, cfg.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create gateway synchronizer: %w", err)
+		return nil, fmt.Errorf("failed to create synchronizer: %w", err)
 	}
 
 	// Create RPC server - use test server if explicitly enabled
@@ -221,12 +226,11 @@ func buildApp(ctx context.Context, cfg config.Config, gwSigner sdk.Signer, logge
 	}
 
 	return &App{
-		cfg:           cfg,
-		endorserSyncs: endorserSyncs,
-		gwSync:        gwSync,
-		gateway:       gateway,
-		chain:         chain,
-		rpcServer:     rpcServer,
+		cfg:          cfg,
+		synchronizer: synchronizer,
+		gateway:      gateway,
+		chain:        chain,
+		rpcServer:    rpcServer,
 	}, nil
 }
 
@@ -237,18 +241,11 @@ func (a *App) Run(ctx context.Context) error {
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	// Start synchronizers
-	for _, sync := range a.endorserSyncs {
-		g.Go(func() error { return sync.Start(gctx) })
-	}
-	g.Go(func() error { return a.gwSync.Start(gctx) })
+	g.Go(func() error { return a.synchronizer.Start(gctx) })
 
 	// Wait for initial sync before serving traffic
-	for i, sync := range a.endorserSyncs {
-		if err := WaitUntilSynced(gctx, sync, 10*time.Second); err != nil {
-			return err
-		}
-		appLogger.Debugf("endorser %d synced", i)
+	if err := WaitUntilSynced(gctx, a.synchronizer, a.cfg.Synchronizer.SyncTimeout()); err != nil {
+		return err
 	}
 
 	// Start gateway worker pool

--- a/gateway/app/app_test.go
+++ b/gateway/app/app_test.go
@@ -114,11 +114,11 @@ func endpoint(port int) common.ClientConfig {
 func splitAppConfig(t *testing.T, dbConnString string) config.Config {
 	t.Helper()
 	return config.Config{
-		Network: common.Network{Protocol: "fabric-x", Channel: "mychannel", Namespace: "basic", NsVersion: "1.0", ChainID: 4011},
+		Network:   common.Network{Protocol: "fabric-x", Channel: "mychannel", Namespace: "basic", NsVersion: "1.0", ChainID: 4011},
+		Committer: endpoint(2),
 		Gateway: config.Gateway{
 			Database:       config.DB{ConnString: dbConnString},
 			Orderers:       []common.ClientConfig{endpoint(1)},
-			Committer:      endpoint(2),
 			Endorsers:      []common.ClientConfig{endpoint(3)},
 			SubmitterCount: 1,
 		},

--- a/gateway/app/hybridx/hybrid.go
+++ b/gateway/app/hybridx/hybrid.go
@@ -44,7 +44,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 // the store that neither path will ever fill.
 //
 // HybridSynchronizer satisfies the app.Synchronizer interface (Start + Ready)
-// and plugs directly into NewGatewaySynchronizer as the fabric-x implementation.
+// and plugs directly into app.NewSynchronizer as the fabric-x implementation.
 package hybridx
 
 import (

--- a/gateway/app/testnode.go
+++ b/gateway/app/testnode.go
@@ -94,10 +94,6 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to start in-process network: %w", err)
 	}
-
-	orderer := &common.Endpoint{Host: "127.0.0.1", Port: nw.OrdererPort}
-	peer := &common.Endpoint{Host: "127.0.0.1", Port: nw.PeerPort}
-
 	cfg := config.Config{
 		Network: common.Network{
 			Protocol:  protocol,
@@ -106,15 +102,29 @@ func NewTestNode(ctx context.Context, tcfg TestNodeConfig) (*App, error) {
 			NsVersion: testNodeNsVersion,
 			ChainID:   tcfg.ChainID,
 		},
+		Committer: common.ClientConfig{
+			Endpoint: &common.Endpoint{
+				Host: "127.0.0.1",
+				Port: nw.PeerPort,
+			},
+		},
 		Gateway: config.Gateway{
-			Listen:    tcfg.Listen,
-			Database:  config.DB{ConnString: ":memory:"},
-			Orderers:  []common.ClientConfig{{Endpoint: orderer}},
-			Committer: common.ClientConfig{Endpoint: peer},
+			Listen: tcfg.Listen,
+			Database: config.DB{
+				ConnString: ":memory:",
+			},
+			Orderers: []common.ClientConfig{
+				{
+					Endpoint: &common.Endpoint{
+						Host: "127.0.0.1",
+						Port: nw.OrdererPort,
+					},
+				},
+			},
 		},
 	}
 
-	application, err := buildApp(ctx, cfg, signer, logger, []eapi.Service{directiveEndorser}, nil, endorserKVS, true, tcfg.TestAccountsPath, endorserKVS)
+	application, err := buildApp(ctx, cfg, signer, logger, []eapi.Service{directiveEndorser}, endorserKVS, true, tcfg.TestAccountsPath, endorserKVS)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/app/wiring.go
+++ b/gateway/app/wiring.go
@@ -57,15 +57,18 @@ func NewNetworkSubmitters(ctx context.Context, protocol string, orderers []netwo
 	return submitters, nil
 }
 
-// NewGatewaySynchronizer creates the protocol-appropriate synchronizer that delivers
-// committed blocks to handlers, in order. Callers decide the handler list (and therefore
-// the sync topology): a real backend typically registers only [chain, gateway], while an
-// in-process test backend with per-endorser-embedded synchronization instead registers
-// [endorser DBs..., chain, gateway] on a single synchronizer so that endorser state is
-// applied before the gateway marks a transaction complete.
+// NewSynchronizer creates the protocol-appropriate synchronizer that delivers
+// committed blocks to handlers, in order — the one synchronizer a process
+// runs, feeding every store it owns (chain, an embedded endorser's KVS,
+// gateway), not just the gateway. Callers decide the handler list (and
+// therefore the sync topology): a real backend typically registers only
+// [chain, gateway], while an in-process test backend with per-endorser-
+// embedded synchronization instead registers [endorser DBs..., chain,
+// gateway] on a single synchronizer so that endorser state is applied before
+// the gateway marks a transaction complete.
 //
 // namespace is used by the fabric-x hybrid synchronizer to filter the notification stream.
-func NewGatewaySynchronizer(protocol string, db network.BlockHeightReader, channel, namespace string, committer network.PeerConf, gwSigner sdk.Signer, logger sdk.Logger, handlers ...blocks.BlockHandler) (Synchronizer, error) {
+func NewSynchronizer(protocol string, db network.BlockHeightReader, channel, namespace string, committer network.PeerConf, gwSigner sdk.Signer, logger sdk.Logger, handlers ...blocks.BlockHandler) (Synchronizer, error) {
 	switch protocol {
 	case "fabric":
 		return nfab.NewSynchronizer(db, channel, committer, gwSigner, logger, handlers...)

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -23,11 +23,40 @@ import (
 type Config struct {
 	Logging Logging        `mapstructure:"logging"   yaml:"logging"`
 	Network common.Network `mapstructure:"network"   yaml:"network"`
-	Gateway Gateway        `mapstructure:"gateway"   yaml:"gateway"`
+
+	// Committer is this process's connection to the committer it stays in
+	// sync with. One synchronizer per process means one committer
+	// connection per process, so it lives here rather than under gateway:
+	// or endorser: even though today only the synchronizer consumes it.
+	Committer common.ClientConfig `mapstructure:"committer" yaml:"committer"`
+	// Synchronizer configures this process's single synchronizer, which
+	// delivers committed blocks to the chain, the embedded endorser's KVS,
+	// and the gateway.
+	Synchronizer Synchronizer `mapstructure:"synchronizer" yaml:"synchronizer"`
+
+	Gateway Gateway `mapstructure:"gateway"   yaml:"gateway"`
 
 	// Endorser configures this process's own, embedded endorser. A real
 	// deployment never embeds more than one.
 	Endorser *endorser.Endorser `mapstructure:"endorser" yaml:"endorser"`
+}
+
+// Synchronizer configures the process-wide synchronizer.
+type Synchronizer struct {
+	// Timeout bounds how long Run waits for the initial sync to complete
+	// before returning an error. Zero means DefaultSyncTimeout.
+	Timeout time.Duration `mapstructure:"timeout" yaml:"timeout"`
+}
+
+// DefaultSyncTimeout is used when Synchronizer.Timeout is unset.
+const DefaultSyncTimeout = 10 * time.Minute
+
+// SyncTimeout returns the configured timeout, or DefaultSyncTimeout.
+func (s Synchronizer) SyncTimeout() time.Duration {
+	if s.Timeout <= 0 {
+		return DefaultSyncTimeout
+	}
+	return s.Timeout
 }
 
 // Logging is the config for the Fabric Logger
@@ -60,14 +89,12 @@ type Gateway struct {
 	Identity common.IdentityConfig `mapstructure:"identity" yaml:"identity"`
 	Database DB                    `mapstructure:"database" yaml:"database"`
 
-	Orderers  []common.ClientConfig `mapstructure:"orderers" yaml:"orderers"`
-	Committer common.ClientConfig   `mapstructure:"committer" yaml:"committer"`
+	Orderers []common.ClientConfig `mapstructure:"orderers" yaml:"orderers"`
 
 	// Endorsers, when set, switches to split deployment: the gateway dials each
 	// entry over gRPC (co-located endorsers included, addressed on localhost)
 	// instead of embedding one from the top-level Endorser config.
-	Endorsers   []common.ClientConfig `mapstructure:"endorsers" yaml:"endorsers"`
-	SyncTimeout time.Duration         `mapstructure:"sync-timeout" yaml:"sync-timeout"`
+	Endorsers []common.ClientConfig `mapstructure:"endorsers" yaml:"endorsers"`
 
 	WorkerCount         int `mapstructure:"worker-count"  yaml:"worker-count"`
 	SubmitterCount      int `mapstructure:"submitter-count" yaml:"submitter-count"`
@@ -88,6 +115,9 @@ func (cfg Config) Validate() error {
 	if protocolErr != nil {
 		errs = append(errs, protocolErr)
 	}
+	if err := cfg.Committer.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("committer: %w", err))
+	}
 	if cfg.Gateway.Listen == "" {
 		errs = append(errs, errors.New("gateway.listen is required"))
 	} else if err := common.ValidateListenAddress(cfg.Gateway.Listen); err != nil {
@@ -98,9 +128,6 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.Gateway.Database.ConnString == "" {
 		errs = append(errs, errors.New("gateway.database.connection-string is required"))
-	}
-	if err := cfg.Gateway.Committer.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("gateway.committer: %w", err))
 	}
 	if len(cfg.Gateway.Orderers) == 0 {
 		errs = append(errs, errors.New("gateway.orderers must have at least one entry"))

--- a/gateway/config/validate_test.go
+++ b/gateway/config/validate_test.go
@@ -51,19 +51,18 @@ func validConfig(t *testing.T) config.Config {
 	client := common.ClientConfig{Endpoint: ep, TLS: tlsCfg}
 	identity := common.IdentityConfig{MspID: "Org1MSP", MSPDir: mspDir}
 	return config.Config{
-		Network: common.Network{Channel: "mychannel", Namespace: "basic"},
+		Network:   common.Network{Channel: "mychannel", Namespace: "basic"},
+		Committer: client,
 		Gateway: config.Gateway{
-			Listen:    "0.0.0.0:8545",
-			Identity:  identity,
-			Database:  config.DB{ConnString: "file:gw.db"},
-			Committer: client,
-			Orderers:  []common.ClientConfig{client},
+			Listen:   "0.0.0.0:8545",
+			Identity: identity,
+			Database: config.DB{ConnString: "file:gw.db"},
+			Orderers: []common.ClientConfig{client},
 		},
 		Endorser: &endorsercfg.Endorser{
-			Name:      "org1",
-			Identity:  identity,
-			Committer: client,
-			Database:  endorsercfg.DB{Database: "sqlite", ConnString: "file:e.db"},
+			Name:     "org1",
+			Identity: identity,
+			Database: endorsercfg.DB{Database: "sqlite", ConnString: "file:e.db"},
 		},
 	}
 }
@@ -85,8 +84,8 @@ func TestConfigValidate(t *testing.T) {
 		{"missing identity msp-dir", func(c *config.Config) { c.Gateway.Identity.MSPDir = "" }, "msp-dir"},
 		{"msp-dir not exist", func(c *config.Config) { c.Gateway.Identity.MSPDir = "/no/such/dir" }, "msp-dir"},
 		{"missing db conn-string", func(c *config.Config) { c.Gateway.Database.ConnString = "" }, "gateway.database.connection-string"},
-		{"nil committer endpoint", func(c *config.Config) { c.Gateway.Committer.Endpoint = nil }, "endpoint"},
-		{"missing committer cert", func(c *config.Config) { c.Gateway.Committer.TLS.CertPath = "/no/cert" }, "tls.cert-path"},
+		{"nil committer endpoint", func(c *config.Config) { c.Committer.Endpoint = nil }, "endpoint"},
+		{"missing committer cert", func(c *config.Config) { c.Committer.TLS.CertPath = "/no/cert" }, "tls.cert-path"},
 		{"no orderers", func(c *config.Config) { c.Gateway.Orderers = nil }, "gateway.orderers"},
 		{"orderer nil endpoint", func(c *config.Config) { c.Gateway.Orderers[0].Endpoint = nil }, "endpoint"},
 		{"orderer missing ca cert", func(c *config.Config) { c.Gateway.Orderers[0].TLS.CACertPaths = []string{"/no/ca"} }, "tls.ca-cert-paths"},
@@ -98,7 +97,7 @@ func TestConfigValidate(t *testing.T) {
 			c.Endorser.Database.Database = ""
 		}, "database"},
 		{"split mode: gateway.endorsers set, no embedded endorser is fine", func(c *config.Config) {
-			c.Gateway.Endorsers = []common.ClientConfig{c.Gateway.Committer}
+			c.Gateway.Endorsers = []common.ClientConfig{c.Committer}
 			c.Endorser = nil
 		}, ""},
 		{"split mode: invalid gateway.endorsers entry reported", func(c *config.Config) {
@@ -106,7 +105,7 @@ func TestConfigValidate(t *testing.T) {
 			c.Endorser = nil
 		}, "gateway.endorsers[0]"},
 		{"both endorser and gateway.endorsers set", func(c *config.Config) {
-			c.Gateway.Endorsers = []common.ClientConfig{c.Gateway.Committer}
+			c.Gateway.Endorsers = []common.ClientConfig{c.Committer}
 		}, "mutually exclusive"},
 	}
 

--- a/integration/fablo-org1.yaml
+++ b/integration/fablo-org1.yaml
@@ -12,19 +12,20 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 7041
+  tls:
+    mode: tls
+    server-name: peer0.org1.example.com
+    ca-cert-paths:
+      - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 7041
-    tls:
-      mode: tls
-      server-name: peer0.org1.example.com
-      ca-cert-paths:
-        - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
   database:
     database: memory

--- a/integration/fablo-org2.yaml
+++ b/integration/fablo-org2.yaml
@@ -14,19 +14,20 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 7061
+  tls:
+    mode: tls
+    server-name: peer0.org2.example.com
+    ca-cert-paths:
+      - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
+
 endorser:
   name: org2
   identity:
     msp-id: Org2MSP
     msp-dir: ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 7061
-    tls:
-      mode: tls
-      server-name: peer0.org2.example.com
-      ca-cert-paths:
-        - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
   database:
     database: memory

--- a/integration/fablo.hardhat.yaml
+++ b/integration/fablo.hardhat.yaml
@@ -12,6 +12,16 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 7041
+  tls:
+    mode: tls
+    server-name: peer0.org1.example.com
+    ca-cert-paths:
+      - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+
 gateway:
   listen: "0.0.0.0:8545"
 
@@ -33,29 +43,10 @@ gateway:
         ca-cert-paths:
           - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/tlsca/tlsca.orderer.example.com-cert.pem
 
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 7041
-    tls:
-      mode: tls
-      server-name: peer0.org1.example.com
-      ca-cert-paths:
-        - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
-
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 7041
-    tls:
-      mode: tls
-      server-name: peer0.org1.example.com
-      ca-cert-paths:
-        - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
   database:
     database: memory

--- a/integration/fablo.yaml
+++ b/integration/fablo.yaml
@@ -19,6 +19,16 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 7041
+  tls:
+    mode: tls
+    server-name: peer0.org1.example.com
+    ca-cert-paths:
+      - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+
 gateway:
   listen: "0.0.0.0:8545"
 
@@ -39,16 +49,6 @@ gateway:
         server-name: orderer0.group1.orderer.example.com
         ca-cert-paths:
           - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/tlsca/tlsca.orderer.example.com-cert.pem
-
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 7041
-    tls:
-      mode: tls
-      server-name: peer0.org1.example.com
-      ca-cert-paths:
-        - ../testdata/fablo/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
 
   # Split deployment: dial org1's and org2's endorsers over gRPC rather than
   # embedding them. Both entries present the gateway's own (org1) client cert;

--- a/integration/fabx-2of2-org1.yaml
+++ b/integration/fabx-2of2-org1.yaml
@@ -12,20 +12,21 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
+    key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
+    ca-cert-paths:
+      - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: ../testdata/crypto/peerOrganizations/org1.example.com/peers/endorser.org1.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
   database:
     database: memory

--- a/integration/fabx-2of2-org2.yaml
+++ b/integration/fabx-2of2-org2.yaml
@@ -12,24 +12,25 @@ network:
 logging:
   spec: info
 
+# Block sync runs against the single committer this test network provides,
+# org1's, which is issued by and trusts only org1's TLS CA - hence org1
+# material here. This is transport auth only; the endorsement identity the
+# policy is evaluated against is Org2MSP below.
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
+    key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
+    ca-cert-paths:
+      - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
 endorser:
   name: org2
   identity:
     msp-id: Org2MSP
     msp-dir: ../testdata/crypto/peerOrganizations/org2.example.com/peers/endorser.org2.example.com/msp
-  # Block sync runs against the single committer this test network provides,
-  # org1's, which is issued by and trusts only org1's TLS CA - hence org1
-  # material here. This is transport auth only; the endorsement identity
-  # the policy is evaluated against is Org2MSP above.
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
   database:
     database: memory

--- a/integration/fabx-2of2.yaml
+++ b/integration/fabx-2of2.yaml
@@ -18,6 +18,17 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
+    key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
+    ca-cert-paths:
+      - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
 gateway:
   listen: "0.0.0.0:8546"
 
@@ -38,17 +49,6 @@ gateway:
         key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
         ca-cert-paths:
           - ../testdata/crypto/ordererOrganizations/orderer-org-1/tlsca/tlsca.orderer-org-1-cert.pem
-
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
 
   # Split deployment: dial org1's and org2's endorsers over gRPC rather than
   # embedding them. Both entries present the gateway's own (org1) client

--- a/integration/fabx-full.yaml
+++ b/integration/fabx-full.yaml
@@ -11,6 +11,17 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
+    key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
+    ca-cert-paths:
+      - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
 gateway:
   listen: "0.0.0.0:8545"
 
@@ -60,32 +71,11 @@ gateway:
         ca-cert-paths:
           - ../testdata/crypto/ordererOrganizations/orderer-org-4/tlsca/tlsca.orderer-org-4-cert.pem
 
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
-
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: ../testdata/crypto/peerOrganizations/org1.example.com/peers/endorser.org1.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
   database:
     database: memory
     # connection-string: "file:endorser-org1.db?mode=memory&cache=shared"

--- a/integration/fabx.yaml
+++ b/integration/fabx.yaml
@@ -11,6 +11,17 @@ network:
 logging:
   spec: info
 
+committer:
+  endpoint:
+    host: 127.0.0.1
+    port: 4001
+  tls:
+    mode: mtls
+    cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
+    key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
+    ca-cert-paths:
+      - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
 gateway:
   listen: "0.0.0.0:8545"
 
@@ -33,32 +44,11 @@ gateway:
         ca-cert-paths:
           - ../testdata/crypto/ordererOrganizations/orderer-org-1/tlsca/tlsca.orderer-org-1-cert.pem
 
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
-
 endorser:
   name: org1
   identity:
     msp-id: Org1MSP
     msp-dir: ../testdata/crypto/peerOrganizations/org1.example.com/peers/endorser.org1.example.com/msp
-  committer:
-    endpoint:
-      host: 127.0.0.1
-      port: 4001
-    tls:
-      mode: mtls
-      cert-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.crt
-      key-path: ../testdata/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/tls/client.key
-      ca-cert-paths:
-        - ../testdata/crypto/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
   database:
     database: memory
     # connection-string: "file:endorser-org1.db?mode=memory&cache=shared"

--- a/integration/split_endorsers.go
+++ b/integration/split_endorsers.go
@@ -127,7 +127,7 @@ func startEndorserGRPCServer(t *testing.T, configFile string, trustedCAs []strin
 	// A plain logger, not TestLogger: the synchronizer logs from goroutines
 	// that outlive the test, and t.Logf panics once the test has finished.
 	logger := sdk.NewStdLogger("endorser-" + ecfg.Name)
-	end, sync, _, err := eapp.NewEndorser(ecfg, cfg.Network, signer, logger, false)
+	end, sync, _, err := eapp.NewEndorser(ecfg, cfg.Network, cfg.Committer, signer, logger, false)
 	if err != nil {
 		t.Fatalf("%s: NewEndorser: %v", ecfg.Name, err)
 	}
@@ -219,7 +219,7 @@ func buildSplitGatewayApp(t *testing.T, configFile, org1Addr, org2Addr string) (
 // The single-process harness tests need none of this. They register
 // [endorser KVS..., chain, gateway] on one synchronizer, so endorser state is
 // always applied before the gateway marks a transaction complete -- see
-// app.NewGatewaySynchronizer.
+// app.NewSynchronizer.
 //
 // The account nonce is used as the marker because an endorser applies a block's
 // state in one step: once the nonce reflects the transaction, that same

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -257,7 +257,7 @@ func buildTestHarness(t *testing.T, logger sdk.Logger, cfg config.Config, evmCon
 	// The ordering is the responsibility of the chainFactory; see defaultHandlerChain for
 	// the conventional ordering (endorser KVS…, chain store, gateway, extra observers…).
 	if !bypass {
-		sync, err = app.NewGatewaySynchronizer(cfg.Network.Protocol, heightReader, cfg.Network.Channel, cfg.Network.Namespace, cfg.Gateway.Committer.ToPeerConf(), gwSigner, logger, handlers...)
+		sync, err = app.NewSynchronizer(cfg.Network.Protocol, heightReader, cfg.Network.Channel, cfg.Network.Namespace, cfg.Committer.ToPeerConf(), gwSigner, logger, handlers...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -405,22 +405,19 @@ func NewLocalTestHarnessWithFactory(t *testing.T, logger sdk.Logger, evmConfig e
 			NsVersion: "1.0",
 			ChainID:   4011,
 		},
+		Committer:    common.ClientConfig{Endpoint: peer},
+		Synchronizer: config.Synchronizer{Timeout: 2 * time.Second},
 		Gateway: config.Gateway{
 			Database: config.DB{
 				ConnString: filepath.Join(dir, "gateway.db"),
 				TriePath:   filepath.Join(dir, "triedb.db"),
 			},
-			SyncTimeout: 2 * time.Second,
 			Orderers: []common.ClientConfig{
 				{Endpoint: orderer},
 			},
-			Committer: common.ClientConfig{
-				Endpoint: peer,
-			},
 		},
 		Endorser: &econf.Endorser{
-			Committer: common.ClientConfig{Endpoint: peer},
-			Name:      "endorser1",
+			Name: "endorser1",
 			Database: econf.DB{
 				Database:    "memory",
 				ConnString:  filepath.Join(dir, "endorser1.db"),


### PR DESCRIPTION
Committer is now a top level config key. The App has a single synchronizer, instead of having one for the endorser (world state) path and another for the gateway (block/tx store) path.