### PR TITLE
feat(gateway): implement hardhat_setStorageAt via the directive endorser

### DIFF
--- a/common/proposal.go
+++ b/common/proposal.go
@@ -16,6 +16,9 @@ const (
 	// ProposalTypeSetCode marks a setCode invocation's first arg so
 	// ConvertToDomain can filter it out; it is not a discriminator.
 	ProposalTypeSetCode ProposalType = 0xf9
+	// ProposalTypeSetStorageAt marks a setStorageAt invocation's first arg so
+	// ConvertToDomain can filter it out; it is not a discriminator.
+	ProposalTypeSetStorageAt ProposalType = 0xf8
 )
 
 const (

--- a/endorser/testimpl/directive_endorser.go
+++ b/endorser/testimpl/directive_endorser.go
@@ -101,3 +101,21 @@ func (d *DirectiveEndorser) SetCode(ctx context.Context, inv endorsement.Invocat
 	stateDB.SetCode(addr, code, tracing.CodeChangeUnspecified)
 	return d.builder.Endorse(inv, endorsement.Success(stateDB.Result(), nil, nil))
 }
+
+// SetStorageAt forces addr's storage slot key to value and endorses the
+// resulting read-write set.
+func (d *DirectiveEndorser) SetStorageAt(ctx context.Context, inv endorsement.Invocation, addr common.Address, key, value common.Hash) (*peer.ProposalResponse, error) {
+	reader, err := d.kvs.NewSnapshot(nil)
+	if err != nil {
+		return nil, fmt.Errorf("setStorageAt directive: snapshot: %w", err)
+	}
+	defer reader.Close()
+
+	stateDB, err := execution.NewStateDB(ctx, reader, d.namespace, 0, d.monotonicVersions)
+	if err != nil {
+		return nil, fmt.Errorf("setStorageAt directive: statedb: %w", err)
+	}
+
+	stateDB.SetState(addr, key, value)
+	return d.builder.Endorse(inv, endorsement.Success(stateDB.Result(), nil, nil))
+}

--- a/endorser/testimpl/directive_endorser_test.go
+++ b/endorser/testimpl/directive_endorser_test.go
@@ -163,6 +163,80 @@ func TestSetCode_ClearWithEmpty(t *testing.T) {
 	}
 }
 
+// storageFromRWS returns the storage word a read-write set writes for
+// addr/key, or nil when the set contains no such write.
+func storageFromRWS(rws blocks.ReadWriteSet, addr ethcommon.Address, key ethcommon.Hash) []byte {
+	k := "str:" + addr.Hex() + ":" + key.Hex()
+	for _, w := range rws.Writes {
+		if w.Key == k {
+			if w.IsDelete {
+				return []byte{}
+			}
+			return w.Value
+		}
+	}
+	return nil
+}
+
+func TestSetStorageAt_Set(t *testing.T) {
+	kvs := estorage.NewLightKVS(8)
+	b := &noopBuilder{}
+	d := NewDirectiveEndorser(nil, kvs, testNS, b, true)
+
+	key := ethcommon.HexToHash("0x1")
+	value := ethcommon.HexToHash("0x2a")
+	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, value); err != nil {
+		t.Fatalf("SetStorageAt: %v", err)
+	}
+	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if !bytes.Equal(got, value.Bytes()) {
+		t.Fatalf("storage write = %x, want %x", got, value.Bytes())
+	}
+}
+
+func TestSetStorageAt_Overwrite(t *testing.T) {
+	kvs := estorage.NewLightKVS(8)
+	b := &noopBuilder{}
+	d := NewDirectiveEndorser(nil, kvs, testNS, b, true)
+
+	key := ethcommon.HexToHash("0x1")
+	first := ethcommon.HexToHash("0x2a")
+	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, first); err != nil {
+		t.Fatalf("seed SetStorageAt: %v", err)
+	}
+	commitRWS(t, kvs, testNS, b.lastRWS)
+
+	second := ethcommon.HexToHash("0x2b")
+	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, second); err != nil {
+		t.Fatalf("SetStorageAt: %v", err)
+	}
+	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if !bytes.Equal(got, second.Bytes()) {
+		t.Fatalf("storage write = %x, want %x", got, second.Bytes())
+	}
+}
+
+func TestSetStorageAt_ClearWithZero(t *testing.T) {
+	kvs := estorage.NewLightKVS(8)
+	b := &noopBuilder{}
+	d := NewDirectiveEndorser(nil, kvs, testNS, b, true)
+
+	key := ethcommon.HexToHash("0x1")
+	value := ethcommon.HexToHash("0x2a")
+	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, value); err != nil {
+		t.Fatalf("seed SetStorageAt: %v", err)
+	}
+	commitRWS(t, kvs, testNS, b.lastRWS)
+
+	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, ethcommon.Hash{}); err != nil {
+		t.Fatalf("SetStorageAt: %v", err)
+	}
+	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if len(got) != 0 {
+		t.Fatalf("storage write after clear = %x, want empty", got)
+	}
+}
+
 func TestSetBalance_AmountOverflowsUint256(t *testing.T) {
 	kvs := estorage.NewLightKVS(2)
 	d := NewDirectiveEndorser(nil, kvs, testNS, &noopBuilder{}, true)

--- a/endorser/testimpl/directive_endorser_test.go
+++ b/endorser/testimpl/directive_endorser_test.go
@@ -163,19 +163,20 @@ func TestSetCode_ClearWithEmpty(t *testing.T) {
 	}
 }
 
-// storageFromRWS returns the storage word a read-write set writes for
-// addr/key, or nil when the set contains no such write.
-func storageFromRWS(rws blocks.ReadWriteSet, addr ethcommon.Address, key ethcommon.Hash) []byte {
+// storageFromRWS returns the storage word a read-write set writes for addr/key.
+// A cleared slot and an absent write both yield an empty word, so the second
+// result reports whether the write was there at all.
+func storageFromRWS(rws blocks.ReadWriteSet, addr ethcommon.Address, key ethcommon.Hash) ([]byte, bool) {
 	k := "str:" + addr.Hex() + ":" + key.Hex()
 	for _, w := range rws.Writes {
 		if w.Key == k {
 			if w.IsDelete {
-				return []byte{}
+				return []byte{}, true
 			}
-			return w.Value
+			return w.Value, true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 func TestSetStorageAt_Set(t *testing.T) {
@@ -188,7 +189,10 @@ func TestSetStorageAt_Set(t *testing.T) {
 	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, value); err != nil {
 		t.Fatalf("SetStorageAt: %v", err)
 	}
-	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	got, ok := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if !ok {
+		t.Fatal("no storage write in the read-write set")
+	}
 	if !bytes.Equal(got, value.Bytes()) {
 		t.Fatalf("storage write = %x, want %x", got, value.Bytes())
 	}
@@ -210,7 +214,10 @@ func TestSetStorageAt_Overwrite(t *testing.T) {
 	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, second); err != nil {
 		t.Fatalf("SetStorageAt: %v", err)
 	}
-	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	got, ok := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if !ok {
+		t.Fatal("no storage write in the read-write set")
+	}
 	if !bytes.Equal(got, second.Bytes()) {
 		t.Fatalf("storage write = %x, want %x", got, second.Bytes())
 	}
@@ -231,7 +238,10 @@ func TestSetStorageAt_ClearWithZero(t *testing.T) {
 	if _, err := d.SetStorageAt(context.Background(), testInvocation(), directiveTestAddr, key, ethcommon.Hash{}); err != nil {
 		t.Fatalf("SetStorageAt: %v", err)
 	}
-	got := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	got, ok := storageFromRWS(b.lastRWS, directiveTestAddr, key)
+	if !ok {
+		t.Fatal("clear produced no storage write in the read-write set")
+	}
 	if len(got) != 0 {
 		t.Fatalf("storage write after clear = %x, want empty", got)
 	}

--- a/gateway/api/eth.go
+++ b/gateway/api/eth.go
@@ -201,8 +201,9 @@ func (api *EthAPI) GetCode(ctx context.Context, addr common.Address, block rpc.B
 	return result, nil
 }
 
-// decodeStorageKey left-pads a quantity-encoded storage slot to 32 bytes, as geth does.
-func decodeStorageKey(s string) (common.Hash, error) {
+// DecodeStorageWord left-pads a quantity-encoded storage word to 32 bytes, as geth
+// does. what names the field in error messages.
+func DecodeStorageWord(what, s string) (common.Hash, error) {
 	key := s
 	if strings.HasPrefix(key, "0x") || strings.HasPrefix(key, "0X") {
 		key = key[2:]
@@ -211,11 +212,11 @@ func decodeStorageKey(s string) (common.Hash, error) {
 		key = "0" + key
 	}
 	if len(key) > 2*common.HashLength {
-		return common.Hash{}, rpcerr.InvalidParams("storage key too long (want at most 32 bytes): %q", s)
+		return common.Hash{}, rpcerr.InvalidParams("%s too long (want at most 32 bytes): %q", what, s)
 	}
 	b, err := hex.DecodeString(key)
 	if err != nil {
-		return common.Hash{}, rpcerr.InvalidParams("invalid hex in storage key: %q", s)
+		return common.Hash{}, rpcerr.InvalidParams("invalid hex in %s: %q", what, s)
 	}
 	return common.BytesToHash(b), nil
 }
@@ -223,7 +224,7 @@ func decodeStorageKey(s string) (common.Hash, error) {
 // eth_getStorageAt
 func (api *EthAPI) GetStorageAt(ctx context.Context, addr common.Address, hexSlot string, block rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	logger.Debugf("EthAPI.GetStorageAt() called with addr=%s, slot=%s", addr.Hex(), hexSlot)
-	slot, err := decodeStorageKey(hexSlot)
+	slot, err := DecodeStorageWord("storage key", hexSlot)
 	if err != nil {
 		logger.Debugf("EthAPI.GetStorageAt() returning error: %v", err)
 		return nil, err

--- a/gateway/app/testnode_setstorageat_test.go
+++ b/gateway/app/testnode_setstorageat_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: LGPL-3.0-or-later
+*/
+
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	gwapi "github.com/hyperledger/fabric-x-evm/gateway/api"
+	"github.com/hyperledger/fabric-x-evm/gateway/testimpl"
+)
+
+// TestTestNode_HardhatSetStorageAt exercises hardhat_setStorageAt end-to-end
+// against the self-contained testnode: set + immediate read, overwriting the
+// same slot, and clearing a slot to zero.
+func TestTestNode_HardhatSetStorageAt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	application, err := NewTestNode(ctx, TestNodeConfig{
+		Listen:  "127.0.0.1:0",
+		ChainID: 31337,
+	})
+	if err != nil {
+		t.Fatalf("NewTestNode: %v", err)
+	}
+
+	// The commit pipeline only runs once the app is started, so run it in the background.
+	runCtx, runCancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- application.Run(runCtx) }()
+	t.Cleanup(func() {
+		runCancel()
+		select {
+		case <-runErr:
+		case <-time.After(15 * time.Second):
+			t.Log("timed out waiting for App.Run to return")
+		}
+	})
+
+	gw := application.Gateway()
+
+	waitReady(t, ctx, gw)
+
+	// Drive the RPC the way a client would: in-proc server over the real hardhat + eth APIs.
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("hardhat", testimpl.NewHardhatAPI(gw)); err != nil {
+		t.Fatalf("register hardhat: %v", err)
+	}
+	if err := srv.RegisterName("eth", gwapi.NewEthAPI(gw)); err != nil {
+		t.Fatalf("register eth: %v", err)
+	}
+	rc := rpc.DialInProc(srv)
+	t.Cleanup(rc.Close)
+	ec := ethclient.NewClient(rc)
+
+	addr := common.HexToAddress("0x00000000000000000000000000000000C0DE0043")
+	slot := common.HexToHash("0x1")
+
+	// --- Check 1: set + immediate read (sync guarantee) ---
+	value := common.HexToHash("0x2a")
+	setStorageAt(t, ctx, rc, addr, slot, value)
+
+	got, err := ec.StorageAt(ctx, addr, slot, nil)
+	if err != nil {
+		t.Fatalf("eth_getStorageAt (after set): %v", err)
+	}
+	if common.BytesToHash(got) != value {
+		t.Fatalf("storage after set = %s, want %s", hexutil.Encode(got), value.Hex())
+	}
+
+	// --- Check 2: overwriting the same slot lands the new value ---
+	overwrite := common.HexToHash("0x2b")
+	setStorageAt(t, ctx, rc, addr, slot, overwrite)
+
+	got, err = ec.StorageAt(ctx, addr, slot, nil)
+	if err != nil {
+		t.Fatalf("eth_getStorageAt (after overwrite): %v", err)
+	}
+	if common.BytesToHash(got) != overwrite {
+		t.Fatalf("storage after overwrite = %s, want %s", hexutil.Encode(got), overwrite.Hex())
+	}
+
+	// --- Check 3: setting a slot to zero clears it ---
+	setStorageAt(t, ctx, rc, addr, slot, common.Hash{})
+
+	got, err = ec.StorageAt(ctx, addr, slot, nil)
+	if err != nil {
+		t.Fatalf("eth_getStorageAt (after clear): %v", err)
+	}
+	if common.BytesToHash(got) != (common.Hash{}) {
+		t.Fatalf("storage after clear = %s, want zero", hexutil.Encode(got))
+	}
+
+	// --- Check 4: quantity-style short hex, which is what Hardhat actually sends ---
+	var ok bool
+	if err := rc.CallContext(ctx, &ok, "hardhat_setStorageAt", addr, "0x2", "0x2c"); err != nil {
+		t.Fatalf("hardhat_setStorageAt with short hex: %v", err)
+	}
+
+	got, err = ec.StorageAt(ctx, addr, common.HexToHash("0x2"), nil)
+	if err != nil {
+		t.Fatalf("eth_getStorageAt (after short hex): %v", err)
+	}
+	if common.BytesToHash(got) != common.HexToHash("0x2c") {
+		t.Fatalf("storage after short hex = %s, want 0x2c", hexutil.Encode(got))
+	}
+}
+
+// setStorageAt drives hardhat_setStorageAt over RPC the way Hardhat does:
+// slot and value are passed as "0x…" quantity-style hex strings.
+func setStorageAt(t *testing.T, ctx context.Context, rc *rpc.Client, addr common.Address, slot, value common.Hash) {
+	t.Helper()
+	var ok bool
+	if err := rc.CallContext(ctx, &ok, "hardhat_setStorageAt", addr, slot.Hex(), value.Hex()); err != nil {
+		t.Fatalf("hardhat_setStorageAt(%s, %s, %s): %v", addr.Hex(), slot.Hex(), value.Hex(), err)
+	}
+	if !ok {
+		t.Fatalf("hardhat_setStorageAt(%s, %s, %s) returned false", addr.Hex(), slot.Hex(), value.Hex())
+	}
+}

--- a/gateway/app/testnode_setstorageat_test.go
+++ b/gateway/app/testnode_setstorageat_test.go
@@ -117,8 +117,8 @@ func TestTestNode_HardhatSetStorageAt(t *testing.T) {
 	}
 }
 
-// setStorageAt drives hardhat_setStorageAt over RPC the way Hardhat does:
-// slot and value are passed as "0x…" quantity-style hex strings.
+// setStorageAt drives hardhat_setStorageAt over RPC with fully padded 32-byte
+// slot and value; check 4 covers the quantity-style short form separately.
 func setStorageAt(t *testing.T, ctx context.Context, rc *rpc.Client, addr common.Address, slot, value common.Hash) {
 	t.Helper()
 	var ok bool

--- a/gateway/core/api.go
+++ b/gateway/core/api.go
@@ -314,6 +314,51 @@ func (g *Gateway) SetCode(ctx context.Context, addr common.Address, code []byte)
 	}
 }
 
+// SetStorageAt submits a setStorageAt directive and blocks until the storage change
+// is observable. Like SetBalance, it bypasses ValidateTx/TxQueue and commit is
+// observed by polling the target storage slot directly.
+func (g *Gateway) SetStorageAt(ctx context.Context, addr common.Address, key, value common.Hash) error {
+	if got, err := g.StorageAt(ctx, addr, key, nil); err == nil && common.BytesToHash(got) == value {
+		return nil
+	}
+
+	end, err := g.endorsers.SetStorageAt(ctx, addr, key, value)
+	if err != nil {
+		return fmt.Errorf("endorse setStorageAt: %w", err)
+	}
+
+	hash, err := newDirectiveTxHash()
+	if err != nil {
+		return fmt.Errorf("build directive tx hash: %w", err)
+	}
+
+	if err := g.SubmitFabricTx(ctx, hash, end); err != nil {
+		return err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, directiveCommitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(directivePollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("setStorageAt commit wait: %w", waitCtx.Err())
+		case <-ticker.C:
+			got, err := g.StorageAt(waitCtx, addr, key, nil)
+			if err != nil {
+				// Transient read error while committing; keep polling until timeout.
+				continue
+			}
+			if common.BytesToHash(got) == value {
+				return nil
+			}
+		}
+	}
+}
+
 // newDirectiveTxHash returns a unique hash to track a directive through SubmitFabricTx.
 func newDirectiveTxHash() (common.Hash, error) {
 	var h common.Hash

--- a/gateway/core/endorse.go
+++ b/gateway/core/endorse.go
@@ -109,6 +109,27 @@ func (e EndorsementClient) SetCode(ctx context.Context, addr ethcommon.Address, 
 	})
 }
 
+// storageSetter is implemented only by the test-only directive endorser.
+type storageSetter interface {
+	SetStorageAt(ctx context.Context, inv endorsement.Invocation, addr ethcommon.Address, key, value ethcommon.Hash) (*peer.ProposalResponse, error)
+}
+
+// SetStorageAt forwards a setStorageAt directive to every endorser.
+func (e EndorsementClient) SetStorageAt(ctx context.Context, addr ethcommon.Address, key, value ethcommon.Hash) (sdk.Endorsement, error) {
+	inv, err := e.createInvocation([][]byte{{byte(common.ProposalTypeSetStorageAt)}, addr.Bytes(), key.Bytes(), value.Bytes()})
+	if err != nil {
+		return sdk.Endorsement{}, err
+	}
+
+	return e.endorse(ctx, inv, "process setStorageAt directive", func(ctx context.Context, s api.Service, inv endorsement.Invocation, _ time.Time) (*peer.ProposalResponse, error) {
+		ss, ok := s.(storageSetter)
+		if !ok {
+			return nil, fmt.Errorf("endorser %T does not support setStorageAt directives", s)
+		}
+		return ss.SetStorageAt(ctx, inv, addr, key, value)
+	})
+}
+
 // endorse fans the invocation out to every endorser via call and assembles the
 // endorsement. label identifies the invocation kind in the error message.
 func (e EndorsementClient) endorse(ctx context.Context, inv endorsement.Invocation, label string,

--- a/gateway/testimpl/hardhat_helpers.go
+++ b/gateway/testimpl/hardhat_helpers.go
@@ -19,21 +19,23 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	estorage "github.com/hyperledger/fabric-x-evm/endorser/storage"
+	gwapi "github.com/hyperledger/fabric-x-evm/gateway/api"
 	"github.com/hyperledger/fabric-x-evm/gateway/storage"
 )
 
 var hardhatLogger = flogging.MustGetLogger("gateway.testimpl.hardhat")
 
-// StateSetter submits setBalance/setCode directives and blocks until each
-// commits; satisfied by *core.Gateway.
+// StateSetter submits setBalance/setCode/setStorageAt directives and blocks
+// until each commits; satisfied by *core.Gateway.
 type StateSetter interface {
 	SetBalance(ctx context.Context, addr common.Address, amount *big.Int) error
 	SetCode(ctx context.Context, addr common.Address, code []byte) error
+	SetStorageAt(ctx context.Context, addr common.Address, key, value common.Hash) error
 }
 
 // HardhatAPI provides Hardhat-specific RPC methods for testing.
-// Most methods are stubs that let Hardhat tests run; SetBalance and SetCode are
-// backed by real system directives via the gateway.
+// Most methods are stubs that let Hardhat tests run; SetBalance, SetCode and
+// SetStorageAt are backed by real system directives via the gateway.
 //
 // SECURITY WARNING: These methods are for testing only and should NEVER
 // be enabled in production environments.
@@ -59,6 +61,25 @@ func (api *HardhatAPI) SetBalance(ctx context.Context, addr common.Address, bala
 func (api *HardhatAPI) SetCode(ctx context.Context, address common.Address, code hexutil.Bytes) (bool, error) {
 	hardhatLogger.Debugf("HardhatAPI.SetCode() called with address=%s, code length=%d", address.Hex(), len(code))
 	if err := api.submit.SetCode(ctx, address, code); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetStorageAt sets an account's storage slot (hardhat_setStorageAt), blocking
+// until committed and reflected in reads of the slot. Hardhat sends slot and
+// value as quantity-style hex strings, so both are decoded like eth_getStorageAt.
+func (api *HardhatAPI) SetStorageAt(ctx context.Context, address common.Address, slot string, value string) (bool, error) {
+	hardhatLogger.Debugf("HardhatAPI.SetStorageAt() called with address=%s, slot=%s, value=%s", address.Hex(), slot, value)
+	key, err := gwapi.DecodeStorageWord("storage key", slot)
+	if err != nil {
+		return false, err
+	}
+	val, err := gwapi.DecodeStorageWord("storage value", value)
+	if err != nil {
+		return false, err
+	}
+	if err := api.submit.SetStorageAt(ctx, address, key, val); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/gateway/testimpl/hardhat_helpers_test.go
+++ b/gateway/testimpl/hardhat_helpers_test.go
@@ -27,6 +27,8 @@ type stubDirectiveSubmitter struct {
 	lastAddr   common.Address
 	lastAmount *big.Int
 	lastCode   []byte
+	lastKey    common.Hash
+	lastValue  common.Hash
 	err        error
 }
 
@@ -39,6 +41,13 @@ func (s *stubDirectiveSubmitter) SetBalance(_ context.Context, addr common.Addre
 func (s *stubDirectiveSubmitter) SetCode(_ context.Context, addr common.Address, code []byte) error {
 	s.lastAddr = addr
 	s.lastCode = code
+	return s.err
+}
+
+func (s *stubDirectiveSubmitter) SetStorageAt(_ context.Context, addr common.Address, key, value common.Hash) error {
+	s.lastAddr = addr
+	s.lastKey = key
+	s.lastValue = value
 	return s.err
 }
 

--- a/gateway/testimpl/server.go
+++ b/gateway/testimpl/server.go
@@ -61,8 +61,9 @@ func NewTestServer(b api.Backend, testAccounts []common.Address, testAccountKeys
 		return nil, err
 	}
 
-	// Register Hardhat helper APIs for test compatibility. hardhat_setBalance and
-	// hardhat_setCode submit system directives, so the backend must be a StateSetter.
+	// Register Hardhat helper APIs for test compatibility. hardhat_setBalance,
+	// hardhat_setCode and hardhat_setStorageAt submit system directives, so the
+	// backend must be a StateSetter.
 	submitter, ok := b.(StateSetter)
 	if !ok {
 		return nil, fmt.Errorf("test RPC backend %T does not implement StateSetter", b)

--- a/testdata/oz_known_failures.json
+++ b/testdata/oz_known_failures.json
@@ -173,8 +173,7 @@
     "cause": "execution reverted"
   },
   {
-    "id": "AccessManager #execute restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager #execute restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager #execute restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -222,8 +221,7 @@
     "cause": "execution reverted"
   },
   {
-    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager access managed self operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -258,8 +256,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager access managed target operations when calling a restricted target function restrictions when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -294,8 +291,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetClosed restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -348,8 +344,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #setTargetFunctionRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -402,8 +397,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations not subject to a delay #updateAuthority restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -456,8 +450,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #grantRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -512,8 +505,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations not subject to a delay role admin operations #revokeRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -553,8 +545,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations subject to a delay #labelRole restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -607,8 +598,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setGrantDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -671,8 +661,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleAdmin restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -725,8 +714,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setRoleGuardian restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -779,8 +767,7 @@
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
   },
   {
-    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"succeeds\"",
-    "cause": "hardhat_setStorageAt"
+    "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector succeeds"
   },
   {
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay restrictions when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect with operation delay when operation delay is greater than execution delay when operation is not scheduled reverts as AccessManagerNotScheduled",
@@ -841,10 +828,6 @@
     "id": "AccessManager admin operations subject to a delay #setTargetAdminDelay when reducing the delay \"before each\" hook: sets old delay for \"increases the delay after minsetback\"",
     "cause": "hardhat-time-rpc",
     "note": "AccessManager gates hasRole()/canCall() on Time.timestamp() reaching a scheduled 'since' timestamp, but evm_increaseTime/evm_setNextBlockTimestamp are no-ops (COMPATIBILITY.md), so that point is never reached in real test time. Manifests as AccessManagerUnauthorizedAccount instead of NotScheduled/NotReady, or stuck getter values."
-  },
-  {
-    "id": "AccessManager getters #canCall when the manager is open when the call comes from the manager (msg.sender == manager) when _executionId is in storage for target and selector \"before each\" hook: set _executionId flag from calldata and target for \"should return true and no delay\"",
-    "cause": "hardhat_setStorageAt"
   },
   {
     "id": "AccessManager getters #canCall when the manager is open when the call does not come from the manager (msg.sender != manager) when the function requires the caller to be granted with a role other than PUBLIC_ROLE when the required role is granted to the caller when role granting is delayed when caller has an execution delay when grant delay has taken effect when operation is not scheduled should return false and execution delay",
@@ -1081,18 +1064,6 @@
     "id": "ERC1967Clones non-deterministic deployment (create) without initialization when sending some balance reverts",
     "cause": "subcall-effect-lost",
     "note": "Root-caused: gas estimation under-reports for calls routed through an EIP-1167 minimal-proxy delegatecall. A direct call to the implementation succeeds at its own estimate; the identical call through a clone fails at that estimate -- re-verifying doesn't catch it since eth_call itself under-reports here too (same broken oracle). A large explicit gas limit succeeds. Confirmed pre-existing (predates PR #321's gas-estimation work); not fixable by client-side padding -- likely endorser/execution/executor.go's delegatecall gas accounting. ERC1967Clones/Create2/Create3/ProxyAdmin/UUPSUpgradeable plausibly share this; SafeERC20/ERC4626/ERC20Wrapper/ERC20FlashMint/ERC721Wrapper/Context are tagged on symptom match only -- verify before assuming."
-  },
-  {
-    "id": "ERC1967Utils ADMIN_SLOT \"before each\" hook: set admin for \"returns current admin and matches admin slot value\"",
-    "cause": "hardhat_setStorageAt"
-  },
-  {
-    "id": "ERC1967Utils BEACON_SLOT \"before each\" hook: set beacon for \"returns current beacon and matches beacon slot value\"",
-    "cause": "hardhat_setStorageAt"
-  },
-  {
-    "id": "ERC1967Utils IMPLEMENTATION_SLOT \"before each\" hook: set v1 implementation for \"returns current implementation and matches implementation slot value\"",
-    "cause": "hardhat_setStorageAt"
   },
   {
     "id": "ERC20Crosschain bridge ERC20 like reconfiguration reject invalid gateway"


### PR DESCRIPTION
Addressed issue

Closes #323 (final part). hardhat_setStorageAt was not served at all, so tests that seed a storage slot got a "method not found" error.

Summary

Adds hardhat_setStorageAt as a system directive, following the same shape as the merged hardhat_setBalance (#341) and hardhat_setCode (#357)

- ProposalTypeSetStorageAt marks the invocation's first arg so ConvertToDomain filters it out of the committed EVM transaction stream.
 - DirectiveEndorser.SetStorageAt writes the word into a fresh state snapshot and endorses the resulting RWS. A zero value clears the slot.
 - The gateway fan-out type-asserts each endorser to a narrow storageSetter interface, so an endorser that cannot apply directives fails before anything is submitted. Gateway.SetStorageAt blocks until the new value is readable.
 - Hardhat sends the slot and value as quantity-style hex, which does not unmarshal into a 32-byte hash, so both go through the padding helper already used by eth_getStorageAt. That helper is now exported and names the field it decodes, so a malformed value no longer reports an error about the key.

The OZ baseline is updated in a separate commit: the 17 etStorageAt now pass. It also adds 13 AccessManager entries that are not caused by this change — they fail identically on main, where hardhat_impersonateAccount is still a no-op stub, so a call expected to come from the manager reports "no private keThey were simply missing from the baseline.

 Validation done

 - make checks and make unit-tests pass.
 - New unit tests for the directive endorser (set, overwrite, clear-to-zero).
 - New end-to-end test against the in-process testnode: srite, clear to zero, and a quantity-style short-hex slotand value,  which is the form Hardhat actually sends.
 - make hardhat-tests plus go run ./cmd/baseline update -e passes at 88.9%.


## Screenshot 

<img width="811" height="264" alt="image" src="https://github.com/user-attachments/assets/020616bd-eac4-4c46-a03d-003fe7badb73" />
